### PR TITLE
Icicle Source REPL

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -152,6 +152,20 @@ executable             icicle
                      , transformers
                      , x-optparse
 
+executable             icicle-repl
+    ghc-options:       -Wall -threaded -O2
+    main-is:           main/icicle-repl.hs
+    build-depends:     base
+                     , either
+                     , icicle
+                     , filepath
+                     , haskeline
+                     , p
+                     , text
+                     , transformers
+                     , wl-pprint
+                     , x-optparse
+
 test-suite test
   type:                exitcode-stdio-1.0
 

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -113,6 +113,7 @@ library
                        Icicle.Dictionary
                        Icicle.Encoding
                        Icicle.Internal.Pretty
+                       Icicle.Internal.Rename
                        Icicle.Serial
                        Icicle.Simulator
 

--- a/main/icicle-repl.hs
+++ b/main/icicle-repl.hs
@@ -1,0 +1,114 @@
+{-# LANGUAGE ViewPatterns #-}
+
+import           Control.Monad
+import           Data.Text                   (Text)
+import qualified Data.Text                   as T
+import qualified System.Console.Haskeline    as HL
+import qualified Text.PrettyPrint.Leijen     as PP
+
+import           Icicle
+import qualified Icicle.Core.Program.Program as CP
+import qualified Icicle.Repl                 as SR
+import qualified Icicle.Source.Parser        as SP
+import           System.Environment
+
+main :: IO ()
+main = runRepl
+
+runRepl :: IO ()
+runRepl
+  = do putStrLn "icicle-repl"
+       HL.runInputT HL.defaultSettings $ loop defaultState
+  where
+    loop :: ReplState -> HL.InputT IO ()
+    loop state
+      = do line <- HL.getInputLine "> "
+           case line of
+             Nothing      -> loop state
+             Just ":quit" -> return ()
+             Just ":q"    -> return ()
+             Just str     -> handleLine state str >>= loop
+
+--------------------------------------------------------------------------------
+
+data ReplState
+   = ReplState
+   { dataFeat :: Maybe String
+   , hasType  :: Bool
+   , hasCore  :: Bool
+   , hasEval  :: Bool }
+
+-- | Settable REPL states
+data Set
+   = ShowType
+   | ShowCore
+   | ShowEval
+
+-- | REPL commands
+data Command
+   = CommandBlank
+   | CommandSet  Set
+   | CommandLoad FilePath
+
+defaultState :: ReplState
+defaultState
+  = ReplState Nothing False False False
+
+readCommand :: String -> Maybe Command
+readCommand (words -> ss)
+  | null ss                    = Just CommandBlank
+  | ":set":"show-type":_ <- ss = Just $ CommandSet ShowType
+  | ":set":"show-core":_ <- ss = Just $ CommandSet ShowCore
+  | ":set":"show-eval":_ <- ss = Just $ CommandSet ShowEval
+  | ":load":f:_          <- ss = Just $ CommandLoad f
+  | otherwise                  = Nothing
+
+handleLine :: ReplState -> String -> HL.InputT IO ReplState
+handleLine state line = case readCommand line of
+  Just CommandBlank          -> do
+    HL.outputStrLn "please input a command or an Icicle expression"
+    return state
+
+  -- Whether to show type of result
+  Just (CommandSet ShowType) -> do
+    let v = not (hasType state)
+    HL.outputStrLn $ concat ["ok, show-type is now ", showFlag v]
+    return $ state { hasType = v }
+
+  -- Whether to show core
+  Just (CommandSet ShowCore) -> do
+    let v = not (hasCore state)
+    HL.outputStrLn $ concat ["ok, show-core is now ", showFlag v]
+    return $ state { hasCore = v }
+
+  -- Whether to show eval result
+  Just (CommandSet ShowEval) -> do
+    let v = not (hasEval state)
+    HL.outputStrLn $ concat ["ok, show-eval is now ", showFlag v]
+    return $ state { hasEval = v }
+
+  Just (CommandLoad fp)      -> do
+    HL.outputStrLn "dunno"
+    return state
+
+  -- An Icicle expression
+  Nothing -> do
+    when (hasCore state) $ case showCore (T.pack line) of
+        Left  e -> HL.outputStrLn "REPL error:" >> prettyHL e
+        Right p -> HL.outputStrLn "Result:" >> prettyHL p
+    return state
+
+prettyHL :: PP.Pretty a => a -> HL.InputT IO ()
+prettyHL x = HL.outputStrLn $ PP.displayS (PP.renderCompact $ PP.pretty x) ""
+
+showFlag :: Bool -> String
+showFlag True  = "on"
+showFlag False = "off"
+
+--------------------------------------------------------------------------------
+
+type ProgramV = CP.Program SP.Variable
+
+showCore :: Text -> Either SR.ReplError ProgramV
+showCore = SR.sourceParseConvert
+

--- a/main/icicle-repl.hs
+++ b/main/icicle-repl.hs
@@ -1,4 +1,5 @@
-{-# LANGUAGE ViewPatterns #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE ViewPatterns  #-}
 
 import           Control.Monad
 import           Data.Text                   (Text)
@@ -6,18 +7,16 @@ import qualified Data.Text                   as T
 import qualified System.Console.Haskeline    as HL
 import qualified Text.PrettyPrint.Leijen     as PP
 
-import           Icicle
 import qualified Icicle.Core.Program.Program as CP
 import qualified Icicle.Repl                 as SR
 import qualified Icicle.Source.Parser        as SP
-import           System.Environment
 
 main :: IO ()
 main = runRepl
 
 runRepl :: IO ()
 runRepl
-  = do putStrLn "icicle-repl"
+  = do putStrLn "welcome to iREPL"
        HL.runInputT HL.defaultSettings $ loop defaultState
   where
     loop :: ReplState -> HL.InputT IO ()
@@ -95,7 +94,7 @@ handleLine state line = case readCommand line of
   Nothing -> do
     when (hasCore state) $ case showCore (T.pack line) of
         Left  e -> HL.outputStrLn "REPL error:" >> prettyHL e
-        Right p -> HL.outputStrLn "Result:" >> prettyHL p
+        Right p -> HL.outputStrLn "Result:"     >> prettyHL p
     return state
 
 prettyHL :: PP.Pretty a => a -> HL.InputT IO ()

--- a/main/icicle.hs
+++ b/main/icicle.hs
@@ -47,8 +47,7 @@ main = getArgs >>= \args -> case args of
   _ ->
     usage >> exitFailure
 
-
-run :: Dictionary -> FilePath -> EitherT ParseError IO ()
+run :: Dictionary -> FilePath -> EitherT Icicle.ParseError IO ()
 run dict p =
   do    ls  <- lift
              $ T.lines <$> T.readFile p

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -1,5 +1,7 @@
 -- | Base definitions common across all languages.
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DeriveFunctor #-}
+
 module Icicle.Common.Base (
       Name   (..)
     , BaseValue (..)
@@ -20,7 +22,7 @@ data Name n =
  -- | Prefix a name.
  -- Very useful for generating fresh(ish) readable names.
  | NameMod  n (Name n)
- deriving (Eq,Ord,Show)
+ deriving (Eq,Ord,Show,Functor)
 
 
 -- | Base values - real values that can be serialised and whatnot

--- a/src/Icicle/Data.hs
+++ b/src/Icicle/Data.hs
@@ -17,6 +17,7 @@ module Icicle.Data (
   ) where
 
 import           Data.Text
+import qualified Text.PrettyPrint.Leijen as PP
 
 import           Icicle.Data.DateTime
 
@@ -28,6 +29,8 @@ newtype Entity =
       getEntity     :: Text
     } deriving (Eq, Ord, Show)
 
+instance PP.Pretty Entity where
+  pretty (Entity t) = PP.text (unpack t)
 
 newtype Attribute =
   Attribute {
@@ -71,6 +74,14 @@ data Value =
   | Tombstone
   deriving (Eq, Show)
 
+instance PP.Pretty Value where
+  pretty v = case v of
+    StringValue t  -> PP.text (unpack t)
+    IntValue    i  -> PP.int i
+    DoubleValue d  -> PP.double d
+    BooleanValue b -> PP.pretty b
+    -- I'm too lazy
+    _              -> PP.text (show v)
 
 data Struct =
   Struct    [(Attribute, Value)]

--- a/src/Icicle/Internal/Rename.hs
+++ b/src/Icicle/Internal/Rename.hs
@@ -1,0 +1,87 @@
+-- | Renaming all the different ASTs in Icicle.
+--
+module Icicle.Internal.Rename where
+
+import           Icicle.Common.Base
+import           Icicle.Common.Exp
+import qualified Icicle.Core.Exp             as CE
+import qualified Icicle.Core.Program.Program as CP
+import qualified Icicle.Core.Reduce          as CR
+import qualified Icicle.Core.Stream          as CS
+import qualified Icicle.Source.Query         as SQ
+import qualified Icicle.Source.Query.Exp     as SE
+
+renameQT :: (n -> m) -> SQ.QueryTop a n -> SQ.QueryTop a m
+renameQT f (SQ.QueryTop x q)
+  = SQ.QueryTop (f x) (renameQ f q)
+
+renameQ :: (n -> m) -> SQ.Query a n -> SQ.Query a m
+renameQ f (SQ.Query cs x)
+  = SQ.Query (map (renameC f) cs) (renameX f x)
+
+renameC :: (n -> m) -> SQ.Context a n -> SQ.Context a m
+renameC f cc = case cc of
+  SQ.Windowed a b c -> SQ.Windowed a b c
+  SQ.Latest   a b   -> SQ.Latest   a b
+  SQ.GroupBy  a e   -> SQ.GroupBy  a (renameX f e)
+  SQ.Distinct a e   -> SQ.Distinct a (renameX f e)
+  SQ.Filter   a e   -> SQ.Filter   a (renameX f e)
+  SQ.LetFold  a x   -> SQ.LetFold  a (renameF f x)
+  SQ.Let      a n e -> SQ.Let      a (f n) (renameX f e)
+
+renameF :: (n -> m) -> SQ.Fold (SQ.Query a n) a n -> SQ.Fold (SQ.Query a m) a m
+renameF f d
+  = SQ.Fold
+    (f         $ SQ.foldBind d)
+    (renameX f $ SQ.foldInit d)
+    (renameX f $ SQ.foldWork d)
+    (SQ.foldType d)
+
+renameX :: (n -> m) -> SQ.Exp a n -> SQ.Exp a m
+renameX f e = case e of
+  SE.Var a n     -> SE.Var a (f n)
+  SE.Nested a q  -> SE.Nested a (renameQ f q)
+  SE.App a e1 e2 -> SE.App a (renameX f e1) (renameX f e2)
+  SE.Prim a p    -> SE.Prim a p
+
+renameN :: (n -> m) -> Name n -> Name m
+renameN f (Name v)        = Name    (f v)
+renameN f (NameMod n1 n2) = NameMod (f n1) (renameN f n2)
+
+renameP :: (n -> m) -> CP.Program n -> CP.Program m
+renameP f prog
+  = CP.Program
+    { CP.input     = CP.input prog
+    , CP.precomps  = map (renameNX f) (CP.precomps prog)
+    , CP.streams   = map (renameNS f) (CP.streams prog)
+    , CP.reduces   = map (renameNR f) (CP.reduces prog)
+    , CP.postdate  = fmap (renameN f) (CP.postdate prog)
+    , CP.postcomps = map (renameNX f) (CP.postcomps prog)
+    , CP.returns   = renameCX f (CP.returns prog) }
+
+renameNS :: (n -> m) -> (Name n, CS.Stream n) -> (Name m, CS.Stream m)
+renameNS f (n, s) = (renameN f n, renameS f s)
+
+renameS :: (n -> m) -> CS.Stream n -> CS.Stream m
+renameS _ CS.Source                 = CS.Source
+renameS _ (CS.SourceWindowedDays i) = CS.SourceWindowedDays i
+renameS f (CS.STrans i e n)         = CS.STrans i (renameCX f e) (renameN f n)
+
+renameNR :: (n -> m) -> (Name n, CR.Reduce n) -> (Name m, CR.Reduce m)
+renameNR f (n, r) = (renameN f n, renameR f r)
+
+renameR :: (n -> m) -> CR.Reduce n -> CR.Reduce m
+renameR f = CR.renameReduce (fmap f)
+
+renameNX :: (n -> m) -> (Name n, CE.Exp n) -> (Name m, CE.Exp m)
+renameNX f (n, e) = (renameN f n, renameCX f e)
+
+renameCX :: (n -> m) -> CE.Exp n -> CE.Exp m
+renameCX f e = case e of
+  XVar n       -> XVar (renameN f n)
+  XApp e1 e2   -> XApp (renameCX f e1) (renameCX f e2)
+  XLam n t  e1 -> XLam (renameN f n) t (renameCX f e1)
+  XLet n e1 e2 -> XLet (renameN f n) (renameCX f e1) (renameCX f e2)
+  XPrim p      -> XPrim p
+  XValue x y   -> XValue x y
+

--- a/src/Icicle/Repl.hs
+++ b/src/Icicle/Repl.hs
@@ -9,84 +9,91 @@ module Icicle.Repl (
   , readFacts
   ) where
 
-import qualified        Icicle.Common.Fresh             as Fresh
-import qualified        Icicle.Common.Base              as Com
-import qualified        Icicle.Common.Type              as Com
-import qualified        Icicle.Core.Program.Program     as Core
+import           Icicle.BubbleGum
+import           Icicle.Common.Base
+import qualified Icicle.Common.Fresh           as Fresh
+import           Icicle.Common.Type
+import qualified Icicle.Core.Program.Program   as Core
+import           Icicle.Data
+import qualified Icicle.Dictionary             as D
+import           Icicle.Internal.Pretty
+import qualified Icicle.Serial                 as S
+import qualified Icicle.Source.Checker.Checker as SC
+import qualified Icicle.Source.Checker.Error   as SC
+import qualified Icicle.Source.Parser          as SP
+import qualified Icicle.Source.Query           as SQ
+import qualified Icicle.Source.ToCore.Base     as STC
+import qualified Icicle.Source.ToCore.ToCore   as STC
+import qualified Icicle.Source.Type            as ST
+import qualified Icicle.Simulator as S
+import qualified Icicle.Core.Eval.Program as EP
 
-import qualified        Icicle.Data                     as D
-import qualified        Icicle.Dictionary               as D
-import qualified        Icicle.Serial                   as S
+import           P
 
-import qualified        Icicle.Source.Checker.Checker   as SC
-import qualified        Icicle.Source.Checker.Error     as SC
-import qualified        Icicle.Source.Parser            as SP
-import qualified        Icicle.Source.Query             as SQ
-import qualified        Icicle.Source.ToCore.ToCore     as STC
-import qualified        Icicle.Source.ToCore.Base       as STC
-import qualified        Icicle.Source.Type              as ST
-
-import                  Icicle.Internal.Pretty
-
-import                  P
-
-import                  Data.Either.Combinators
-import qualified        Data.Map                        as Map
-import                  Data.Text                       (Text)
-import qualified        Data.Text                       as T
-import qualified        Data.Traversable                as TR
+import           Data.Either.Combinators
+import qualified Data.Map                      as Map
+import           Data.Text                     (Text)
+import qualified Data.Text                     as T
+import qualified Data.Traversable              as TR
 
 
 data ReplError
- = ReplErrorParseError SP.ParseError
- | ReplErrorCheckError   (SC.CheckError SP.SourcePos Var)
- | ReplErrorConvertError (STC.ConvertError SP.SourcePos Var)
- | ReplErrorDecodeError S.ParseError
+ = ReplErrorParse   SP.ParseError
+ | ReplErrorCheck   (SC.CheckError SP.SourcePos Var)
+ | ReplErrorConvert (STC.ConvertError SP.SourcePos Var)
+ | ReplErrorDecode  S.ParseError
+ | ReplErrorRuntime S.SimulateError
  deriving (Show)
 
 instance Pretty ReplError where
- pretty e 
+ pretty e
   = case e of
-     ReplErrorParseError p
+     ReplErrorParse p
       -> "Parse error:" <> line
       <> indent 2 (text $ show p)
-     ReplErrorCheckError ce
+     ReplErrorCheck ce
       -> "Check error:" <> line
       <> indent 2 (pretty ce)
-     ReplErrorConvertError ce
+     ReplErrorConvert ce
       -> "Convert error:" <> line
       <> indent 2 (pretty ce)
-     ReplErrorDecodeError d
+     ReplErrorDecode d
       -> "Decode error:" <> line
+      <> indent 2 (text $ show d)
+     ReplErrorRuntime d
+      -> "Runtime error:" <> line
       <> indent 2 (text $ show d)
 
 
 type Var        = SP.Variable
 type QueryTop'  = SQ.QueryTop SP.SourcePos Var
 type QueryTop'T = SQ.QueryTop (SP.SourcePos, ST.UniverseType) Var
-
 type Program'   = Core.Program Var
+
+--------------------------------------------------------------------------------
+
+-- * Check and Convert
 
 sourceParse :: T.Text -> Either ReplError QueryTop'
 sourceParse t
- = mapLeft ReplErrorParseError
+ = mapLeft ReplErrorParse
  $ SP.parseQueryTop t
 
 
 sourceCheck :: D.Dictionary -> QueryTop' -> Either ReplError (QueryTop'T, ST.UniverseType)
 sourceCheck d q
  = let d' = featureMapOfDictionary d
-   in  mapLeft ReplErrorCheckError
+   in  mapLeft ReplErrorCheck
      $ SC.checkQT d' q
 
 
 sourceConvert :: QueryTop'T -> Either ReplError Program'
 sourceConvert q
  = mapRight snd
- $ mapLeft ReplErrorConvertError
+ $ mapLeft ReplErrorConvert
  $ Fresh.runFreshT (STC.convertQueryTop q) namer
  where
-  mkName i = Com.Name $ SP.Variable ("v" <> T.pack (show i))
+  mkName i = Name $ SP.Variable ("v" <> T.pack (show i))
   namer = Fresh.counterNameState mkName 0
 
 
@@ -103,14 +110,13 @@ featureMapOfDictionary (D.Dictionary ds)
  $ concatMap go
    ds
  where
-  go (D.Attribute attr, D.ConcreteDefinition _enc)
+  go (Attribute attr, D.ConcreteDefinition _enc)
    -- TODO: convert Encoding to feature map
-   = [(SP.Variable attr, Map.singleton (SP.Variable "value") Com.IntT)]
+   = [(SP.Variable attr, Map.singleton (SP.Variable "value") IntT)]
   go _
    = []
 
-
-readFacts :: D.Dictionary -> Text -> Either ReplError [D.AsAt D.Fact]
+readFacts :: D.Dictionary -> Text -> Either ReplError [AsAt Fact]
 readFacts dict raw
-  = mapLeft ReplErrorDecodeError
+  = mapLeft ReplErrorDecode
   $ TR.traverse (S.decodeEavt dict) $ T.lines raw

--- a/src/Icicle/Repl.hs
+++ b/src/Icicle/Repl.hs
@@ -29,7 +29,6 @@ import                  Icicle.Internal.Pretty
 import                  P
 
 import                  Data.Either.Combinators
-
 import qualified        Data.Map                        as Map
 import qualified        Data.Text                       as T
 
@@ -101,4 +100,3 @@ featureMapOfDictionary (D.Dictionary ds)
    = [(SP.Variable attr, Map.singleton (SP.Variable "value") Com.IntT)]
   go _
    = []
-

--- a/src/Icicle/Simulator.hs
+++ b/src/Icicle/Simulator.hs
@@ -3,8 +3,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Icicle.Simulator (
     streams
-  , Partition
+  , Partition(..)
+  , SimulateError
   , evaluateVirtuals
+  , evaluateVirtualValue
+  , valueToCore
+  , valueFromCore
   ) where
 
 import           Data.List


### PR DESCRIPTION
REPL for Icicle surface language.

Commands:

  * `:load <filepath>`
  * `:set show-type` -- show the expression type
  * `:set show-core` -- show core output
  * `:set show-eval` -- show evaluated result

Given an Icicle expression, e.g. `feature salary ~> sum value`, show the result type and core output -- plus the result value if a data set is given as well.
