### PR TITLE
Newest shouldn't have all facts stuck to it

### DIFF
--- a/data/libs/prelude.icicle
+++ b/data/libs/prelude.icicle
@@ -8,5 +8,5 @@ max v = let fold1 s = v : case v > s | True -> v | False -> s end ~> s.
 min v = let fold1 s = v : case v < s | True -> v | False -> s end ~> s.
 
 # Time statements
-newest v = let fold1 s = v : v ~> s.
+newest v = latest 1 ~> let fold1 s = v : v ~> s.
 oldest v = let fold1 s = v : s ~> s.


### PR DESCRIPTION
Maybe this feature should be renamed to current_state or something as well?