### PR TITLE
Add DateTime to language

### DIFF
--- a/doc/existing.md
+++ b/doc/existing.md
@@ -2,11 +2,9 @@ Existing virtual features
 =========================
 
 If we can express all these, we're doing OK.
-This is just using a made-up core syntax, and windowed expressions which aren't implemented.
-The plan is to add constant size windows and make it so precomputations, streams and reductions can only use the current/snapshot/chord date if they are windowed.
+This is just using a made-up core syntax, but it's similar to what the existing pretty printer outputs.
 
-I'm assuming that we can add array, map and set primitives fairly easily.
-I'm also ignoring tombstones for now, but I think we can add an option/maybe-ish type for that.
+I'm ignoring tombstones for now, but I figure we can use an option/maybe type for that.
 
 
 CountBy

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -130,3 +130,17 @@ test-suite test
                      , QuickCheck                      == 2.7.*
                      , quickcheck-instances            == 0.3.*
                      , containers                      == 0.5.*
+
+test-suite test-cli
+  type:                exitcode-stdio-1.0
+
+  main-is:             test-cli.hs
+
+  ghc-options:         -Wall -threaded -O2
+
+  hs-source-dirs:
+                       test
+
+  build-depends:
+                       base                            >= 3          && < 5
+                     , orphanarium-core

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -51,6 +51,7 @@ library
                        Icicle.BubbleGum
 
                        Icicle.Common.Base
+                       Icicle.Common.Fresh
                        Icicle.Common.Exp
                        Icicle.Common.Exp.Alpha
                        Icicle.Common.Exp.Check
@@ -60,6 +61,7 @@ library
                        Icicle.Common.Exp.Eval
                        Icicle.Common.Exp.Simp
                        Icicle.Common.Exp.Simp.Beta
+                       Icicle.Common.Exp.Simp.ANormal
                        Icicle.Common.Fragment
                        Icicle.Common.Type
                        Icicle.Common.Value

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -46,6 +46,7 @@ library
                        Icicle.Avalanche.FromCore
                        Icicle.Avalanche.Eval
                        Icicle.Avalanche.Check
+                       Icicle.Avalanche.Simp
 
                        Icicle.BubbleGum
 
@@ -57,6 +58,8 @@ library
                        Icicle.Common.Exp.Error
                        Icicle.Common.Exp.Exp
                        Icicle.Common.Exp.Eval
+                       Icicle.Common.Exp.Simp
+                       Icicle.Common.Exp.Simp.Beta
                        Icicle.Common.Fragment
                        Icicle.Common.Type
                        Icicle.Common.Value

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -103,6 +103,8 @@ showDictionary d
         T.putStrLn "Avalanche:"
         print (PP.indent 4 $ PP.pretty av)
 
+        T.putStrLn ""
+
 
 
 usage :: IO ()

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -99,7 +99,7 @@ showDictionary d
           -> do T.putStrLn "Has type:"
                 print (PP.indent 4 $ PP.pretty ty)
          
-        let av = AvS.simpAvalanche $ AvC.programFromCore "elem" "accum" prog
+        let av = AvS.simpAvalanche $ AvC.programFromCore (AvC.namerText id) prog
         T.putStrLn "Avalanche:"
         print (PP.indent 4 $ PP.pretty av)
 

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -12,8 +12,9 @@ import           Icicle
 import           Icicle.Data.DateTime
 
 import qualified Icicle.Internal.Pretty as PP
--- import qualified Icicle.Core.Program.Program as Program
 import qualified Icicle.Core.Program.Check   as Program
+
+import qualified Icicle.Avalanche.FromCore   as AvC
 
 import           P
 
@@ -96,6 +97,11 @@ showDictionary d
          Right ty
           -> do T.putStrLn "Has type:"
                 print (PP.indent 4 $ PP.pretty ty)
+         
+        let av = AvC.programFromCore "elem" "accum" prog
+        T.putStrLn "Avalanche:"
+        print (PP.indent 4 $ PP.pretty av)
+
 
 
 usage :: IO ()

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -15,6 +15,7 @@ import qualified Icicle.Internal.Pretty as PP
 import qualified Icicle.Core.Program.Check   as Program
 
 import qualified Icicle.Avalanche.FromCore   as AvC
+import qualified Icicle.Avalanche.Simp       as AvS
 
 import           P
 
@@ -98,7 +99,7 @@ showDictionary d
           -> do T.putStrLn "Has type:"
                 print (PP.indent 4 $ PP.pretty ty)
          
-        let av = AvC.programFromCore "elem" "accum" prog
+        let av = AvS.simpAvalanche $ AvC.programFromCore "elem" "accum" prog
         T.putStrLn "Avalanche:"
         print (PP.indent 4 $ PP.pretty av)
 

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -11,8 +11,9 @@ import           Data.Text.IO as T
 import           Icicle
 import           Icicle.Data.DateTime
 
-import qualified Icicle.Internal.Pretty as PP
+import qualified Icicle.Internal.Pretty      as PP
 import qualified Icicle.Core.Program.Check   as Program
+import qualified Icicle.Common.Fresh         as Fresh
 
 import qualified Icicle.Avalanche.FromCore   as AvC
 import qualified Icicle.Avalanche.Simp       as AvS
@@ -99,7 +100,8 @@ showDictionary d
           -> do T.putStrLn "Has type:"
                 print (PP.indent 4 $ PP.pretty ty)
          
-        let av = AvS.simpAvalanche $ AvC.programFromCore (AvC.namerText id) prog
+        let av = AvS.simpAvalanche (Fresh.counterPrefixNameState "anf")
+               $ AvC.programFromCore (AvC.namerText id) prog
         T.putStrLn "Avalanche:"
         print (PP.indent 4 $ PP.pretty av)
 

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -56,16 +56,16 @@ run dict p =
         lift $ mapM_ (print.prettyResult) v
  where
   prettyResult (attr, vals)
-   =      PP.text "Virtual feature: " <> PP.text (T.unpack $ getAttribute attr)
-   PP.<$> PP.indent 4 (PP.vcat $ fmap prettyResultEnt vals)
+   =       PP.text "Virtual feature: " <> PP.text (T.unpack $ getAttribute attr)
+   PP.<$$> PP.indent 4 (PP.vcat $ fmap prettyResultEnt vals)
 
   prettyResultEnt (ent, res)
-   =      PP.text "Entity:  " <> PP.text (show $ getEntity ent)
-   PP.<$> case res of
+   =       PP.text "Entity:  " <> PP.text (show $ getEntity ent)
+   PP.<$$> case res of
             Left e
-                -> PP.text "Error:   " PP.<$> PP.indent 4 (PP.text $ show e) <> PP.line
+                -> PP.text "Error:   " PP.<$$> PP.indent 4 (PP.text $ show e) <> PP.line
             Right (v,hist)
-                -> PP.text "Value:   " <> PP.text (show v) PP.<$> PP.text "History: " <> PP.indent 0 (PP.vcat $ fmap (PP.text . show) hist) <> PP.line
+                -> PP.text "Value:   " <> PP.text (show v) PP.<$$> PP.text "History: " <> PP.indent 0 (PP.vcat $ fmap (PP.text . show) hist) <> PP.line
 
 -- Show the virtual features
 showDictionary :: Dictionary -> IO ()
@@ -100,10 +100,12 @@ showDictionary d
           -> do T.putStrLn "Has type:"
                 print (PP.indent 4 $ PP.pretty ty)
          
-        let av = AvS.simpAvalanche (Fresh.counterPrefixNameState "anf")
-               $ AvC.programFromCore (AvC.namerText id) prog
+        let av   = AvC.programFromCore (AvC.namerText id) prog
+        let avs  = snd
+                 $ Fresh.runFresh (AvS.simpAvalanche av)
+                                  (Fresh.counterPrefixNameState "anf")
         T.putStrLn "Avalanche:"
-        print (PP.indent 4 $ PP.pretty av)
+        print (PP.indent 4 $ PP.pretty avs)
 
         T.putStrLn ""
 

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -89,10 +89,10 @@ checkLoop
         => Fragment p
         -> Env  n Type
         -> Env  n AccType
-        -> Loop n p
+        -> FactLoop n p
         -> Either (ProgramError n p) ()
-checkLoop frag env accs (Loop inputType stmts_)
- = go env stmts_
+checkLoop frag env accs (FactLoop inputType inputBind stmts_)
+ = go (Map.insert inputBind (FunT [] inputType) env) stmts_
 
  where
   go e stmts = mapM_ (checkStmt e) stmts
@@ -112,9 +112,6 @@ checkLoop frag env accs (Loop inputType stmts_)
        -> do t <- mapLeft ProgramErrorExp
                 $ checkExp frag e x
              go (Map.insert n t e) stmts
-
-      UseSource n stmts
-       -> go (Map.insert n (FunT [] inputType) e) stmts
    
       Update n x
        -> do t <- mapLeft ProgramErrorExp

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -92,9 +92,11 @@ checkLoop
         -> FactLoop n p
         -> Either (ProgramError n p) ()
 checkLoop frag env accs (FactLoop inputType inputBind stmts_)
- = go (Map.insert inputBind (FunT [] inputType) env) stmts_
+ = go (Map.insert inputBind streamType env) stmts_
 
  where
+  streamType = FunT [] (PairT inputType DateTimeT)
+
   go e stmts = mapM_ (checkStmt e) stmts
 
   checkStmt e s

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -48,8 +48,11 @@ checkProgram frag p
 
         -- Put the accs in the environment
         let env' = Map.union (Map.map typeOfAccType accs) pres
+        let env''= case postdate p of
+                   Nothing -> env'
+                   Just nm -> Map.insert nm (FunT [] DateTimeT) env'
 
-        posts   <- checkExps env'
+        posts   <- checkExps env''
                  $ postcomps p
 
         mapLeft ProgramErrorExp

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -37,9 +37,9 @@ checkProgram
         -> Program n p
         -> Either (ProgramError n p) Type
 checkProgram frag p
- = do   pres    <- checkExps Map.empty
+ = do   pres    <- checkExps (Map.singleton (binddate p) (FunT [] DateTimeT))
                  $ precomps p
-        
+
         accs    <- Map.fromList
                <$> (mapM (checkAcc pres)            
                  $ accums p)
@@ -48,11 +48,8 @@ checkProgram frag p
 
         -- Put the accs in the environment
         let env' = Map.union (Map.map typeOfAccType accs) pres
-        let env''= case postdate p of
-                   Nothing -> env'
-                   Just nm -> Map.insert nm (FunT [] DateTimeT) env'
 
-        posts   <- checkExps env''
+        posts   <- checkExps env'
                  $ postcomps p
 
         mapLeft ProgramErrorExp

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -107,9 +107,6 @@ checkLoop frag env accs (FactLoop inputType inputBind stmts_)
              requireSame (ProgramErrorWrongType x) t (FunT [] BoolT)
              go e stmts
 
-      IfWindowed _ stmts
-       ->    go e stmts
-
       Let n x stmts
        -> do t <- mapLeft ProgramErrorExp
                 $ checkExp frag e x

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -145,9 +145,14 @@ evalProgram evalPrim now values p
         -- Grab the history out of the accumulator heap while we're at it
         let bgs = bubbleGumOutputOfAccumulatorHeap accs'
 
+        -- Fill date if necesary
+        let env'' = case postdate p of
+                    Nothing -> env'
+                    Just nm -> Map.insert nm (VBase $ VDateTime now) env'
+
         -- Use final scalar heap to evaluate postcomputations
         posts <- mapLeft RuntimeErrorPost
-                $ XV.evalExps evalPrim env' (postcomps p)
+                $ XV.evalExps evalPrim env'' (postcomps p)
 
         -- Then use postcomputations to evaluate the return value
         ret   <- mapLeft RuntimeErrorReturn

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -207,7 +207,10 @@ evalLoop
 
 evalLoop evalPrim now (FactLoop _ bind stmts) xh ah input
  -- Just go through all the statements
- = foldM (evalStmt evalPrim now (Map.insert bind (VBase $ snd $ fact input) xh) input) ah stmts
+ = foldM (evalStmt evalPrim now xh' input) ah stmts
+ where
+  xh' = Map.insert bind streamvalue xh
+  streamvalue = VBase $ VPair (snd $ fact input) (VDateTime $ time input)
 
 
 -- | Evaluate a single statement for a single value

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -239,12 +239,6 @@ evalStmt evalPrim now xh input ah stmt
              _
               -> return ah
 
-    IfWindowed window stmts
-        -- Check the input fact's time against now
-     -> if   withinWindow (time input) now window
-        then go' stmts
-        else return ah
-
     -- Evaluate and insert the value into the heap.
     Let n x stmts
      -> do  v <- eval x

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -199,15 +199,15 @@ evalLoop
         :: Ord n
         => XV.EvalPrim n p
         -> DateTime
-        -> Loop n p
+        -> FactLoop n p
         -> Heap n p
         -> AccumulatorHeap n
         -> AsAt (BubbleGumFact, BaseValue)
         -> Either (RuntimeError n p) (AccumulatorHeap n)
 
-evalLoop evalPrim now (Loop _ stmts) xh ah input
+evalLoop evalPrim now (FactLoop _ bind stmts) xh ah input
  -- Just go through all the statements
- = foldM (evalStmt evalPrim now xh input) ah stmts
+ = foldM (evalStmt evalPrim now (Map.insert bind (VBase $ snd $ fact input) xh) input) ah stmts
 
 
 -- | Evaluate a single statement for a single value
@@ -244,10 +244,6 @@ evalStmt evalPrim now xh input ah stmt
     Let n x stmts
      -> do  v <- eval x
             go (Map.insert n v xh) ah stmts
-
-    -- Store the input in the heap.
-    UseSource n stmts
-     -> go (Map.insert n (VBase $ snd $ fact input) xh) ah stmts
 
     -- Update accumulator
     Update n x

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -37,6 +37,7 @@ programFromCore elemPrefix accPrefix p
                 $ makeStatements elemPrefix accPrefix
                   (C.streams p) (C.reduces p)
 
+ , A.postdate   = C.postdate    p
  , A.postcomps  = C.postcomps   p
  , A.returns    = C.returns     p
  }

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -33,7 +33,7 @@ programFromCore elemPrefix accPrefix p
  , A.accums     = fmap accum (C.reduces p)
 
  -- Nest the streams into a single loop
- , A.loop       = A.Loop (C.input p)
+ , A.loop       = A.FactLoop (C.input p) (Name elemPrefix)
                 $ makeStatements elemPrefix accPrefix
                   (C.streams p) (C.reduces p)
 
@@ -90,19 +90,17 @@ insertStream elemPrefix accPrefix strs reds (n, strm)
        -- All statements together
        alls     = upds <> subs
        
-       -- The sources need a name to refer to the input by
-       allSrc   = UseSource (NameMod elemPrefix n) alls
        -- Bind something or other
        allLet x = Let (NameMod elemPrefix n) x     alls
 
    in case strm of
        -- Sources just bind the input and do their children
        CS.Source
-        -> allSrc
+        -> allLet $ XVar $ Name elemPrefix
 
        -- If within i days
        CS.SourceWindowedDays i
-        -> IfWindowed i [allSrc]
+        -> IfWindowed i [allLet $ XVar $ Name elemPrefix]
 
        -- Filters become ifs
        CS.STrans (CS.SFilter _) x inp

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -139,7 +139,7 @@ instance TransformX Statement where
 
 instance (Pretty n, Pretty p) => Pretty (Program n p) where
  pretty p
-  =   text "let " <> pretty (binddate p) <> text " = date; " <> line
+  =   pretty (binddate p) <> text " = date; " <> line
   <>  vcat (semis $ fmap prettyX (precomps  p)) <> line
   <>  vcat (semis $ fmap pretty  (accums    p)) <> line
   <>                     pretty  (loop      p)  <> line
@@ -177,11 +177,11 @@ instance (Pretty n, Pretty p) => Pretty (Statement n p) where
       <> text "}"
 
      Let n x [sub@(Let _ _ _)]
-      -> text "let" <+> pretty n <+> text "=" <+> pretty x <> line
+      -> pretty n <+> text "=" <+> pretty x <> text "; and" <> line
       <> pretty sub
 
      Let n x stmts
-      -> text "let" <+> pretty n <+> text "=" <+> pretty x <+> text "in {" <> line
+      -> pretty n <+> text "=" <+> pretty x <> text "; in {" <> line
       <> semis stmts
       <> text "}"
 

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -88,8 +88,12 @@ instance TransformX Program where
         precomps'  <- mapM bind                    $ precomps  p
         accums'    <- mapM (transformX names exps) $ accums    p
         loop'      <-       transformX names exps  $ loop      p
-        postcomps' <- mapM bind                    $ postcomps p
-        returns'   <-                        exps  $ returns   p
+
+        let ret     = makeLets (postcomps p) (returns p)
+        ret'       <- exps ret
+        let (postcomps',returns')
+                    = takeLets ret'
+
         return $ Program 
                { binddate  = binddate'
                , precomps  = precomps'

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -22,6 +22,7 @@ data Program n p =
   { precomps    :: [(Name n, Exp n p)]
   , accums      :: [Accumulator n p]
   , loop        :: FactLoop n p
+  , postdate    :: Maybe (Name n)
   , postcomps   :: [(Name n, Exp n p)]
   , returns     :: Exp n p
   }
@@ -89,6 +90,7 @@ instance TransformX Program where
   { precomps  = fmap bind                    $ precomps  p
   , accums    = fmap (transformX names exps) $ accums    p
   , loop      =       transformX names exps  $ loop      p
+  , postdate  = fmap names                   $ postdate  p
   , postcomps = fmap bind                    $ postcomps p
   , returns   =                        exps  $ returns   p
   }
@@ -130,11 +132,17 @@ instance (Pretty n, Pretty p) => Pretty (Program n p) where
   =   vcat (semis $ fmap prettyX (precomps  p)) <> line
   <>  vcat (semis $ fmap pretty  (accums    p)) <> line
   <>                     pretty  (loop      p)  <> line
+  <>  postdateline
   <>  vcat (semis $ fmap prettyX (postcomps p)) <> line
   <>  text "return"  <+> pretty  (returns   p)
   where
    semis = fmap (<> text ";")
    prettyX  (a,b) = pretty a <+> text "=" <+> pretty b
+
+   postdateline
+    = case postdate p of
+      Nothing -> text ""
+      Just nm -> text "let " <> pretty nm <> text " = date; " <> line
 
 
 instance (Pretty n, Pretty p) => Pretty (Accumulator n p) where

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -69,8 +69,6 @@ data Statement n p
  -- Branches
  -- | An IF for filters
  = If (Exp n p)                 [Statement n p]
- -- | An if for windows
- | IfWindowed Int               [Statement n p]
  -- | Local binding, so the name better be unique
  | Let    (Name n) (Exp n p)    [Statement n p]
 
@@ -114,8 +112,6 @@ instance TransformX Statement where
   = case stmt of
      If x ss
       -> If (exps x) (go ss)
-     IfWindowed i ss
-      -> IfWindowed i (go ss)
      Let n x ss
       -> Let (names n) (exps x) (go ss)
      Update n x
@@ -163,11 +159,6 @@ instance (Pretty n, Pretty p) => Pretty (Statement n p) where
   = case s of
      If x stmts
       -> text "if (" <> pretty x <> text ") {" <> line
-      <> semis stmts
-      <> text "}"
-
-     IfWindowed i stmts
-      -> text "windowed " <> pretty i <> text " {" <> line
       <> semis stmts
       <> text "}"
 

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -176,6 +176,10 @@ instance (Pretty n, Pretty p) => Pretty (Statement n p) where
       <> semis stmts
       <> text "}"
 
+     Let n x [sub@(Let _ _ _)]
+      -> text "let" <+> pretty n <+> text "=" <+> pretty x <> line
+      <> pretty sub
+
      Let n x stmts
       -> text "let" <+> pretty n <+> text "=" <+> pretty x <+> text "in {" <> line
       <> semis stmts

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -11,7 +11,7 @@ import              Icicle.Avalanche.Program
 
 import              P
 
-simpAvalanche :: (Show n, Show p, Ord n) => NameState n -> Program n p -> Program n p
-simpAvalanche ns p
- = transformX id (\x -> snd $ runFresh (simp x) ns) p
+simpAvalanche :: (Show n, Show p, Ord n) => Program n p -> Fresh n (Program n p)
+simpAvalanche p
+ = transformX return simp p
 

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -5,11 +5,13 @@ module Icicle.Avalanche.Simp (
   ) where
 
 import              Icicle.Common.Exp
+import              Icicle.Common.Fresh
 
 import              Icicle.Avalanche.Program
 
 import              P
 
-simpAvalanche :: (Show n, Show p, Ord n) => Program n p -> Program n p
-simpAvalanche = transformX id simp
+simpAvalanche :: (Show n, Show p, Ord n) => NameState n -> Program n p -> Program n p
+simpAvalanche ns p
+ = transformX id (\x -> snd $ runFresh (simp x) ns) p
 

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -1,0 +1,15 @@
+-- | Convert Core programs to Avalanche
+{-# LANGUAGE NoImplicitPrelude #-}
+module Icicle.Avalanche.Simp (
+    simpAvalanche
+  ) where
+
+import              Icicle.Common.Exp
+
+import              Icicle.Avalanche.Program
+
+import              P
+
+simpAvalanche :: (Show n, Show p, Ord n) => Program n p -> Program n p
+simpAvalanche = transformX id simp
+

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Avalanche.Simp (
     simpAvalanche
+  , pullLets
   ) where
 
+import              Icicle.Common.Base
 import              Icicle.Common.Exp
 import              Icicle.Common.Fresh
 
@@ -13,5 +15,49 @@ import              P
 
 simpAvalanche :: (Show n, Show p, Ord n) => Program n p -> Fresh n (Program n p)
 simpAvalanche p
- = transformX return simp p
+ = pullLets <$> transformX return simp p
 
+
+pullLets :: Program n p -> Program n p
+pullLets p
+ = p
+ { precomps = pullExps $ precomps p
+ , loop     = pullLoop $ loop p
+ , postcomps= pullExps $ postcomps p
+ }
+
+pullExps :: [(Name n, Exp n p)] -> [(Name n, Exp n p)]
+pullExps
+ = concatMap pullX
+ where
+  pullX (n,x)
+   = let (bs,x') = takeLets x
+     in  bs <> [(n,x')]
+
+pullLoop :: FactLoop n p -> FactLoop n p
+pullLoop (FactLoop v n stms)
+ = FactLoop v n
+ $ fmap pullStmt stms
+
+pullStmt :: Statement n p -> Statement n p
+pullStmt stm
+ = case stm of
+    If x subs
+     -> pres x (\x' -> If x'    $ go subs)
+    Let n x subs
+     -> pres x (\x' -> Let n x' $ go subs)
+
+    Update n x
+     -> pres x (Update n)
+    Push n x
+     -> pres x (Push n)
+
+ where
+  pres x instmt
+   = let (bs, x') = takeLets x
+     in  foldr mkLet (instmt x') bs
+
+  mkLet (n,x) s
+   = Let n x [s]
+
+  go = fmap pullStmt

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -6,9 +6,11 @@ module Icicle.Common.Base (
     ) where
 
 import              Icicle.Internal.Pretty
+import              Icicle.Data.DateTime
 
 import              P
-import qualified    Data.Map as Map
+import qualified    Data.Map    as Map
+import qualified    Data.Text   as T
 
 
 -- | User defined names.
@@ -28,6 +30,7 @@ data Name n =
 data BaseValue
  = VInt   Int
  | VBool  Bool
+ | VDateTime        DateTime
  | VArray [BaseValue]
  | VPair  BaseValue BaseValue
  | VSome  BaseValue
@@ -50,6 +53,8 @@ instance Pretty BaseValue where
       -> pretty i
      VBool b
       -> pretty b
+     VDateTime dt
+      -> text $ T.unpack $ renderDate dt
      VArray vs
       -> pretty vs
      VPair a b

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -1,12 +1,14 @@
--- | Base definitions for Core programs.
+-- | Base definitions common across all languages.
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Common.Base (
       Name   (..)
+    , BaseValue (..)
     ) where
 
 import              Icicle.Internal.Pretty
 
 import              P
+import qualified    Data.Map as Map
 
 
 -- | User defined names.
@@ -19,8 +21,43 @@ data Name n =
  deriving (Eq,Ord,Show)
 
 
+-- | Base values - real values that can be serialised and whatnot
+-- These are used in the expressions, but actual values can be
+-- closures, which include expressions.
+-- This is in here to resolve circular dependency.
+data BaseValue
+ = VInt   Int
+ | VBool  Bool
+ | VArray [BaseValue]
+ | VPair  BaseValue BaseValue
+ | VSome  BaseValue
+ | VNone
+ | VMap   (Map.Map BaseValue BaseValue)
+ deriving (Show, Ord, Eq)
+
+
+
 -- Pretty printing ---------------
 
 instance Pretty n => Pretty (Name n) where
  pretty (Name n)        = pretty n
  pretty (NameMod p n)   = pretty p <> text "$" <> pretty n
+
+instance Pretty BaseValue where
+ pretty v
+  = case v of
+     VInt i
+      -> pretty i
+     VBool b
+      -> pretty b
+     VArray vs
+      -> pretty vs
+     VPair a b
+      -> text "(" <> pretty a <> text ", " <> pretty b <> text ")"
+     VSome a
+      -> text "Some" <+> pretty a
+     VNone
+      -> text "None"
+     VMap mv
+      -> text "Map" <+> pretty (Map.toList mv)
+

--- a/src/Icicle/Common/Exp.hs
+++ b/src/Icicle/Common/Exp.hs
@@ -9,5 +9,6 @@ import              Icicle.Common.Exp.Compounds  as X
 import              Icicle.Common.Exp.Error      as X
 import              Icicle.Common.Exp.Eval       as X
 import              Icicle.Common.Exp.Exp        as X
+import              Icicle.Common.Exp.Simp       as X
 
 

--- a/src/Icicle/Common/Exp/Alpha.hs
+++ b/src/Icicle/Common/Exp/Alpha.hs
@@ -35,15 +35,21 @@ alphaEquality' m x1 x2
  , XVar n2          <- x2
  = lookupBoth m (n1, n2)
 
- -- Recurse with same map
- | XApp x11 x12     <- x1
- , XApp x21 x22     <- x2
- = go x11 x21 && go x12 x22
-
  -- Simple primitive
  | XPrim p1         <- x1
  , XPrim p2         <- x2
  = p1 == p2
+
+ -- Base values
+ | XValue t1 v1     <- x1
+ , XValue t2 v2     <- x2
+ =  t1 == t2
+ && v1 == v2
+
+ -- Recurse with same map
+ | XApp x11 x12     <- x1
+ , XApp x21 x22     <- x2
+ = go x11 x21 && go x12 x22
 
  -- Types must match. Names can be different, so add them to bijection
  | XLam n1 t1 x1'   <- x1

--- a/src/Icicle/Common/Exp/Check.hs
+++ b/src/Icicle/Common/Exp/Check.hs
@@ -59,6 +59,11 @@ typecheck frag e xx
     XVar n
      -> lookupOrDie ExpErrorVarNotInEnv e n
 
+    XValue t v
+     -> if   valueMatchesType v t
+        then return (FunT [] t)
+        else Left (ExpErrorValueNotOfType v t)
+
     -- Application
     XApp p q
      -> do  p' <- go p
@@ -97,6 +102,9 @@ checkPrimsFullyApplied frag xx
  = case xx of
     -- Variables are ok
     XVar{}
+     -> ok
+
+    XValue{}
      -> ok
 
     -- Application to primitive:

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -6,9 +6,10 @@ module Icicle.Common.Exp.Compounds (
     , takeApps
     , takePrimApps
     , makeLets
-    , substMaybe
+    , takeLets
     , freevars
     , allvars
+    , substMaybe
     ) where
 
 import              Icicle.Common.Base
@@ -22,12 +23,6 @@ import qualified    Data.Set    as Set
 makeApps :: Exp n p -> [Exp n p] -> Exp n p
 makeApps f args
  = foldl XApp f args
-
-
--- | Prefix an expression with some let bindings
-makeLets :: [(Name n, Exp n p)] -> Exp n p -> Exp n p
-makeLets bs x
- = foldr (uncurry XLet) x bs
 
 
 -- | Split an expression into its function part and any arguments applied to it.
@@ -48,6 +43,23 @@ takePrimApps xx
  = case takeApps xx of
     (XPrim p, args) -> Just (p, args)
     _               -> Nothing
+
+
+-- | Prefix an expression with some let bindings
+makeLets :: [(Name n, Exp n p)] -> Exp n p -> Exp n p
+makeLets bs x
+ = foldr (uncurry XLet) x bs
+
+-- | Pull out the top-level let bindings
+takeLets :: Exp n p -> ([(Name n, Exp n p)], Exp n p)
+takeLets xx
+ = case xx of
+    XLet n x y
+     -> let (bs, y') = takeLets y
+        in  ((n,x) : bs, y')
+    _
+     -> ([], xx)
+
 
 
 -- | Collect all free variables in an expression

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -6,6 +6,7 @@ module Icicle.Common.Exp.Compounds (
     , takePrimApps
     , substMaybe
     , freevars
+    , allvars
     ) where
 
 import              Icicle.Common.Base
@@ -49,6 +50,22 @@ freevars xx
     XApp p q    -> freevars p <> freevars q
     XLam n _ x  -> Set.delete n (freevars x)
     XLet n x y  -> freevars x <> Set.delete n (freevars y)
+
+
+-- | Collect all variable names in an expression:
+-- free and bound
+allvars
+        :: Ord n
+        => Exp n p
+        -> Set.Set (Name n)
+allvars xx
+ = case xx of
+    XVar n      -> Set.singleton n
+    XPrim{}     -> Set.empty
+    XValue{}    -> Set.empty
+    XApp p q    -> allvars p <> allvars q
+    XLam n _ x  -> Set.singleton n <> allvars x
+    XLet n x y  -> Set.singleton n <> allvars x <> allvars y
 
 
 -- | Substitute an expression in, but if it would require renaming

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -2,8 +2,10 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Common.Exp.Compounds (
-      takeApps
+      makeApps
+    , takeApps
     , takePrimApps
+    , makeLets
     , substMaybe
     , freevars
     , allvars
@@ -14,6 +16,18 @@ import              Icicle.Common.Exp.Exp
 import              P
 
 import qualified    Data.Set    as Set
+
+
+-- | Apply an expression to any number of arguments
+makeApps :: Exp n p -> [Exp n p] -> Exp n p
+makeApps f args
+ = foldl XApp f args
+
+
+-- | Prefix an expression with some let bindings
+makeLets :: [(Name n, Exp n p)] -> Exp n p -> Exp n p
+makeLets bs x
+ = foldr (uncurry XLet) x bs
 
 
 -- | Split an expression into its function part and any arguments applied to it.

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -137,12 +137,19 @@ substMaybe name payload into
        -> XLam n t <$> go x
 
       XLet n x1 x2
+       -- If the let's name is clashes with the substitution we're trying to make
+       -- and the *body* of the let needs to be substituted into,
+       -- we cannot proceed.
+       -- (It doesn't matter if the definition, x1, mentions name because "n" is not bound there)
        | (n `Set.member` payload_free) || n == name
        , name `Set.member` freevars x2
        -> Nothing
 
-       | not (name `Set.member` freevars x2)
+       -- If name is not mentioned in x1 or x2, we do not need to perform any substitution.
+       |  not (name `Set.member` freevars x1)
+       && not (name `Set.member` freevars x2)
        -> return xx
 
+       -- Proceed as usual
        | otherwise
        -> XLet n <$> go x1 <*> go x2

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -44,8 +44,9 @@ freevars
 freevars xx
  = case xx of
     XVar n      -> Set.singleton n
-    XApp p q    -> freevars p <> freevars q
     XPrim{}     -> Set.empty
+    XValue{}    -> Set.empty
+    XApp p q    -> freevars p <> freevars q
     XLam n _ x  -> Set.delete n (freevars x)
     XLet n x y  -> freevars x <> Set.delete n (freevars y)
 
@@ -72,7 +73,10 @@ substMaybe name payload into
        -> return xx
       XApp p q
        -> XApp <$> go p <*> go q
+
       XPrim{}
+       -> return xx
+      XValue{}
        -> return xx
 
       XLam n t x

--- a/src/Icicle/Common/Exp/Error.hs
+++ b/src/Icicle/Common/Exp/Error.hs
@@ -24,6 +24,9 @@ data ExpError n p
 
  -- Primitives cannot be partially applied
  | ExpErrorPrimitiveNotFullyApplied p (Exp n p)
+
+ -- Value not of type
+ | ExpErrorValueNotOfType BaseValue ValType
  deriving (Show, Eq, Ord)
 
 
@@ -44,4 +47,7 @@ instance (Pretty n, Pretty p) => Pretty (ExpError n p) where
 
     ExpErrorPrimitiveNotFullyApplied p x
      ->  text "The primitive " <> pretty p <> text " is not fully applied in expression " <> pretty x
+
+    ExpErrorValueNotOfType v t
+     ->  text "The value " <> pretty v <> text " does not have type " <> pretty t
 

--- a/src/Icicle/Common/Exp/Eval.hs
+++ b/src/Icicle/Common/Exp/Eval.hs
@@ -48,6 +48,9 @@ eval evalPrim h xx
      -> maybeToRight (RuntimeErrorVarNotInHeap n)
                      (Map.lookup n h)
 
+    XValue _ bv
+     -> return $ VBase bv
+
     -- Application of primitive.
     -- Primitives must be fully applied, so evalPrim will eat all the arguments.
     XApp{}

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -47,7 +47,7 @@ renameExp f (XLam n t b) = XLam (f n) t (renameExp f b)
 renameExp f (XLet n p q) = XLet (f n) (renameExp f p) (renameExp f q)
 
 class TransformX x where
- transformX :: (Name n -> Name n') -> (Exp n p -> Exp n' p') -> x n p -> x n' p'
+ transformX :: (Applicative m, Monad m) => (Name n -> m (Name n')) -> (Exp n p -> m (Exp n' p')) -> x n p -> m (x n' p')
 
 -- Pretty printing ---------------
 

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -44,11 +44,15 @@ renameExp f (XLet n p q) = XLet (f n) (renameExp f p) (renameExp f q)
 instance (Pretty n, Pretty p) => Pretty (Exp n p) where
  pretty (XVar n) = pretty n
 
- pretty (XApp p q) = pretty p <+> inner q
+ pretty (XApp p q) = inner' p <+> inner q
   where
    inner i
     = case i of
        XApp{} -> parens $ pretty i
+       XLam{} -> parens $ pretty i
+       _      ->          pretty i
+   inner' i
+    = case i of
        XLam{} -> parens $ pretty i
        _      ->          pretty i
 

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -69,7 +69,7 @@ instance (Pretty n, Pretty p) => Pretty (Exp n p) where
        XLam{} -> parens $ pretty i
        _      ->          pretty i
 
- pretty (XLam b t x) = text "\\" <> pretty b <> text " : " <> pretty t <> text ". " <> pretty x
+ pretty (XLam b t x) = text "\\" <> pretty b <> text " : " <> pretty t <> text ". " <> align (pretty x)
 
  pretty (XLet b x i) = text "let " <> pretty b
                     <> text " = "  <> align (pretty x)

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -60,9 +60,10 @@ instance (Pretty n, Pretty p) => Pretty (Exp n p) where
   where
    inner i
     = case i of
-       XApp{} -> parens $ pretty i
-       XLam{} -> parens $ pretty i
-       _      ->          pretty i
+       XApp{}   -> parens $ pretty i
+       XLam{}   -> parens $ pretty i
+       XValue{} -> parens $ pretty i
+       _        ->          pretty i
    inner' i
     = case i of
        XLam{} -> parens $ pretty i

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -18,11 +18,16 @@ data Exp n p
  -- | Read a variable from heap
  = XVar (Name n)
 
- -- | Apply something
- | XApp (Exp n p) (Exp n p)
-
  -- | A predefined primitive
  | XPrim p
+
+ -- | A constant simple value
+ -- We need the type here because if this is, say, an empty array,
+ -- we would not be able to guess the element type.
+ | XValue ValType BaseValue
+
+ -- | Apply something
+ | XApp (Exp n p) (Exp n p)
 
  -- | Lambda abstraction:
  -- This is only really used for arguments passed to primitives such as fold.
@@ -34,9 +39,10 @@ data Exp n p
 
 
 renameExp :: (Name n -> Name n') -> Exp n p -> Exp n' p
-renameExp f (XVar n) = XVar (f n)
-renameExp f (XApp p q) = XApp (renameExp f p) (renameExp f q)
-renameExp _ (XPrim p) = XPrim p
+renameExp f (XVar n)     = XVar (f n)
+renameExp _ (XPrim p)    = XPrim p
+renameExp _ (XValue t v) = XValue t v
+renameExp f (XApp p q)   = XApp (renameExp f p) (renameExp f q)
 renameExp f (XLam n t b) = XLam (f n) t (renameExp f b)
 renameExp f (XLet n p q) = XLet (f n) (renameExp f p) (renameExp f q)
 
@@ -46,9 +52,11 @@ class TransformX x where
 -- Pretty printing ---------------
 
 instance (Pretty n, Pretty p) => Pretty (Exp n p) where
- pretty (XVar n) = pretty n
+ pretty (XVar n)    = pretty n
+ pretty (XPrim p)   = pretty p
+ pretty (XValue t v)= pretty v <+> text ":" <+> pretty t
 
- pretty (XApp p q) = inner' p <+> inner q
+ pretty (XApp p q)  = inner' p <+> inner q
   where
    inner i
     = case i of
@@ -60,8 +68,8 @@ instance (Pretty n, Pretty p) => Pretty (Exp n p) where
        XLam{} -> parens $ pretty i
        _      ->          pretty i
 
- pretty (XPrim p)  = pretty p
  pretty (XLam b t x) = text "\\" <> pretty b <> text " : " <> pretty t <> text ". " <> pretty x
+
  pretty (XLet b x i) = text "let " <> pretty b
                     <> text " = "  <> align (pretty x)
                    </> text " in " <> align (pretty i)

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -3,6 +3,7 @@
 module Icicle.Common.Exp.Exp (
       Exp     (..)
     , renameExp
+    , TransformX (..)
     ) where
 
 import              Icicle.Internal.Pretty
@@ -38,6 +39,9 @@ renameExp f (XApp p q) = XApp (renameExp f p) (renameExp f q)
 renameExp _ (XPrim p) = XPrim p
 renameExp f (XLam n t b) = XLam (f n) t (renameExp f b)
 renameExp f (XLet n p q) = XLet (f n) (renameExp f p) (renameExp f q)
+
+class TransformX x where
+ transformX :: (Name n -> Name n') -> (Exp n p -> Exp n' p') -> x n p -> x n' p'
 
 -- Pretty printing ---------------
 

--- a/src/Icicle/Common/Exp/Simp.hs
+++ b/src/Icicle/Common/Exp/Simp.hs
@@ -6,10 +6,15 @@ module Icicle.Common.Exp.Simp (
 
 import Icicle.Common.Exp.Exp
 import Icicle.Common.Exp.Simp.Beta
+import Icicle.Common.Exp.Simp.ANormal
+import Icicle.Common.Fresh
 
 import P
 
 
 -- | Just perform beta reduction for now
-simp :: (Show n, Show p, Ord n) => Exp n p -> Exp n p
-simp = beta isSimpleValue
+simp :: (Show n, Show p, Ord n) => Exp n p -> Fresh n (Exp n p)
+simp xx
+ = anormal
+ $ beta isSimpleValue
+   xx

--- a/src/Icicle/Common/Exp/Simp.hs
+++ b/src/Icicle/Common/Exp/Simp.hs
@@ -1,0 +1,15 @@
+-- | Simplifier for simple expressions
+{-# LANGUAGE NoImplicitPrelude #-}
+module Icicle.Common.Exp.Simp (
+      simp
+    ) where
+
+import Icicle.Common.Exp.Exp
+import Icicle.Common.Exp.Simp.Beta
+
+import P
+
+
+-- | Just perform beta reduction for now
+simp :: (Show n, Show p, Ord n) => Exp n p -> Exp n p
+simp = beta isSimpleValue

--- a/src/Icicle/Common/Exp/Simp/ANormal.hs
+++ b/src/Icicle/Common/Exp/Simp/ANormal.hs
@@ -1,0 +1,70 @@
+-- | A-normalise expressions
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PatternGuards #-}
+module Icicle.Common.Exp.Simp.ANormal (
+      anormal
+    ) where
+
+import Icicle.Common.Base
+import Icicle.Common.Exp.Exp
+import Icicle.Common.Exp.Compounds
+import Icicle.Common.Fresh
+
+import P
+import Data.List (unzip)
+
+anormal :: Exp n p -> Fresh n (Exp n p)
+anormal xx
+ = do   (bs, x) <- anormal' xx
+        return $ makeLets bs x
+
+
+anormal' :: Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
+anormal' xx
+ = case xx of
+    XVar{}
+     -> ret
+    XPrim{}
+     -> ret
+    XValue{}
+     -> ret
+
+    XApp{}
+     -> do  let (f,args) = takeApps xx
+            (bf, xf)    <-      extractBinding f
+            (bs, xs)    <- unzip <$> mapM extractBinding args
+            return (concat (bf:bs), makeApps xf xs)
+
+    XLam n v x
+     -> do  x' <- anormal x
+            return ([], XLam n v x')
+
+    XLet n x y
+     -> do  (bx, x')    <- anormal' x
+            (by, y')    <- anormal' y
+            -- TODO: I think we need to rename in here
+            return (bx <> [(n, x')] <> by, y')
+
+ where
+  ret = return ([], xx)
+
+
+
+extractBinding :: Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
+extractBinding xx
+ | isNormal xx
+ = return ([], xx)
+ | otherwise
+ = do   (bs,x') <- anormal' xx
+        n       <- fresh
+        return (bs <> [(n,x')], XVar n)
+
+isNormal :: Exp n p -> Bool
+isNormal xx
+ = case xx of
+    XVar{}   -> True
+    XPrim{}  -> True
+    XValue{} -> True
+    XApp{}   -> False
+    XLam{}   -> False
+    XLet{}   -> False

--- a/src/Icicle/Common/Exp/Simp/ANormal.hs
+++ b/src/Icicle/Common/Exp/Simp/ANormal.hs
@@ -1,4 +1,21 @@
 -- | A-normalise expressions
+-- A-normal form is where the function and arguments of an application
+-- can only be simple expressions such as values, variables, and primitives,
+-- and let bindings are serialised.
+--
+-- For example,
+--
+--   map (+(5-2)) [1,2,3]
+--
+-- would end up as something like
+--
+--   let a = 5 - 2
+--   let b = (+a)
+--   let c = [1,2,3]
+--   in  map b c
+--
+-- Conversion to a-normal form is not a benefit in itself, but simplifies
+-- later transformations.
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Common.Exp.Simp.ANormal (
@@ -13,15 +30,62 @@ import Icicle.Common.Fresh
 import P
 import Data.List (unzip)
 
-anormal :: Exp n p -> Fresh n (Exp n p)
+import qualified    Data.Set    as Set
+
+-- | A-normalise an expression.
+-- We need a fresh name supply.
+anormal :: Ord n => Exp n p -> Fresh n (Exp n p)
 anormal xx
- = do   (bs, x) <- anormal' xx
-        return $ makeLets bs x
+ = do   (bs, x)  <- anormal' xx
+        (bs',x') <- renames bs [] x
+        return $ makeLets bs' x'
+ where
+
+  -- The sub-expressions of x might already have let bindings, and we're
+  -- going to pull those out.
+  --
+  -- However, this actually changes the scope of those let bindings
+  -- as they will now encompass any bindings in other sub-expressions.
+  --
+  -- If the same name is used in multiple places, we'll introduce shadowing, which is
+  -- outlawed by the type checker.
+  --
+  -- So, we look at each binding, and if it would shadow something, we rename it.
+  renames [] seen  x
+   = return (seen, x)
+
+  renames ((n,b):bs) seen x
+   -- Check if n is used anywhere else
+   | n `Set.member` allvars (makeLets bs x)
+   = do n' <- fresh
+        -- Lets are non-recursive, so "b" will not change.
+
+        -- We need to convert the rest of the bindings into a
+        -- series of lets that we can substitute on.
+        --
+        -- Note that mapping subst over (fmap snd bs) wouldn't work - because we'd lose
+        -- valuable shadowing information from the names in (fmap fst bs).
+        let lets = makeLets bs x
+        -- Substitute with the new name
+        lets' <- subst n (XVar n') lets
+
+        -- It's silly, but we need to pull back out to a list of bindings again.
+        -- We could save some work by going backwards, but this way seems simpler for now.
+        let (bs',x') = takeLets lets'
+
+        -- Proceed.
+        renames bs' (seen <> [(n', b)]) x'
+
+   -- The name isn't used elsewhere, so we can skip it
+   | otherwise
+   = renames bs (seen <> [(n,b)]) x
 
 
-anormal' :: Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
+-- | Recursively pull out sub-expressions to be bound
+anormal' :: Ord n => Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
 anormal' xx
  = case xx of
+    -- Values and other simple expressions can be left alone.
     XVar{}
      -> ret
     XPrim{}
@@ -29,28 +93,40 @@ anormal' xx
     XValue{}
      -> ret
 
+    -- An application - might as well do it in one go
     XApp{}
-     -> do  let (f,args) = takeApps xx
+     -> do  -- Grab the function and its arguments
+            let (f,args) = takeApps xx
+            -- Recurse over the function and grab its bindings, if any
             (bf, xf)    <-      extractBinding f
+            -- And with the arguments
             (bs, xs)    <- unzip <$> mapM extractBinding args
+
+            -- Push all the bindings together, then reconstruct the new application
             return (concat (bf:bs), makeApps xf xs)
 
+    -- Lambdas are barriers.
+    -- We don't want to pull anything out.
     XLam n v x
      -> do  x' <- anormal x
             return ([], XLam n v x')
 
+    -- Just recurse over lets
     XLet n x y
      -> do  (bx, x')    <- anormal' x
             (by, y')    <- anormal' y
-            -- TODO: I think we need to rename in here
+
             return (bx <> [(n, x')] <> by, y')
 
  where
+  -- Return unchanged
   ret = return ([], xx)
 
 
-
-extractBinding :: Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
+-- | Extract bindings for part of an application expression.
+-- If it's simple, just give it back.
+-- If it's interesting, anormalise it and bind it to a fresh name
+extractBinding :: Ord n => Exp n p -> Fresh n ([(Name n, Exp n p)], Exp n p)
 extractBinding xx
  | isNormal xx
  = return ([], xx)
@@ -59,6 +135,8 @@ extractBinding xx
         n       <- fresh
         return (bs <> [(n,x')], XVar n)
 
+
+-- | Check whether expression is worth extracting
 isNormal :: Exp n p -> Bool
 isNormal xx
  = case xx of

--- a/src/Icicle/Common/Exp/Simp/Beta.hs
+++ b/src/Icicle/Common/Exp/Simp/Beta.hs
@@ -1,0 +1,53 @@
+-- | Beta and let reduction for simple values
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PatternGuards #-}
+module Icicle.Common.Exp.Simp.Beta (
+      beta
+    , isSimpleValue
+    ) where
+
+import Icicle.Common.Exp.Exp
+import Icicle.Common.Exp.Compounds
+
+import P
+
+
+-- | Beta and let reduction
+beta :: (Show n, Show p, Ord n) => (Exp n p -> Bool) -> Exp n p -> Exp n p
+beta isValue toplevel
+ = go toplevel
+ where
+  go xx
+   = case xx of
+      XApp p q
+       | XLam n _ x <- go p
+       , v <- go q
+       , isValue v
+       , Just x' <- substMaybe n v x
+       -> go x'
+     
+      XApp p q
+       -> go p `XApp` go q
+
+      XLam n t x
+       -> XLam n t $ go x
+
+      XLet n v x
+       | isValue v
+       , Just x' <- substMaybe n v x
+       -> go x'
+
+      XLet n v x
+       -> XLet n (go v) (go x)
+  
+      XVar{}          -> xx
+      XPrim{}         -> xx
+
+
+-- | Check if expression is just a primitive or a variable.
+isSimpleValue :: Exp n p -> Bool
+isSimpleValue xx
+ = case xx of
+    XPrim{} -> True
+    XVar{}  -> True
+    _       -> False

--- a/src/Icicle/Common/Exp/Simp/Beta.hs
+++ b/src/Icicle/Common/Exp/Simp/Beta.hs
@@ -40,6 +40,7 @@ beta isValue toplevel
       XLet n v x
        -> XLet n (go v) (go x)
   
+      XValue{}        -> xx
       XVar{}          -> xx
       XPrim{}         -> xx
 
@@ -50,4 +51,5 @@ isSimpleValue xx
  = case xx of
     XPrim{} -> True
     XVar{}  -> True
+    XValue{}-> True
     _       -> False

--- a/src/Icicle/Common/Fresh.hs
+++ b/src/Icicle/Common/Fresh.hs
@@ -1,0 +1,59 @@
+-- | Generating Fresh names
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE ExistentialQuantification #-}
+module Icicle.Common.Fresh (
+      Fresh    (..)
+    , NameState
+    , mkNameState
+    , counterNameState
+    , counterPrefixNameState
+    , fresh
+    ) where
+
+import              Icicle.Common.Base
+import              P
+
+import qualified    Data.Text as T
+
+newtype Fresh n a
+ = Fresh
+ { runFresh :: NameState n -> (NameState n, a) }
+
+data NameState n
+ = forall s.
+ NameState (s -> (Name n, s))
+            s
+
+mkNameState :: (s -> (Name n, s)) -> s -> NameState n
+mkNameState = NameState
+
+counterNameState :: (Int -> Name n) -> Int -> NameState n
+counterNameState f i
+ = mkNameState (\i' -> (f i', i'+1)) i
+
+counterPrefixNameState :: T.Text -> NameState T.Text
+counterPrefixNameState prefix
+ = counterNameState (\i -> NameMod prefix $ Name $ T.pack $ show i) 0
+
+fresh :: Fresh n (Name n)
+fresh
+ = Fresh
+ $ \ns ->
+   case ns of
+    NameState f s
+     -> let (n,s') = f s
+        in  (NameState f s', n)
+
+instance Monad (Fresh n) where
+ (>>=) p q
+  = Fresh
+  $ \ns ->
+     let (ns',a) = runFresh p ns
+     in runFresh (q a) ns'
+
+ return a = Fresh $ \ns -> (ns, a)
+
+instance Functor (Fresh n) where
+ fmap f p
+  = p >>= (return . f)
+

--- a/src/Icicle/Common/Fresh.hs
+++ b/src/Icicle/Common/Fresh.hs
@@ -57,3 +57,10 @@ instance Functor (Fresh n) where
  fmap f p
   = p >>= (return . f)
 
+instance Applicative (Fresh n) where
+ pure = return
+ (<*>) f x
+  = do f' <- f
+       x' <- x
+       return $ f' x'
+ 

--- a/src/Icicle/Common/Type.hs
+++ b/src/Icicle/Common/Type.hs
@@ -44,6 +44,7 @@ import qualified    Data.Map as Map
 data ValType =
    IntT
  | BoolT
+ | DateTimeT
  | ArrayT ValType
  | MapT   ValType ValType
  | OptionT        ValType
@@ -164,6 +165,10 @@ valueMatchesType v t
  , BoolT        <- t
  = True
 
+ | VDateTime _  <- v
+ , DateTimeT    <- t
+ = True
+
  | VArray vs    <- v
  , ArrayT t'    <- t
  = all (flip valueMatchesType t') vs
@@ -196,6 +201,7 @@ valueMatchesType v t
 instance Pretty ValType where
  pretty IntT            = text "Int"
  pretty BoolT           = text "Bool"
+ pretty DateTimeT       = text "DateTime"
  pretty (ArrayT t)      = text "Array " <> pretty t
  pretty (MapT k v)      = text "Map" <+> pretty k <+> pretty v
  pretty (OptionT a)     = text "Option" <+> pretty a

--- a/src/Icicle/Common/Value.hs
+++ b/src/Icicle/Common/Value.hs
@@ -3,7 +3,6 @@
 module Icicle.Common.Value (
       Heap
     , Value     (..)
-    , BaseValue (..)
     , getBaseValue
     ) where
 
@@ -26,19 +25,6 @@ data Value n p
  -- | A function carries its own heap, the name of its argument, and the expression to apply.
  -- Actually - we might want the type of the argument here too, for typeOfValue
  | VFun   (Heap n p)  (Name n)  (Exp n p)
- deriving (Show, Ord, Eq)
-
-
--- | Base values - real values that can be serialised and whatnot
--- Note that subvalues of these are also base values - so we can't have, say, a pair of functions.
-data BaseValue
- = VInt   Int
- | VBool  Bool
- | VArray [BaseValue]
- | VPair  BaseValue BaseValue
- | VSome  BaseValue
- | VNone
- | VMap   (Map.Map BaseValue BaseValue)
  deriving (Show, Ord, Eq)
 
 

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -72,18 +72,6 @@ evalPrim p vs
       -> primError
 
 
-     PrimConst (PrimConstBool b)
-      | [] <- vs
-      -> return $ VBase $ VBool b
-      | otherwise
-      -> primError
-
-     PrimConst (PrimConstInt i)
-      | [] <- vs
-      -> return $ VBase $ VInt i
-      | otherwise
-      -> primError
-
      PrimConst (PrimConstPair _ _)
       | [VBase x,VBase y] <- vs
       -> return $ VBase $ VPair x y
@@ -93,24 +81,6 @@ evalPrim p vs
      PrimConst (PrimConstSome _)
       | [VBase v] <- vs
       -> return $ VBase $ VSome v
-      | otherwise
-      -> primError
-
-     PrimConst (PrimConstNone _)
-      | [] <- vs
-      -> return $ VBase $ VNone
-      | otherwise
-      -> primError
-
-     PrimConst (PrimConstArrayEmpty _)
-      | [] <- vs
-      -> return $ VBase $ VArray []
-      | otherwise
-      -> primError
-
-     PrimConst (PrimConstMapEmpty _ _)
-      | [] <- vs
-      -> return $ VBase $ VMap Map.empty
       | otherwise
       -> primError
 

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -52,7 +52,7 @@ evalPrim p vs
           PrimRelationGt -> i >  j
           PrimRelationGe -> i >= j
           PrimRelationLt -> i <  j
-          PrimRelationLe -> i <  j
+          PrimRelationLe -> i <= j
           PrimRelationEq -> i == j
           PrimRelationNe -> i /= j
       | otherwise

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -9,6 +9,7 @@ import Icicle.Common.Base
 import Icicle.Common.Value
 import Icicle.Common.Exp.Eval
 import Icicle.Core.Exp.Prim
+import qualified    Icicle.Data.DateTime as DT
 
 import              P
 
@@ -40,8 +41,12 @@ evalPrim p vs
       -> primError
 
 
-     PrimRelation rel
-      | [VBase (VInt i), VBase (VInt j)] <- vs
+     PrimRelation rel _
+      -- It is safe to assume they are of the same value type
+      -- and "ordable", if we assume that it typechecks.
+      -- So we should be able to rely on the BaseValue Ord instance
+      -- without unwrapping the different types
+      | [VBase i, VBase j] <- vs
       -> return $ VBase $ VBool
        $ case rel of
           PrimRelationGt -> i >  j
@@ -135,6 +140,15 @@ evalPrim p vs
 
       | otherwise
       -> primError
+
+
+     -- Date stuff
+     PrimDateTime PrimDateTimeDaysDifference
+      | [VBase (VDateTime a), VBase (VDateTime b)] <- vs
+      -> return $ VBase $ VInt $ DT.daysDifference a b
+      | otherwise
+      -> primError
+
 
  where
   applies :: Ord n => Value n Prim -> [Value n Prim] -> Either (RuntimeError n Prim) (Value n Prim)

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -5,6 +5,7 @@ module Icicle.Core.Eval.Exp (
       evalPrim
     ) where
 
+import Icicle.Common.Base
 import Icicle.Common.Value
 import Icicle.Common.Exp.Eval
 import Icicle.Core.Exp.Prim

--- a/src/Icicle/Core/Eval/Program.hs
+++ b/src/Icicle/Core/Eval/Program.hs
@@ -45,8 +45,8 @@ data RuntimeError n
 -- some value, and the minimum facts needed to compute next value.
 data ProgramValue n =
  ProgramValue {
-    value   :: V.BaseValue
- ,  history :: [BubbleGumOutput n V.BaseValue]
+    value   :: BaseValue
+ ,  history :: [BubbleGumOutput n BaseValue]
  }
  deriving (Show, Eq)
 
@@ -105,7 +105,7 @@ evalReds
         => V.Heap n Prim
         -> SV.StreamHeap  n
         -> [(Name n, Reduce n)]
-        -> Either (RuntimeError n) ([BubbleGumOutput n V.BaseValue], V.Heap n Prim)
+        -> Either (RuntimeError n) ([BubbleGumOutput n BaseValue], V.Heap n Prim)
 
 evalReds xh _ []
  = return ([], xh)

--- a/src/Icicle/Core/Eval/Program.hs
+++ b/src/Icicle/Core/Eval/Program.hs
@@ -67,8 +67,13 @@ eval d sv p
         (bgs,reds)
                 <- evalReds pres            stms        (P.reduces      p)
 
+        -- Insert date into environment if necessary
+        let reds' = case P.postdate p of
+                    Nothing -> reds
+                    Just nm -> Map.insert nm (VBase $ VDateTime d) reds
+
         post    <- mapLeft RuntimeErrorPost
-                 $ XV.evalExps XV.evalPrim  reds        (P.postcomps    p)
+                 $ XV.evalExps XV.evalPrim  reds'       (P.postcomps    p)
 
         ret     <- mapLeft RuntimeErrorReturn
                  $ XV.eval XV.evalPrim post

--- a/src/Icicle/Core/Eval/Reduce.hs
+++ b/src/Icicle/Core/Eval/Reduce.hs
@@ -34,8 +34,8 @@ type RuntimeError n
 
 -- | Evaluating a reduction also gives us the history of its inputs
 type ReduceValue n =
- ( BubbleGumOutput n V.BaseValue
- , V.BaseValue )
+ ( BubbleGumOutput n BaseValue
+ , BaseValue )
 
 
 -- | Evaluate a reduction.
@@ -84,12 +84,12 @@ eval reduction_name xh sh r
             num' <- evalX num
             -- It better be an Int
             case num' of
-             V.VBase (V.VInt i)
+             V.VBase (VInt i)
                  -- Take the latest i 
               -> let sv' = latest i $ fst sv
                  -- and split into history and values
                  in  return ( BubbleGumFacts $ flavoursOfSource sv'
-                            , V.VArray $ fmap snd sv' )
+                            , VArray $ fmap snd sv' )
 
              _
               -> Left (SV.RuntimeErrorExpNotOfType num' IntT)

--- a/src/Icicle/Core/Eval/Stream.hs
+++ b/src/Icicle/Core/Eval/Stream.hs
@@ -39,7 +39,7 @@ import qualified    Data.Map as Map
 -- If it is windowed, we instead store the values needed to recompute, as values will drop off
 -- the start of the window.
 type StreamValue
- = ([(BubbleGumFact, V.BaseValue)], StreamWindow)
+ = ([(BubbleGumFact, BaseValue)], StreamWindow)
 
 -- | Whether this stream is the result - directly or indirectly - of a windowed source
 data StreamWindow = Windowed Int | UnWindowed
@@ -49,7 +49,7 @@ data StreamWindow = Windowed Int | UnWindowed
 -- These can be used by windowing functions or ignored.
 -- Afterwards they are thrown away, but could still be included in the value itself.
 type DatedStreamValue
- = [AsAt (BubbleGumFact, V.BaseValue)]
+ = [AsAt (BubbleGumFact, BaseValue)]
 
 
 -- | A stream heap maps from names to stream values
@@ -122,7 +122,7 @@ eval window_check xh concreteValues sh s
   evalFilt x arg
    = do v <- applyX x arg
         case v of
-         V.VBase (V.VBool b)
+         V.VBase (VBool b)
           -> return b
          _
           -> Left (RuntimeErrorExpNotOfType v BoolT)

--- a/src/Icicle/Core/Eval/Stream.hs
+++ b/src/Icicle/Core/Eval/Stream.hs
@@ -80,12 +80,12 @@ eval window_check xh concreteValues sh s
  = case s of
     -- Raw input is easy
     Source
-     -> return (fmap fact concreteValues, UnWindowed)
+     -> return (fmap streamvalue concreteValues, UnWindowed)
 
     -- Windowed input.
     -- The dates are assured to be increasing, so we could really use a takeWhile.dropWhile or something
     SourceWindowedDays window
-     -> return ( fmap fact
+     -> return ( fmap streamvalue
                $ filter (\v -> withinWindow (time v) window_check window)
                $ concreteValues
 
@@ -103,6 +103,9 @@ eval window_check xh concreteValues sh s
             return (sv', snd sv)
 
  where
+  streamvalue v
+   = (fst $ fact v, VPair (snd $ fact v) (VDateTime $ time v))
+
   -- Evaluate transform over given values.
   -- We don't need the stream heap any more.
   --

--- a/src/Icicle/Core/Exp/Combinators.hs
+++ b/src/Icicle/Core/Exp/Combinators.hs
@@ -32,10 +32,10 @@ var = XVar . Name
 
 
 constI :: Int -> X.Exp n
-constI = XPrim . PrimConst . PrimConstInt
+constI = XValue IntT  . VInt
 
 constB :: Bool -> X.Exp n
-constB = XPrim . PrimConst . PrimConstBool
+constB = XValue BoolT . VBool
 
 
 prim2 :: Prim -> X.Exp n -> X.Exp n -> X.Exp n

--- a/src/Icicle/Core/Exp/Combinators.hs
+++ b/src/Icicle/Core/Exp/Combinators.hs
@@ -59,27 +59,27 @@ infixl 6 -~
 infixl 7 /~
 
 (>~) :: X.Exp n -> X.Exp n -> X.Exp n
-(>~) = prim2 (PrimRelation PrimRelationGt)
+(>~) = prim2 (PrimRelation PrimRelationGt IntT)
 infix 4 >~
 
 (>=~) :: X.Exp n -> X.Exp n -> X.Exp n
-(>=~) = prim2 (PrimRelation PrimRelationGe)
+(>=~) = prim2 (PrimRelation PrimRelationGe IntT)
 infix 4 >=~
 
 (<~) :: X.Exp n -> X.Exp n -> X.Exp n
-(<~) = prim2 (PrimRelation PrimRelationLt)
+(<~) = prim2 (PrimRelation PrimRelationLt IntT)
 infix 4 <~
 
 (<=~) :: X.Exp n -> X.Exp n -> X.Exp n
-(<=~) = prim2 (PrimRelation PrimRelationLe)
+(<=~) = prim2 (PrimRelation PrimRelationLe IntT)
 infix 4 <=~
 
 (==~) :: X.Exp n -> X.Exp n -> X.Exp n
-(==~) = prim2 (PrimRelation PrimRelationEq)
+(==~) = prim2 (PrimRelation PrimRelationEq IntT)
 infix 4 ==~
 
 (/=~) :: X.Exp n -> X.Exp n -> X.Exp n
-(/=~) = prim2 (PrimRelation PrimRelationNe)
+(/=~) = prim2 (PrimRelation PrimRelationNe IntT)
 infix 4 /=~
 
 

--- a/src/Icicle/Core/Exp/Combinators.hs
+++ b/src/Icicle/Core/Exp/Combinators.hs
@@ -9,12 +9,14 @@ import              Icicle.Common.Type
 import              Icicle.Core.Exp.Prim
 import qualified    Icicle.Core.Exp.Exp     as X
 import              Icicle.Common.Exp.Exp
+import              Icicle.Common.Exp.Compounds
 
-import              System.IO.Unsafe
-import              System.IO
-import              Data.IORef
 import              P
-import              Data.Text   as T
+import qualified    Data.Text   as T
+import              Data.Text   (Text)
+import qualified    Data.Set    as Set
+
+import              Prelude (error)
 
 -- | Right-associative application
 ($~) :: X.Exp n -> X.Exp n -> X.Exp n
@@ -85,24 +87,31 @@ infix 4 /=~
 
 lam :: ValType -> (X.Exp Text -> X.Exp Text) -> X.Exp Text
 lam t f
- = unsafePerformIO
- $ do   n <- lam_get_counter
-        let v = NameMod "_" $ Name $ T.pack $ show n
-        return $  XLam v t $ f $ XVar v
- 
+ = let -- Try with a bad name - this won't necessarily be fresh,
+       -- but it will allow us to get the variables in the expression
+       init = f (XVar $ Name "$$$")
+       vars = allvars init
 
--- | Unsafe fresh name generation for lambdas
--- !!!
--- I think there's a better way to do this with
--- tying some knots and getting free variables
--- but free variables isn't implemented yet.
-lam_get_counter :: IO Int
-lam_get_counter
- = do   n <- readIORef lam_free_counter
-        modifyIORef lam_free_counter (+1)
-        return n
+       -- Look through all the numbers, and find one that isn't already
+       -- used in the expression
+       free = filter (not . flip Set.member vars)
+            $ fmap varOfInt [0..]
 
-{-# NOINLINE lam_free_counter #-}
-lam_free_counter :: IORef Int
-lam_free_counter = unsafePerformIO $ newIORef 0
+       -- Take the head; free should be a practically infinite list.
+       -- If it is empty, that means there are at least 2^64 variables
+       -- in the expression and it isn't going to fit in memory.
+       -- In that case, we might as well die anyway.
+       v    = head_error free
+   in  XLam v t (f $ XVar v)
+
+ where
+  head_error (x:_)
+   = x
+  head_error []
+   = error "Icicle/Core/Exp/Combinators.hs: lam: this is impossible; taking the head of a nearly-infinite list should not fail"
+
+  -- Convert an int to a variable name
+  varOfInt :: Int -> Name Text
+  varOfInt i
+   = NameMod "_" $ Name $ T.pack $ show i
 

--- a/src/Icicle/Core/Exp/Combinators.hs
+++ b/src/Icicle/Core/Exp/Combinators.hs
@@ -37,6 +37,11 @@ constI = XValue IntT  . VInt
 constB :: Bool -> X.Exp n
 constB = XValue BoolT . VBool
 
+fstOfSource :: ValType -> X.Exp Text -> X.Exp Text
+fstOfSource ty p
+ = XPrim (PrimFold (PrimFoldPair ty DateTimeT) ty)
+    @~ (lam ty $ \x -> lam DateTimeT $ \_ -> x) @~ p
+
 
 prim2 :: Prim -> X.Exp n -> X.Exp n -> X.Exp n
 prim2 p x y = XPrim p @~ x @~ y

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -8,6 +8,7 @@ module Icicle.Core.Exp.Prim (
     , PrimConst(..)
     , PrimFold (..)
     , PrimMap  (..)
+    , PrimDateTime (..)
     , typeOfPrim
     ) where
 
@@ -21,13 +22,16 @@ import              P
 -- Pretty empty for now.
 data Prim
  = PrimArith    PrimArith
- | PrimRelation PrimRelation
+ -- | Relation prims like less than, equal etc work for a bunch of different types
+ | PrimRelation PrimRelation ValType
  | PrimLogical  PrimLogical
  | PrimConst    PrimConst
  -- | Fold and return type
  | PrimFold     PrimFold ValType
  -- | Map primitives
  | PrimMap      PrimMap
+ -- | Date primitives
+ | PrimDateTime PrimDateTime
  deriving (Eq, Ord, Show)
 
 -- | Arithmetic primitives
@@ -74,6 +78,12 @@ data PrimMap
  = PrimMapInsertOrUpdate ValType ValType
  deriving (Eq, Ord, Show)
 
+-- | DateTime primitives
+data PrimDateTime
+ = PrimDateTimeDaysDifference
+ deriving (Eq, Ord, Show)
+
+
 
 -- | A primitive always has a well-defined type
 typeOfPrim :: Prim -> Type
@@ -83,9 +93,9 @@ typeOfPrim p
     PrimArith _
      -> FunT [intT, intT] IntT
 
-    -- All relations are ints
-    PrimRelation _
-     -> FunT [intT, intT] BoolT
+    -- All relations are binary to bool
+    PrimRelation _ val
+     -> FunT [funOfVal val, funOfVal val] BoolT
 
     -- Logical relations
     PrimLogical PrimLogicalNot
@@ -116,6 +126,8 @@ typeOfPrim p
     PrimMap (PrimMapInsertOrUpdate k v)
      -> FunT [FunT [funOfVal v] v, funOfVal v, funOfVal k, funOfVal (MapT k v)] (MapT k v)
 
+    PrimDateTime PrimDateTimeDaysDifference
+     -> FunT [funOfVal DateTimeT, funOfVal DateTimeT] IntT
  where
   intT = FunT [] IntT
 
@@ -127,12 +139,17 @@ instance Pretty Prim where
  pretty (PrimArith PrimArithMinus)      = text  "sub#"
  pretty (PrimArith PrimArithDiv)        = text  "div#"
 
- pretty (PrimRelation PrimRelationGt)   = text  "gt#"
- pretty (PrimRelation PrimRelationGe)   = text  "ge#"
- pretty (PrimRelation PrimRelationLt)   = text  "lt#"
- pretty (PrimRelation PrimRelationLe)   = text  "le#"
- pretty (PrimRelation PrimRelationEq)   = text  "eq#"
- pretty (PrimRelation PrimRelationNe)   = text  "ne#"
+ pretty (PrimRelation rel t)
+  = text prel <+> brackets (pretty t)
+  where
+   prel
+    = case rel of
+       PrimRelationGt -> "gt#"
+       PrimRelationGe -> "ge#"
+       PrimRelationLt -> "lt#"
+       PrimRelationLe -> "le#"
+       PrimRelationEq -> "eq#"
+       PrimRelationNe -> "ne#"
 
  pretty (PrimLogical  PrimLogicalNot)   = text  "not#"
  pretty (PrimLogical  PrimLogicalAnd)   = text  "and#"
@@ -157,4 +174,7 @@ instance Pretty Prim where
 
  pretty (PrimMap (PrimMapInsertOrUpdate k v))
   = text "Map_insertOrUpdate#" <+> brackets (pretty k) <+> brackets (pretty v)
+
+ pretty (PrimDateTime PrimDateTimeDaysDifference)
+  = text "DateTime_daysDifference#"
 

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -56,13 +56,8 @@ data PrimLogical
 
 -- | Constant primitives and constructors
 data PrimConst
- = PrimConstInt  Int
- | PrimConstBool Bool
- | PrimConstPair ValType ValType
+ = PrimConstPair ValType ValType
  | PrimConstSome ValType
- | PrimConstNone ValType
- | PrimConstArrayEmpty ValType
- | PrimConstMapEmpty   ValType ValType
  deriving (Eq, Ord, Show)
 
 -- | Folds and destructing things
@@ -101,20 +96,10 @@ typeOfPrim p
      -> FunT [funOfVal BoolT, funOfVal BoolT] BoolT
 
     -- Constants
-    PrimConst (PrimConstInt _)
-     -> intT
-    PrimConst (PrimConstBool _)
-     -> FunT [] BoolT
     PrimConst (PrimConstPair a b)
      -> FunT [funOfVal a, funOfVal b] (PairT a b)
     PrimConst (PrimConstSome a)
      -> FunT [funOfVal a] (OptionT a)
-    PrimConst (PrimConstNone a)
-     -> FunT [] (OptionT a)
-    PrimConst (PrimConstArrayEmpty a)
-     -> FunT [] (ArrayT a)
-    PrimConst (PrimConstMapEmpty k v)
-     -> FunT [] (MapT k v)
 
     -- Folds
     PrimFold PrimFoldBool ret
@@ -153,16 +138,8 @@ instance Pretty Prim where
  pretty (PrimLogical  PrimLogicalAnd)   = text  "and#"
  pretty (PrimLogical  PrimLogicalOr)    = text  "or#"
 
- pretty (PrimConst (PrimConstInt i))    = text (show i)
- pretty (PrimConst (PrimConstBool b))   = text (show b)
-
  pretty (PrimConst (PrimConstPair a b)) = text "pair#" <+> brackets (pretty a) <+> brackets (pretty b)
  pretty (PrimConst (PrimConstSome t))   = text "some#" <+> brackets (pretty t)
- pretty (PrimConst (PrimConstNone t))   = text "none#" <+> brackets (pretty t)
- pretty (PrimConst (PrimConstArrayEmpty t))
-                                        = text "Array_empty#" <+> brackets (pretty t)
- pretty (PrimConst (PrimConstMapEmpty k v))
-                                        = text "Map_empty#" <+> brackets (pretty k) <+> brackets (pretty v)
 
  pretty (PrimFold f ret)
   = let f' = case f of

--- a/src/Icicle/Core/Program/Check.hs
+++ b/src/Icicle/Core/Program/Check.hs
@@ -35,8 +35,12 @@ checkProgram p
         -- Check reduces against streams and pres
         reds    <- checkReduces stms                      (P.reduces      p)
 
+        -- Insert date if necessary
+        let reds' = case P.postdate p of
+                    Nothing -> reds
+                    Just nm -> Map.insert nm (FunT [] DateTimeT) reds
         -- Check postcomputations with precomputations and reduces
-        post    <- checkExps ProgramErrorPost reds        (P.postcomps    p)
+        post    <- checkExps ProgramErrorPost reds'       (P.postcomps    p)
 
         -- Finally, check the return against the postcomputation environment
         rt <- mapLeft ProgramErrorReturn $ checkExp coreFragment post (P.returns      p)

--- a/src/Icicle/Core/Program/Fusion.hs
+++ b/src/Icicle/Core/Program/Fusion.hs
@@ -1,8 +1,9 @@
--- | Fusing two programs together
+-- | Fusing programs together
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Core.Program.Fusion (
     fusePrograms
+  , fuseMultiple
   ) where
 
 import Icicle.Common.Base
@@ -14,15 +15,28 @@ import Icicle.Core.Exp.Combinators
 import Icicle.Core.Exp.Prim
 import qualified Icicle.Common.Exp.Exp as X
 
--- import              Data.Either.Combinators
 import              P
 
 data FusionError n
  = FusionErrorNotSameType ValType ValType
  | FusionErrorTypeError (Maybe (ProgramError n)) (Maybe (ProgramError n))
+ | FusionErrorNothingToFuse
+ deriving (Show)
 
+
+-- | Fuse programs together, prefixing each with its name to ensure that the
+-- generated program has no name clashes.
+-- The two names must be distinct.
 fusePrograms :: Ord n => n -> Program n -> n -> Program n -> Either (FusionError n) (Program n)
 fusePrograms ln lp rn rp
+ = fuseProgramsDistinctNames (prefix ln lp) (prefix rn rp)
+ where
+  prefix n = renameProgram (NameMod n)
+
+
+-- | Fuse programs together, assuming they already have no name clashes.
+fuseProgramsDistinctNames :: Ord n => Program n -> Program n -> Either (FusionError n) (Program n)
+fuseProgramsDistinctNames lp rp
  | input lp /= input rp
  = Left
  $ FusionErrorNotSameType (input lp) (input rp)
@@ -31,39 +45,42 @@ fusePrograms ln lp rn rp
     (Right (FunT [] lt), Right (FunT [] rt))
      -> return
       $ Program
-        { input     = input lp'
-        , precomps  = precomps  lp' <> precomps  rp'
-        , streams   = streams   lp' <> streams   rp'
-        , reduces   = reduces   lp' <> reduces   rp'
+        { input     = input lp
+        , precomps  = precomps  lp <> precomps  rp
+        , streams   = streams   lp <> streams   rp
+        , reduces   = reduces   lp <> reduces   rp
         , postdate  = postdate'
-        , postcomps = postdate'bind <> postcomps lp' <> postcomps rp'
-        , returns   = X.XPrim (PrimConst (PrimConstPair lt rt)) @~ returns lp' @~ returns rp'
+        , postcomps = postdate'bind <> postcomps lp <> postcomps rp
+        , returns   = X.XPrim (PrimConst (PrimConstPair lt rt)) @~ returns lp @~ returns rp
         }
     (le, re)
      -> Left
       $ FusionErrorTypeError (leftToMaybe le) (leftToMaybe re)
 
  where
-  prefix pre 
-   = renameProgram (NameMod pre)
-  lp' = prefix ln lp
-  rp' = prefix rn rp
-
   -- Get new date binding for use in postcomputation.
   (postdate', postdate'bind)
   -- If both use the date, we need to bind both values
-   | Just ld <- postdate lp'
-   , Just rd <- postdate rp'
+   | Just ld <- postdate lp
+   , Just rd <- postdate rp
    = (Just ld, [(rd, X.XVar ld)])
 
    -- Only one uses the date
-   | Just ld <- postdate lp'
+   | Just ld <- postdate lp
    = (Just ld, [])
 
-   | Just rd <- postdate rp'
+   | Just rd <- postdate rp
    = (Just rd, [])
 
    -- Neither use the date
    | otherwise
    = (Nothing, [])
 
+
+-- | Fuse a list of programs together, prefixing each with its name
+fuseMultiple :: Ord n => [(n, Program n)] -> Either (FusionError n) (Program n)
+fuseMultiple ps
+ = let ps' = fmap (\(n,p) -> renameProgram (NameMod n) p) ps
+   in  case ps' of
+        [] -> Left FusionErrorNothingToFuse
+        (f:fs) -> foldM fuseProgramsDistinctNames f fs

--- a/src/Icicle/Core/Program/Program.hs
+++ b/src/Icicle/Core/Program/Program.hs
@@ -34,6 +34,10 @@ data Program n =
  -- as that would require two passes!
  , reduces      :: [(Name n, Reduce n)]
 
+ -- | Whether the snapshot date is available in the postcomputations.
+ -- If so, the name of variable to use.
+ , postdate     :: Maybe (Name n)
+
  -- | Postcomputations with access to precomputations and reduces
  , postcomps    :: [(Name n, Exp n)]
 
@@ -49,6 +53,7 @@ renameProgram f p
   { precomps    = binds  renameExp      (precomps   p)
   , streams     = binds  renameStream   (streams    p)
   , reduces     = binds  renameReduce   (reduces    p)
+  , postdate    =        fmap f         (postdate   p)
   , postcomps   = binds  renameExp      (postcomps  p)
   , returns     =        renameExp f    (returns    p)
   }
@@ -67,7 +72,7 @@ instance Pretty n => Pretty (Program n) where
   <>    ppbinds (streams p)                            <> line
   <>    text "Reductions:"                             <> line    
   <>    ppbinds (reduces p)                            <> line
-  <>    text "Postcomputations:"                       <> line    
+  <>    text "Postcomputations" <> ppdate              <> line    
   <>    ppbinds (postcomps p)                          <> line
   <>    text "Returning:"                              <> line    
   <>    indent 4 (pretty  $ returns   p)               <> line
@@ -77,3 +82,9 @@ instance Pretty n => Pretty (Program n) where
    ppbinds
     = vcat
     . fmap (\(a,b) -> pretty a <+> text "=" <> line <> indent 4 (pretty b))
+
+   ppdate
+    = case postdate p of
+       Nothing -> text ":"
+       Just n  -> text " with date as " <> pretty n <> text ":"
+

--- a/src/Icicle/Core/Stream/Check.hs
+++ b/src/Icicle/Core/Stream/Check.hs
@@ -37,9 +37,9 @@ checkStream
 checkStream se s
  = case s of
     Source
-     -> return (concrete se)
+     -> return $ PairT (concrete se) DateTimeT
     SourceWindowedDays _
-     -> return (concrete se)
+     -> return $ PairT (concrete se) DateTimeT
     STrans st f n
      -> do  inp <- lookupOrDie StreamErrorVarNotInEnv (streams se) n
             fty <- mapLeft     StreamErrorExp $ checkExp coreFragment (scalars se) f

--- a/src/Icicle/Data/DateTime.hs
+++ b/src/Icicle/Data/DateTime.hs
@@ -7,6 +7,7 @@ module Icicle.Data.DateTime (
   , dateOfYMD
   , dateOfDays
   , withinWindow
+  , daysDifference
   ) where
 
 import qualified Data.Dates         as D
@@ -50,6 +51,13 @@ dateOfDays d
 -- TODO: datesDifference calculates the absolute difference but we don't want abs.
 withinWindow :: DateTime -> DateTime -> Int -> Bool
 withinWindow fact now window
- = let diff = getDateTime fact `D.datesDifference` getDateTime now
-   in  diff <= fromIntegral window
+ = let diff =  daysDifference fact now
+   in  diff <= window
+
+-- | Find number of days between to dates
+-- TODO: datesDifference calculates the absolute difference but we don't want abs.
+daysDifference :: DateTime -> DateTime -> Int
+daysDifference fact now
+ = fromInteger
+ $ getDateTime fact `D.datesDifference` getDateTime now
 

--- a/src/Icicle/Dictionary.hs
+++ b/src/Icicle/Dictionary.hs
@@ -4,6 +4,7 @@ module Icicle.Dictionary (
     Dictionary (..)
   , Definition (..)
   , Virtual (..)
+  , getVirtualFeatures
   , demographics
   ) where
 
@@ -43,6 +44,17 @@ data Virtual =
     } deriving (Eq, Show)
 
 
+-- | Get all virtual features from dictionary
+getVirtualFeatures :: Dictionary -> [(Attribute, Virtual)]
+getVirtualFeatures (Dictionary fs)
+ = P.concatMap getV fs
+ where
+  getV (a, VirtualDefinition v)
+   = [(a,v)]
+  getV _
+   = []
+
+
 
 -- | Example demographics dictionary
 -- Hard-coded for now
@@ -55,35 +67,35 @@ demographics =
  , (Attribute "salary",             ConcreteDefinition IntEncoding)
  
   -- Useless virtual features
- , (Attribute "sum of all salary",      
+ , (Attribute "sum",      
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_sum)
 
- , (Attribute "count all salary entries",
+ , (Attribute "count",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_count)
 
- , (Attribute "mean of all salary",
+ , (Attribute "mean",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_mean)
 
- , (Attribute "filter >= 70k; sum",
+ , (Attribute "filter",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_filt_sum)
 
- , (Attribute "Latest 2 salary entries, unwindowed",
+ , (Attribute "latest",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") (program_latest 2))
 
- , (Attribute "Sum of last 3000 days",
+ , (Attribute "windowed",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") (program_windowed_sum 3000))
 
- , (Attribute "Count unique",
+ , (Attribute "unique",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_count_unique)
 
- , (Attribute "Days since latest",
+ , (Attribute "days_since",
                                     VirtualDefinition
                                   $ Virtual (Attribute "salary") program_days_since_latest)
  ]

--- a/src/Icicle/Dictionary.hs
+++ b/src/Icicle/Dictionary.hs
@@ -94,6 +94,7 @@ program_sum
  , P.streams    = [(N.Name "inp", S.Source)
                   ,(N.Name "inp2", map_fst T.IntT (N.Name "inp"))]
  , P.reduces    = [(N.Name "red", fold_sum (N.Name "inp2"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = var "red"
  }
@@ -121,6 +122,7 @@ program_count
  , P.streams    = [(N.Name "inp", S.Source)
                   ,(N.Name "ones", S.STrans (S.SMap (T.PairT T.IntT T.DateTimeT) T.IntT) const1 (N.Name "inp"))]
  , P.reduces    = [(N.Name "count", fold_sum (N.Name "ones"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = X.XVar (N.Name "count")
  }
@@ -139,6 +141,7 @@ program_mean
                   ,(N.Name "ones", S.STrans (S.SMap (T.PairT T.IntT T.DateTimeT) T.IntT) const1 (N.Name "inp"))]
  , P.reduces    = [(N.Name "count", fold_sum (N.Name "ones"))
                   ,(N.Name "sum",   fold_sum (N.Name "inp2"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = var "sum" /~ var "count"
  }
@@ -156,6 +159,7 @@ program_filt_sum
                   ,(N.Name "inp2", map_fst T.IntT (N.Name "inp"))
                   ,(N.Name "filts", S.STrans (S.SFilter T.IntT) gt (N.Name "inp2"))]
  , P.reduces    = [(N.Name "sum",   fold_sum (N.Name "filts"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = X.XVar (N.Name "sum")
  }
@@ -172,6 +176,7 @@ program_latest n
  , P.precomps   = []
  , P.streams    = [(N.Name "inp", S.Source)]
  , P.reduces    = [(N.Name "latest", R.RLatest (T.PairT T.IntT T.DateTimeT) (constI n) (N.Name "inp"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = X.XVar (N.Name "latest")
  }
@@ -185,6 +190,7 @@ program_windowed_sum days
  , P.streams    = [(N.Name "inp", S.SourceWindowedDays days)
                   ,(N.Name "inp2", map_fst T.IntT (N.Name "inp"))]
  , P.reduces    = [(N.Name "sum",   fold_sum (N.Name "inp2"))]
+ , P.postdate   = Nothing
  , P.postcomps  = []
  , P.returns    = X.XVar (N.Name "sum")
  }
@@ -201,6 +207,7 @@ program_count_unique
                         (lam mT $ \acc -> lam T.IntT $ \v -> X.XPrim (P.PrimMap $ P.PrimMapInsertOrUpdate T.IntT T.IntT) @~ (lam T.IntT $ \_ -> constI 1) @~ constI 1 @~ v @~ acc)
                         (X.XValue (T.MapT T.IntT T.IntT) $ N.VMap $ Map.empty)
                         (N.Name "inp2"))]
+ , P.postdate   = Nothing
  , P.postcomps  = [(N.Name "size", X.XPrim (P.PrimFold (P.PrimFoldMap T.IntT T.IntT) T.IntT) @~ (lam T.IntT $ \a -> lam T.IntT $ \_ -> lam T.IntT $ \b -> a +~ b) @~ constI 0 @~ var "uniq")]
  , P.returns    = var "size"
  }

--- a/src/Icicle/Dictionary.hs
+++ b/src/Icicle/Dictionary.hs
@@ -21,6 +21,7 @@ import qualified Icicle.Core.Program.Program as P
 import           P
 
 import           Data.Text
+import qualified Data.Map                    as Map
 
 
 data Dictionary =
@@ -189,7 +190,7 @@ program_count_unique
  , P.reduces    = [(N.Name "uniq",
                         R.RFold T.IntT mT
                         (lam mT $ \acc -> lam T.IntT $ \v -> X.XPrim (P.PrimMap $ P.PrimMapInsertOrUpdate T.IntT T.IntT) @~ (lam T.IntT $ \_ -> constI 1) @~ constI 1 @~ v @~ acc)
-                        (X.XPrim (P.PrimConst $ P.PrimConstMapEmpty T.IntT T.IntT))
+                        (X.XValue (T.MapT T.IntT T.IntT) $ N.VMap $ Map.empty)
                         (N.Name "inp"))]
  , P.postcomps  = [(N.Name "size", X.XPrim (P.PrimFold (P.PrimFoldMap T.IntT T.IntT) T.IntT) @~ (lam T.IntT $ \a -> lam T.IntT $ \_ -> lam T.IntT $ \b -> a +~ b) @~ constI 0 @~ var "uniq")]
  , P.returns    = var "size"

--- a/src/Icicle/Internal/Pretty.hs
+++ b/src/Icicle/Internal/Pretty.hs
@@ -5,13 +5,16 @@
 -- Its (<>) really is a monoid though, so hiding it and adding
 -- an orphan instance that does the same thing seems fine to me.
 --
+-- The pretty printer also defines <$> which isn't an applicative.
+-- We will just hide that one.
+--
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 module Icicle.Internal.Pretty (
     module PP
     ) where
 
--- The one we want to export without <>
-import              Text.PrettyPrint.Leijen as PP hiding ((<>))
+-- The one we want to export without <> or <$>
+import              Text.PrettyPrint.Leijen as PP hiding ((<>), (<$>))
 -- The one with <>
 import              Text.PrettyPrint.Leijen as PJOIN
 

--- a/src/Icicle/Simulator.hs
+++ b/src/Icicle/Simulator.hs
@@ -18,7 +18,7 @@ import           Icicle.Dictionary
 
 import           P
 
-import qualified Icicle.Common.Value      as V
+import qualified Icicle.Common.Base       as V
 import qualified Icicle.Core.Eval.Program as PV
 import qualified Icicle.Core.Program.Program as P
 

--- a/src/Icicle/Simulator.hs
+++ b/src/Icicle/Simulator.hs
@@ -14,6 +14,7 @@ import           Data.Text (Text)
 
 import qualified Icicle.BubbleGum   as B
 import           Icicle.Data
+import           Icicle.Data.DateTime
 import           Icicle.Dictionary
 
 import           P
@@ -119,6 +120,7 @@ valueFromCore v
  = case v of
     V.VInt i      -> return $ IntValue i
     V.VBool b     -> return $ BooleanValue b
+    V.VDateTime d -> return $ DateValue $ Date $ renderDate d
     V.VArray vs   -> ListValue . List
                   <$> mapM valueFromCore vs
     V.VPair a b   -> PairValue <$> valueFromCore a <*> valueFromCore b

--- a/test/Icicle/Test/Avalanche/CheckCommutes.hs
+++ b/test/Icicle/Test/Avalanche/CheckCommutes.hs
@@ -20,15 +20,14 @@ import           System.IO
 import           Test.QuickCheck
 
 -- We need a way to differentiate stream variables from scalars
-elemPrefix = Var "element" 0
-accPrefix  = Var "accumulator" 0
+namer = Convert.namerText (flip Var 0)
 
 -- A well typed core program is well typed under Avalanche
 prop_check_commutes t =
  forAll (programForStreamType t)
  $ \p ->
     isRight     (checkProgram p) ==>
-     let conv = Convert.programFromCore elemPrefix accPrefix p in
+     let conv = Convert.programFromCore namer p in
      case Check.checkProgram coreFragment conv of
       Right _
        -> property True

--- a/test/Icicle/Test/Avalanche/CheckCommutes.hs
+++ b/test/Icicle/Test/Avalanche/CheckCommutes.hs
@@ -11,26 +11,24 @@ import           Icicle.Core.Exp (coreFragment)
 import qualified Icicle.Avalanche.FromCore  as Convert
 import qualified Icicle.Avalanche.Check     as Check
 
-import           Icicle.Common.Base
 import           Icicle.Internal.Pretty
-
 
 import           P
 
 import           System.IO
 
-
 import           Test.QuickCheck
 
 -- We need a way to differentiate stream variables from scalars
-elemName n = NameMod (Var "element" 0) n
+elemPrefix = Var "element" 0
+accPrefix  = Var "accumulator" 0
 
 -- A well typed core program is well typed under Avalanche
 prop_check_commutes t =
  forAll (programForStreamType t)
  $ \p ->
     isRight     (checkProgram p) ==>
-     let conv = Convert.programFromCore elemName p in
+     let conv = Convert.programFromCore elemPrefix accPrefix p in
      case Check.checkProgram coreFragment conv of
       Right _
        -> property True

--- a/test/Icicle/Test/Avalanche/EvalCommutes.hs
+++ b/test/Icicle/Test/Avalanche/EvalCommutes.hs
@@ -12,20 +12,18 @@ import qualified Icicle.Core.Eval.Program   as PV
 import qualified Icicle.Avalanche.FromCore  as AC
 import qualified Icicle.Avalanche.Eval      as AE
 
-import           Icicle.Common.Base
-
 import           Icicle.Internal.Pretty
 
 import           P
 
 import           System.IO
 
-
 import           Test.QuickCheck
 import           Data.List (sort)
 
 -- We need a way to differentiate stream variables from scalars
-elemName n = NameMod (Var "element" 0) n
+elemPrefix = Var "element" 0
+accPrefix  = Var "accumulator" 0
 
 -- A well typed core program evaluates to a value in avalanche
 prop_eval_right t =
@@ -34,7 +32,7 @@ prop_eval_right t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     isRight $ AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemName p
+     isRight $ AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p
 
 
 -- going to core doesn't affect value
@@ -44,7 +42,7 @@ prop_eval_commutes_value t =
  forAll (inputsForType t)
  $ \(vs,d) -> counterexample (show $ pretty p) $
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemName p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p, PV.eval d vs p) of
       (Right (_, aval), Right cres)
        ->   aval === PV.value   cres
       (_, Left _)
@@ -60,7 +58,7 @@ prop_eval_commutes_history t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemName p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p, PV.eval d vs p) of
       (Right (abg, _), Right cres)
        ->  (sort abg)  === (sort $ PV.history cres)
       _

--- a/test/Icicle/Test/Avalanche/EvalCommutes.hs
+++ b/test/Icicle/Test/Avalanche/EvalCommutes.hs
@@ -22,8 +22,8 @@ import           Test.QuickCheck
 import           Data.List (sort)
 
 -- We need a way to differentiate stream variables from scalars
-elemPrefix = Var "element" 0
-accPrefix  = Var "accumulator" 0
+namer = AC.namerText (flip Var 0)
+
 
 -- A well typed core program evaluates to a value in avalanche
 prop_eval_right t =
@@ -32,7 +32,7 @@ prop_eval_right t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     isRight $ AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p
+     isRight $ AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p
 
 
 -- going to core doesn't affect value
@@ -42,7 +42,7 @@ prop_eval_commutes_value t =
  forAll (inputsForType t)
  $ \(vs,d) -> counterexample (show $ pretty p) $
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p, PV.eval d vs p) of
       (Right (_, aval), Right cres)
        ->   aval === PV.value   cres
       (_, Left _)
@@ -58,7 +58,7 @@ prop_eval_commutes_history t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore elemPrefix accPrefix p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p, PV.eval d vs p) of
       (Right (abg, _), Right cres)
        ->  (sort abg)  === (sort $ PV.history cres)
       _

--- a/test/Icicle/Test/Avalanche/EvalCommutes.hs
+++ b/test/Icicle/Test/Avalanche/EvalCommutes.hs
@@ -56,7 +56,7 @@ prop_eval_commutes_history t =
  forAll (programForStreamType t)
  $ \p ->
  forAll (inputsForType t)
- $ \(vs,d) ->
+ $ \(vs,d) -> counterexample (show $ pretty p) $
     isRight     (checkProgram p) ==>
      case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p, PV.eval d vs p) of
       (Right (abg, _), Right cres)

--- a/test/Icicle/Test/Avalanche/SimpCommutes.hs
+++ b/test/Icicle/Test/Avalanche/SimpCommutes.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Icicle.Test.Avalanche.SimpCommutes where
+
+import           Icicle.Test.Core.Arbitrary
+import           Icicle.Core.Program.Check
+import qualified Icicle.Core.Eval.Exp       as XV
+
+import qualified Icicle.Avalanche.FromCore  as AC
+import qualified Icicle.Avalanche.Eval      as AE
+import qualified Icicle.Avalanche.Simp      as AS
+
+import           Icicle.Common.Base
+import qualified Icicle.Common.Fresh                as Fresh
+
+import           Icicle.Internal.Pretty
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+-- We need a way to differentiate stream variables from scalars
+namer = AC.namerText (flip Var 0)
+
+
+-- Simplifying the Avalanche doesn't affect the value
+prop_simp_commutes_value t =
+ forAll (programForStreamType t)
+ $ \p ->
+ forAll (inputsForType t)
+ $ \(vs,d) -> counterexample (show $ pretty p) $
+    isRight     (checkProgram p) ==>
+     let p' = AC.programFromCore namer p
+
+         simp = snd
+              $ Fresh.runFresh
+                        (AS.simpAvalanche p')
+                        (Fresh.counterNameState (Name . Var "anf") 0)
+         eval = AE.evalProgram XV.evalPrim d vs
+     in (eval p') === (eval simp)
+
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll
+-- tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 1000, maxSize = 10, maxDiscardRatio = 10000})
+

--- a/test/Icicle/Test/Avalanche/SimpCommutes.hs
+++ b/test/Icicle/Test/Avalanche/SimpCommutes.hs
@@ -32,7 +32,7 @@ prop_simp_commutes_value t =
  forAll (programForStreamType t)
  $ \p ->
  forAll (inputsForType t)
- $ \(vs,d) -> counterexample (show $ pretty p) $
+ $ \(vs,d) ->
     isRight     (checkProgram p) ==>
      let p' = AC.programFromCore namer p
 
@@ -41,7 +41,9 @@ prop_simp_commutes_value t =
                         (AS.simpAvalanche p')
                         (Fresh.counterNameState (Name . Var "anf") 0)
          eval = AE.evalProgram XV.evalPrim d vs
-     in (eval p') === (eval simp)
+     in counterexample (show $ pretty p')
+      $ counterexample (show $ pretty simp)
+       (eval p' === eval simp)
 
 
 return []

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -214,7 +214,7 @@ tryExpForType ty env
         
   letty r
    = do t  <- arbitrary
-        n  <- arbitrary
+        n  <- freshInEnv env
         x  <- tryExpForType t env
         let env' = Map.insert n t env
         XLet n x <$> tryExpForType (FunT [] r) env'

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -81,8 +81,8 @@ instance Arbitrary Prim where
     oneof_sized_vals
           [ PrimArith PrimArithMinus
           , PrimArith PrimArithPlus
-          , PrimRelation PrimRelationGt
-          , PrimRelation PrimRelationGe
+          , PrimRelation PrimRelationGt IntT
+          , PrimRelation PrimRelationGe IntT
           , PrimLogical  PrimLogicalNot
           , PrimLogical  PrimLogicalAnd
           ]

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -22,6 +22,7 @@ import           Icicle.Core.Reduce
 import           Icicle.Core.Program.Program    as P
 
 import           Icicle.Test.Arbitrary.Base
+import           Icicle.Test.Arbitrary ()
 import           Orphanarium.Corpus
 
 import           Test.QuickCheck
@@ -103,7 +104,8 @@ instance Arbitrary ValType where
    -- It's fine if they're big, but they have to fit in memory.
    oneof_sized_vals
          [ IntT
-         , BoolT ]
+         , BoolT
+         , DateTimeT ]
          [ ArrayT <$> arbitrary
          , PairT  <$> arbitrary <*> arbitrary
          , MapT  <$> arbitrary <*> arbitrary
@@ -348,6 +350,8 @@ baseValueForType t
      -> VInt <$> arbitrary
     BoolT
      -> VBool <$> arbitrary
+    DateTimeT
+     -> VDateTime <$> arbitrary
     ArrayT t'
      -> smaller (VArray <$> listOf (baseValueForType t'))
     PairT a b

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -297,8 +297,10 @@ programForStreamType streamType
 
   -- Raw source or windowed
   streamSource
-   = oneof [ return (streamType, Source)
-           , (,) streamType . SourceWindowedDays <$> arbitrary ]
+   = oneof [ return (sourceType, Source)
+           , (,) sourceType . SourceWindowedDays <$> arbitrary ]
+
+  sourceType = PairT streamType DateTimeT
 
   -- Transformer: filter or map
   streamTransformer :: Env Var ValType -> Env Var Type -> Gen (ValType, Stream Var)

--- a/test/Icicle/Test/Core/Exp/Check.hs
+++ b/test/Icicle/Test/Core/Exp/Check.hs
@@ -8,6 +8,7 @@ import           Icicle.Test.Core.Arbitrary
 import           Icicle.Common.Exp
 import           Icicle.Common.Type
 import           Icicle.Core.Exp
+import           Icicle.Core.Exp.Combinators
 
 import           P
 
@@ -26,7 +27,7 @@ prop_prefixlet x =
 
 -- Prefixing a let with a known good expression doesn't affect
 prop_prefixletconst x =
- checkExp0 coreFragment x == checkExp0 coreFragment (XLet (fresh 0) (XPrim $ PrimConst $ PrimConstInt 0) x)
+ checkExp0 coreFragment x == checkExp0 coreFragment (XLet (fresh 0) (constI 0) x)
 
 
 -- Wrapping in a lambda does affect typechecking, but not *whether* type exists

--- a/test/Icicle/Test/Core/Exp/Eval.hs
+++ b/test/Icicle/Test/Core/Exp/Eval.hs
@@ -7,6 +7,7 @@ module Icicle.Test.Core.Exp.Eval where
 import           Icicle.Test.Core.Arbitrary
 import qualified Icicle.Core.Exp    as X
 import           Icicle.Core.Exp
+import           Icicle.Core.Exp.Combinators
 import           Icicle.Core.Eval.Exp
 import           Icicle.Common.Exp
 import           Icicle.Common.Base
@@ -44,12 +45,12 @@ prop_prefixlet =
 -- Constant evaluates to constant. How quaint.
 -- =====================
 prop_const i =
- eval0 evalPrim ((XPrim $ PrimConst $ PrimConstInt i) :: X.Exp Var) == Right (VBase $ VInt i)
+ eval0 evalPrim (constI i :: X.Exp Var) == Right (VBase $ VInt i)
 
 -- And likewise, putting anything that typechecks before the constant still evalutes fine
 -- =====================
 prop_constprefix i =
- withTypedExp $ \x _ -> eval0 evalPrim (XLet (fresh 0) x (XPrim $ PrimConst $ PrimConstInt i)) == Right (VBase $ VInt i)
+ withTypedExp $ \x _ -> eval0 evalPrim (XLet (fresh 0) x (constI i)) == Right (VBase $ VInt i)
 
 
 return []

--- a/test/Icicle/Test/Core/Exp/Eval.hs
+++ b/test/Icicle/Test/Core/Exp/Eval.hs
@@ -9,6 +9,7 @@ import qualified Icicle.Core.Exp    as X
 import           Icicle.Core.Exp
 import           Icicle.Core.Eval.Exp
 import           Icicle.Common.Exp
+import           Icicle.Common.Base
 import           Icicle.Common.Value
 
 import           P

--- a/test/Icicle/Test/Core/Exp/Simp.hs
+++ b/test/Icicle/Test/Core/Exp/Simp.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Icicle.Test.Core.Exp.Simp where
+
+import           Icicle.Test.Core.Arbitrary
+import           Icicle.Core.Eval.Exp
+import           Icicle.Common.Exp
+import qualified Icicle.Common.Exp.Simp.Beta        as Beta
+import qualified Icicle.Common.Exp.Simp.ANormal     as ANormal
+import qualified Icicle.Common.Fresh                as Fresh
+import           Icicle.Common.Base
+
+import           P
+
+import           System.IO
+
+import           Test.QuickCheck
+
+
+-- Performing beta reduction
+prop_beta_evaluation
+ = withTypedExp
+ $ \x _
+ -> eval0 evalPrim x == eval0 evalPrim (Beta.beta Beta.isSimpleValue x)
+
+-- Converting to a-normal form
+prop_anormal_form_evaluation
+ = withTypedExp
+ $ \x _
+ -> eval0 evalPrim x == eval0 evalPrim
+   ( snd
+   $ Fresh.runFresh (ANormal.anormal x)
+                    (Fresh.counterNameState (Name . Var "anf") 0))
+
+
+return []
+tests :: IO Bool
+tests = $quickCheckAll

--- a/test/Icicle/Test/Core/Exp/Simp.hs
+++ b/test/Icicle/Test/Core/Exp/Simp.hs
@@ -12,6 +12,8 @@ import qualified Icicle.Common.Exp.Simp.ANormal     as ANormal
 import qualified Icicle.Common.Fresh                as Fresh
 import           Icicle.Common.Base
 
+import           Icicle.Internal.Pretty
+
 import           P
 
 import           System.IO
@@ -23,7 +25,10 @@ import           Test.QuickCheck
 prop_beta_evaluation
  = withTypedExp
  $ \x _
- -> eval0 evalPrim x == eval0 evalPrim (Beta.beta Beta.isSimpleValue x)
+ -> let x' = Beta.beta Beta.isSimpleValue x
+    in  counterexample (show $ pretty x)
+      $ counterexample (show $ pretty x')
+       (eval0 evalPrim x === eval0 evalPrim x')
 
 -- Converting to a-normal form
 prop_anormal_form_evaluation

--- a/test/Icicle/Test/Core/Program/Condense.hs
+++ b/test/Icicle/Test/Core/Program/Condense.hs
@@ -25,14 +25,18 @@ prop_condense_type t =
  $ \p ->
  isRight (checkProgram p) == isRight (checkProgram $ condenseProgram p)
 
--- Condensing doesn't affect evaluation
+-- Condensing doesn't affect evaluation value.
+-- It does affect the history, but not the value
 -- =====================
 prop_condense_eval t =
  forAll (programForStreamType t)
  $ \p1 ->
  forAll (inputsForType t)
  $ \(vs,d) ->
- PV.eval d vs p1 == PV.eval d vs (condenseProgram p1)
+ case (PV.eval d vs p1, PV.eval d vs (condenseProgram p1)) of
+  (Left e1, Left e2)   -> e1 === e2
+  (Right v1, Right v2) -> PV.value v1 === PV.value v2
+  (_,_)                -> property False
 
 
 

--- a/test/Icicle/Test/Core/Program/Fusion.hs
+++ b/test/Icicle/Test/Core/Program/Fusion.hs
@@ -9,7 +9,7 @@ import           Icicle.Test.Core.Arbitrary
 import           Icicle.Core.Program.Check
 import           Icicle.Core.Program.Fusion
 import qualified Icicle.Core.Eval.Program   as PV
-import qualified Icicle.Common.Value        as V
+import qualified Icicle.Common.Base         as V
 
 import           Icicle.Data.DateTime
 

--- a/test/Icicle/Test/Dictionary/Types.hs
+++ b/test/Icicle/Test/Dictionary/Types.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# OPTIONS_GHC -fno-warn-missing-signatures #-}
+module Icicle.Test.Dictionary.Types where
+
+import Icicle.Dictionary
+
+import Icicle.Core.Program.Check
+
+import qualified    Icicle.Internal.Pretty as PP
+
+import              P
+import              System.IO
+
+check_virtual prog
+ = case checkProgram prog of
+    Left err
+     -> do  putStrLn "With program:"
+            print (PP.pretty prog)
+            putStrLn "Got typechecking error:"
+            print (PP.pretty err)
+            return False
+    Right _
+     -> return True
+
+check_attributes (Dictionary attrs)
+ = and <$> mapM check attrs
+ where
+  check (_, ConcreteDefinition _)
+   = return True
+  check (_, VirtualDefinition virtual)
+   = check_virtual (program virtual)
+
+tests :: IO Bool
+tests
+ = do   putStrLn "=== test/Icicle/Test/Dictionary/Types: typechecking demogrpahics === "
+        res <- check_attributes demographics
+        case res of
+         True  -> putStrLn "+++ OK"
+         False -> putStrLn "--- FAIL"
+        return res

--- a/test/cli/demographics/run
+++ b/test/cli/demographics/run
@@ -1,0 +1,3 @@
+#!/bin/sh -eu
+dist/build/icicle/icicle data/example/demographics.psv
+

--- a/test/cli/show-dictionary/run
+++ b/test/cli/show-dictionary/run
@@ -1,0 +1,2 @@
+#!/bin/sh -eu
+dist/build/icicle/icicle --dictionary

--- a/test/test-cli.hs
+++ b/test/test-cli.hs
@@ -1,0 +1,7 @@
+import           Orphanarium.Core.Main
+
+
+main :: IO ()
+main
+ = orphanariumCliMain []
+

--- a/test/test.hs
+++ b/test/test.hs
@@ -12,6 +12,7 @@ import qualified Icicle.Test.Core.Program.Condense
 
 import qualified Icicle.Test.Avalanche.EvalCommutes
 import qualified Icicle.Test.Avalanche.CheckCommutes
+import qualified Icicle.Test.Avalanche.SimpCommutes
 
 import qualified Icicle.Test.Dictionary.Types
 
@@ -35,6 +36,7 @@ main
 
         , Icicle.Test.Avalanche.EvalCommutes.tests
         , Icicle.Test.Avalanche.CheckCommutes.tests
+        , Icicle.Test.Avalanche.SimpCommutes.tests
 
         , Icicle.Test.Dictionary.Types.tests
         ]

--- a/test/test.hs
+++ b/test/test.hs
@@ -10,21 +10,26 @@ import qualified Icicle.Test.Core.Program.Condense
 import qualified Icicle.Test.Avalanche.EvalCommutes
 import qualified Icicle.Test.Avalanche.CheckCommutes
 
+import qualified Icicle.Test.Dictionary.Types
+
 import           Orphanarium.Core.Main
 
 
 main :: IO ()
-main =
-  orphanariumMain 
-    [ Icicle.Test.Encoding.tests
-    , Icicle.Test.Serial.tests
-    , Icicle.Test.Core.Exp.Alpha.tests
-    , Icicle.Test.Core.Exp.Check.tests
-    , Icicle.Test.Core.Exp.Eval.tests
-    , Icicle.Test.Core.Program.Eval.tests
-    , Icicle.Test.Core.Program.Fusion.tests
-    , Icicle.Test.Core.Program.Condense.tests
+main
+ = orphanariumMain 
+        [ Icicle.Test.Encoding.tests
+        , Icicle.Test.Serial.tests
+        , Icicle.Test.Core.Exp.Alpha.tests
+        , Icicle.Test.Core.Exp.Check.tests
+        , Icicle.Test.Core.Exp.Eval.tests
+        , Icicle.Test.Core.Program.Eval.tests
+        , Icicle.Test.Core.Program.Fusion.tests
+        , Icicle.Test.Core.Program.Condense.tests
 
-    , Icicle.Test.Avalanche.EvalCommutes.tests
-    , Icicle.Test.Avalanche.CheckCommutes.tests
-    ]
+        , Icicle.Test.Avalanche.EvalCommutes.tests
+        , Icicle.Test.Avalanche.CheckCommutes.tests
+
+        , Icicle.Test.Dictionary.Types.tests
+        ]
+

--- a/test/test.hs
+++ b/test/test.hs
@@ -1,8 +1,11 @@
 import qualified Icicle.Test.Encoding
 import qualified Icicle.Test.Serial
+
 import qualified Icicle.Test.Core.Exp.Alpha
 import qualified Icicle.Test.Core.Exp.Check
 import qualified Icicle.Test.Core.Exp.Eval
+import qualified Icicle.Test.Core.Exp.Simp
+
 import qualified Icicle.Test.Core.Program.Eval
 import qualified Icicle.Test.Core.Program.Fusion
 import qualified Icicle.Test.Core.Program.Condense
@@ -20,9 +23,12 @@ main
  = orphanariumMain 
         [ Icicle.Test.Encoding.tests
         , Icicle.Test.Serial.tests
+
         , Icicle.Test.Core.Exp.Alpha.tests
         , Icicle.Test.Core.Exp.Check.tests
         , Icicle.Test.Core.Exp.Eval.tests
+        , Icicle.Test.Core.Exp.Simp.tests
+
         , Icicle.Test.Core.Program.Eval.tests
         , Icicle.Test.Core.Program.Fusion.tests
         , Icicle.Test.Core.Program.Condense.tests


### PR DESCRIPTION
We can now implement "days since latest".

Some DateTime primitives such as days difference between two DateTimes.
Each stream now has the fact value and the fact date available.

For Core, only postcomputations are able to access the current date. For Avalanche, any part can access the current date, because window checks need the current date.