### PR TITLE
WIP - small step evaluator

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -74,6 +74,7 @@ library
                        Icicle.Common.Exp.Error
                        Icicle.Common.Exp.Exp
                        Icicle.Common.Exp.Eval
+                       Icicle.Common.Exp.Eval.Small
                        Icicle.Common.Exp.Prim.Minimal
                        Icicle.Common.Exp.Prim.Eval
                        Icicle.Common.Exp.Simp

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -42,7 +42,6 @@ data BaseValue
  deriving (Show, Ord, Eq)
 
 
-
 -- Pretty printing ---------------
 
 instance Pretty n => Pretty (Name n) where

--- a/src/Icicle/Common/Exp/Eval/Small.hs
+++ b/src/Icicle/Common/Exp/Eval/Small.hs
@@ -1,0 +1,90 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+module Icicle.Common.Exp.Eval.Small
+
+where
+
+import qualified Data.Map as M
+
+import Icicle.Internal.Pretty
+import Icicle.Common.Base
+import Icicle.Common.Type
+import Icicle.Common.Value
+import Icicle.Common.Exp.Exp
+import Icicle.Common.Exp.Eval (EvalPrim)
+import qualified Icicle.Common.Exp.Eval as Big
+
+import P
+
+import Data.Either.Combinators (mapLeft)
+
+
+data RuntimeError n p
+  = RuntimeErrorPrimBadArgs p [Value n p]
+  | RuntimeErrorUnboundVar  (Name n)
+  | RuntimeErrorPrimBad p
+  | RuntimeErrorPrimEval (Big.RuntimeError n p)
+  deriving (Show, Eq)
+
+--------------------------------------------------------------------------------
+
+-- | Small step evaluation. Call-by-value for simplicity.
+--
+eval :: Eq n
+     => EvalPrim n p -> Exp n p
+     -> Either (RuntimeError n p) (Exp n p)
+eval evalPrim xx = case xx of
+  -- * Variables must have been substituted away.
+  XVar n
+    -> Left (RuntimeErrorUnboundVar n)
+
+  -- * Values are fully evaluated.
+  XValue{}
+    -> return xx
+
+  -- * App where left is lambda and right is value: substitute.
+  XApp (XLam n t1 e) (XValue t2 v)
+    | t1 == t2
+    -> subst n v t1 e
+
+  -- * App where left is lambda: evals right.
+  XApp e1@XLam{} e2
+    -> fmap (XApp e1) (go e2)
+
+  -- * App where left is other exps: evals left.
+  XApp e1 e2
+    -> fmap (flip XApp e2) (go e1)
+
+  -- * Primitives with no arguments.
+  XPrim p
+    -> do x <- mapLeft RuntimeErrorPrimEval $ evalPrim p []
+          v <- getBaseValue (RuntimeErrorPrimBad p) x
+          t <- typeOfValue  (RuntimeErrorPrimBad p) x
+          return (XValue t v)
+
+  -- * Lambdas cannot go any further.
+  XLam{}
+    -> return xx
+
+  -- * Let where definition is a value: substitute.
+  XLet n (XValue t v) e2
+    -> subst n v t e2
+
+  -- * Let where definition is something else.
+  XLet n e1 e2
+    -> do e <- go e1
+          return (XLet n e e2)
+
+  where go = eval evalPrim
+
+subst :: Eq n
+      => Name n -> BaseValue -> ValType -> Exp n p
+      -> Either (RuntimeError n p) (Exp n p)
+subst x val t body = case body of
+  XVar n
+    | x == n
+    -> return (XValue t val)
+
+  _ -> return body
+
+

--- a/test/Icicle/Test/Core/Exp/Eval.hs
+++ b/test/Icicle/Test/Core/Exp/Eval.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell   #-}
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 module Icicle.Test.Core.Exp.Eval where
 
-import           Icicle.Test.Core.Arbitrary
-import qualified Icicle.Core.Exp    as X
-import           Icicle.Core.Exp
-import           Icicle.Core.Exp.Combinators
-import           Icicle.Core.Eval.Exp
-import           Icicle.Common.Exp
 import           Icicle.Common.Base
+import           Icicle.Common.Exp            as C
+import qualified Icicle.Common.Exp.Eval.Small as ES
 import           Icicle.Common.Value
+import           Icicle.Core.Eval.Exp
+import           Icicle.Core.Exp
+import qualified Icicle.Core.Exp              as X
+import           Icicle.Core.Exp.Combinators
+import           Icicle.Test.Core.Arbitrary
 
 import           P
 
@@ -35,7 +36,7 @@ prop_progress_inverse x =
 -- Prefixing a let with a fresh name doesn't change the semantics,
 -- except for functions where the heap is affected.
 -- It wouldn't actually change the *execution* of the function, but the
--- heap still looks different. 
+-- heap still looks different.
 -- =====================
 
 prop_prefixlet =
@@ -44,14 +45,28 @@ prop_prefixlet =
 
 -- Constant evaluates to constant. How quaint.
 -- =====================
+
 prop_const i =
  eval0 evalPrim (constI i :: X.Exp Var) == Right (VBase $ VInt i)
 
 -- And likewise, putting anything that typechecks before the constant still evalutes fine
 -- =====================
+
 prop_constprefix i =
  withTypedExp $ \x _ -> eval0 evalPrim (XLet (fresh 0) x (constI i)) == Right (VBase $ VInt i)
 
+-- Applying small-step dynamics should eventually get to the same result as
+-- applying big-step.
+-- =====================
+
+prop_small_transition =
+ withTypedExp $ \x _ -> iterateEval x == hush (eval0 evalPrim x)
+ where iterateEval x
+         | Right z  <- ES.eval evalPrim x, z /= x = iterateEval z
+         | XValue{} <- x = hush $ eval0 evalPrim x
+         | otherwise = Nothing
+       hush (Left _)  = Nothing
+       hush (Right x) = Just x
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
small step dynamics for Core

  * still fully evaluates primitives, but we need to pass the return type along
  * otherwise, standard call-by-value