### PR TITLE
Add tombstone parsing, and force facts to be in a namespace (even tho…

### DIFF
--- a/data/example/demographics.psv
+++ b/data/example/demographics.psv
@@ -12,7 +12,7 @@ bart|age|10|1989-12-17
 bart|gender|m|1989-12-17
 lisa|age|8|1989-12-17
 lisa|gender|f|1989-12-17
-lisa|gender|m|1989-12-18
+lisa|gender|NA|1989-12-18
 lisa|gender|m|1989-12-19
 maggie|age|2|1989-12-17
 maggie|gender|f|1989-12-17

--- a/src/Icicle/BubbleGum.hs
+++ b/src/Icicle/BubbleGum.hs
@@ -43,7 +43,7 @@ data BubbleGumFact
 --
 -- TODO: add Attribute and reduction name here
 data BubbleGumOutput n v
- -- | Result of a *full* reduction, as opposed to a windowed reduction. 
+ -- | Result of a *full* reduction, as opposed to a windowed reduction.
  -- There might be multiple reductions in a single feature,
  -- so we want the name of the reduction variable too.
  = BubbleGumReduction   (Name n) v

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -45,6 +45,7 @@ data BaseValue
  | VNone
  | VMap    (Map.Map BaseValue    BaseValue)
  | VStruct (Map.Map StructField  BaseValue)
+ | VTombstone
 
  | VException ExceptionInfo
  deriving (Show, Ord, Eq)
@@ -101,6 +102,8 @@ instance Pretty BaseValue where
       -> text "Map" <+> pretty (Map.toList mv)
      VStruct mv
       -> text "Struct" <+> pretty (Map.toList mv)
+     VTombstone
+      -> text "Tombstone"
      VException e
       -> text "Exception:" <+> pretty e
 

--- a/src/Icicle/Data.hs
+++ b/src/Icicle/Data.hs
@@ -4,6 +4,7 @@ module Icicle.Data (
     Entity (..)
   , Namespace (..)
   , Attribute (..)
+  , FeatureId (..)
   , Fact (..)
   , Fact' (..)
   , AsAt (..)
@@ -42,6 +43,13 @@ newtype Attribute =
   Attribute {
       getAttribute  :: Text
     } deriving (Eq, Ord, Show)
+
+data FeatureId =
+  FeatureId {
+    fidNamespace :: Namespace
+  , fidAttribute :: Attribute
+  }
+
 
 instance Pretty Attribute where
   pretty (Attribute t) = text (unpack t)

--- a/src/Icicle/Dictionary/Demographics.hs
+++ b/src/Icicle/Dictionary/Demographics.hs
@@ -6,23 +6,22 @@ module Icicle.Dictionary.Demographics (
 
 import           Icicle.Data
 
-import           P
-
 import           Icicle.Dictionary.Data
 
 import qualified Data.Map                           as Map
+import qualified Data.Set                           as Set
 
 -- | Example demographics dictionary
 -- Hard-coded for now
 demographics :: Dictionary
 demographics =
  Dictionary
- [ DictionaryEntry (Attribute "gender")             (ConcreteDefinition StringEncoding)
- , DictionaryEntry (Attribute "age")                (ConcreteDefinition IntEncoding)
- , DictionaryEntry (Attribute "state_of_residence") (ConcreteDefinition StringEncoding)
- , DictionaryEntry (Attribute "salary")             (ConcreteDefinition IntEncoding)
- , DictionaryEntry (Attribute "injury")             (ConcreteDefinition $ StructEncoding
+ [ DictionaryEntry (Attribute "gender")             (ConcreteDefinition StringEncoding Set.empty)
+ , DictionaryEntry (Attribute "age")                (ConcreteDefinition IntEncoding Set.empty)
+ , DictionaryEntry (Attribute "state_of_residence") (ConcreteDefinition StringEncoding Set.empty)
+ , DictionaryEntry (Attribute "salary")             (ConcreteDefinition IntEncoding Set.empty)
+ , DictionaryEntry (Attribute "injury")             (ConcreteDefinition (StructEncoding
                         [StructField Mandatory (Attribute "location") StringEncoding
-                        ,StructField Mandatory (Attribute "severity") IntEncoding])
+                        ,StructField Mandatory (Attribute "severity") IntEncoding]) Set.empty)
  ]
  Map.empty

--- a/src/Icicle/Encoding.hs
+++ b/src/Icicle/Encoding.hs
@@ -27,6 +27,7 @@ import qualified Data.Scientific        as S
 import qualified Data.ByteString.Lazy   as BS
 import qualified Data.HashMap.Strict    as HM
 import qualified Data.Map               as Map
+import qualified Data.Set               as Set
 import qualified Data.Vector            as V
 
 import           Icicle.Data
@@ -160,8 +161,11 @@ renderValue tombstone val
 
 -- | Attempt to decode value with given encoding.
 -- Some values may fit multiple encodings.
-parseValue :: Encoding -> Text -> Either DecodeError Value
-parseValue e t
+parseValue :: Encoding -> Set.Set Text -> Text -> Either DecodeError Value
+parseValue e tombstone t
+ | Set.member t tombstone
+ = return Tombstone
+ | otherwise
  = case e of
     StringEncoding
      -> return (StringValue t)

--- a/src/Icicle/Simulator.hs
+++ b/src/Icicle/Simulator.hs
@@ -131,7 +131,7 @@ valueToCore v
                    -> V.VStruct . Map.fromList
                   <$> mapM (\(a,b) -> (,) <$> pure (V.StructField $ getAttribute a) <*> valueToCore b) vs
     DateValue d    -> return $ V.VDateTime d
-    Tombstone      -> Left   $ SimulateErrorCannotConvertToCore v
+    Tombstone      -> return $ V.VTombstone
 
 valueFromCore :: V.BaseValue -> Either (SimulateError a) Value
 valueFromCore v
@@ -151,5 +151,6 @@ valueFromCore v
                   <$> mapM (\(a,b) -> (,) <$> valueFromCore a <*> valueFromCore b) (Map.toList vs)
     V.VStruct vs  -> StructValue . Struct <$> mapM (\(a,b) -> (,) <$> pure (Attribute $ V.nameOfStructField a) <*> valueFromCore b) (Map.toList vs)
 
+    V.VTombstone  -> return Tombstone
     V.VException _-> return Tombstone
 

--- a/src/Icicle/Storage/Dictionary/TextV1.hs
+++ b/src/Icicle/Storage/Dictionary/TextV1.hs
@@ -14,8 +14,8 @@ import           P hiding (concat, intercalate)
 import           Data.Attoparsec.Text
 
 import           Data.Either.Combinators
-import           Data.Text hiding (takeWhile, singleton)
-import           Data.Set (singleton)
+import           Data.Text hiding (takeWhile)
+import qualified Data.Set as Set
 
 import           Icicle.Storage.Encoding
 
@@ -33,7 +33,7 @@ field = append <$> takeWhile (not . isDelimOrEscape) <*> (concat <$> many (cons 
 
 parseIcicleDictionaryV1 :: Parser DictionaryEntry
 parseIcicleDictionaryV1 = do
-  DictionaryEntry <$> (Attribute <$> field) <* p <*> (ConcreteDefinition <$> parseEncoding <*> pure (singleton "NA"))
+  DictionaryEntry <$> (Attribute <$> field) <* p <*> (ConcreteDefinition <$> parseEncoding <*> pure (Set.singleton "NA"))
     where
       p = char '|'
 

--- a/src/Icicle/Storage/Dictionary/TextV1.hs
+++ b/src/Icicle/Storage/Dictionary/TextV1.hs
@@ -14,7 +14,8 @@ import           P hiding (concat, intercalate)
 import           Data.Attoparsec.Text
 
 import           Data.Either.Combinators
-import           Data.Text hiding (takeWhile)
+import           Data.Text hiding (takeWhile, singleton)
+import           Data.Set (singleton)
 
 import           Icicle.Storage.Encoding
 
@@ -32,7 +33,7 @@ field = append <$> takeWhile (not . isDelimOrEscape) <*> (concat <$> many (cons 
 
 parseIcicleDictionaryV1 :: Parser DictionaryEntry
 parseIcicleDictionaryV1 = do
-  DictionaryEntry <$> (Attribute <$> field) <* p <*> (ConcreteDefinition <$> parseEncoding)
+  DictionaryEntry <$> (Attribute <$> field) <* p <*> (ConcreteDefinition <$> parseEncoding <*> pure (singleton "NA"))
     where
       p = char '|'
 
@@ -41,7 +42,7 @@ parseDictionaryLineV1 s =
   mapLeft (ParseError . pack) $ parseOnly parseIcicleDictionaryV1 s
 
 writeDictionaryLineV1 :: DictionaryEntry -> Text
-writeDictionaryLineV1 (DictionaryEntry (Attribute a) (ConcreteDefinition e)) =
+writeDictionaryLineV1 (DictionaryEntry (Attribute a) (ConcreteDefinition e _)) =
   a <> "|" <> prettyConcrete e
 
 writeDictionaryLineV1 (DictionaryEntry _ (VirtualDefinition _)) = "Virtual features not supported in V1"

--- a/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/src/Icicle/Storage/Dictionary/Toml.hs
@@ -39,6 +39,7 @@ import qualified Data.Text                          as T
 import qualified Data.Text.IO                       as T
 
 import qualified Data.Map                           as M
+import qualified Data.Set                           as S
 
 import qualified Text.Parsec                        as Parsec
 
@@ -124,7 +125,7 @@ loadDictionary' parentFuncs parentConf parentConcrete fp
     where
       rp = (takeDirectory fp)
 
-      remakeConcrete (DictionaryEntry' a (ConcreteDefinition' e)) cds = (DictionaryEntry a (ConcreteDefinition e)) : cds
+      remakeConcrete (DictionaryEntry' a (ConcreteDefinition' _ e t)) cds = (DictionaryEntry a (ConcreteDefinition e $ S.fromList $ toList t)) : cds
       remakeConcrete _ cds = cds
 
       remakeVirtuals (DictionaryEntry' a (VirtualDefinition' (Virtual' v))) vds = (a, v) : vds

--- a/test/Icicle/Test/Encoding.hs
+++ b/test/Icicle/Test/Encoding.hs
@@ -7,12 +7,12 @@ module Icicle.Test.Encoding where
 import           Icicle.Test.Arbitrary
 import           Icicle.Encoding
 
-import           P hiding (empty)
+import           P
 
 import           System.IO
 
 import           Test.QuickCheck
-import           Data.Set (empty)
+import qualified Data.Set as Set
 
 
 -- Sanity checking the randomly generated values
@@ -34,7 +34,7 @@ prop_json_roundtrip e =
 
 prop_text_roundtrip e =
  forAll  (valueOfEncoding e)
- $ \v -> (parseValue e empty . renderValue "☠") v === Right v
+ $ \v -> (parseValue e Set.empty . renderValue "☠") v === Right v
 
 return []
 tests :: IO Bool

--- a/test/Icicle/Test/Encoding.hs
+++ b/test/Icicle/Test/Encoding.hs
@@ -7,11 +7,12 @@ module Icicle.Test.Encoding where
 import           Icicle.Test.Arbitrary
 import           Icicle.Encoding
 
-import           P
+import           P hiding (empty)
 
 import           System.IO
 
 import           Test.QuickCheck
+import           Data.Set (empty)
 
 
 -- Sanity checking the randomly generated values
@@ -33,7 +34,7 @@ prop_json_roundtrip e =
 
 prop_text_roundtrip e =
  forAll  (valueOfEncoding e)
- $ \v -> (parseValue e . renderValue "☠") v === Right v
+ $ \v -> (parseValue e empty . renderValue "☠") v === Right v
 
 return []
 tests :: IO Bool


### PR DESCRIPTION
…ugh it's not used yet).

Evaluators currently don't know how to deal with tombstones either.