### PR TITLE
Update melt/constructor to support splitting options in some cases

### DIFF
--- a/src/Icicle/Avalanche/Prim/Eval.hs
+++ b/src/Icicle/Avalanche/Prim/Eval.hs
@@ -6,8 +6,9 @@ module Icicle.Avalanche.Prim.Eval (
     ) where
 
 import Icicle.Common.Base
-import Icicle.Common.Value
 import Icicle.Common.Exp.Eval
+import Icicle.Common.Type
+import Icicle.Common.Value
 import Icicle.Avalanche.Prim.Flat
 
 import              P
@@ -77,9 +78,11 @@ evalPrim p vs
       | otherwise
       -> primError
 
-     PrimUnsafe (PrimUnsafeOptionGet _)
+     PrimUnsafe (PrimUnsafeOptionGet t)
       | [VBase (VSome v)]  <- vs
       -> return $ VBase v
+      | [VBase VNone]      <- vs
+      -> return $ VBase (defaultOfType t)
       | otherwise
       -> primError
 
@@ -102,6 +105,14 @@ evalPrim p vs
       | [VBase (VArray arr1), VBase (VArray arr2)]  <- vs
       -> return $ VBase
        $ VArray (zipWith VPair arr1 arr2)
+      | otherwise
+      -> primError
+
+     PrimOption (PrimOptionPack _)
+      | [VBase (VBool True), VBase v]  <- vs
+      -> return $ VBase $ VSome v
+      | [VBase (VBool False), _]       <- vs
+      -> return $ VBase $ VNone
       | otherwise
       -> primError
 

--- a/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/src/Icicle/Avalanche/Prim/Flat.hs
@@ -1,11 +1,12 @@
 -- | Flat primitives - after the folds are removed
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Avalanche.Prim.Flat (
-      Prim   (..)
+      Prim        (..)
     , PrimProject (..)
-    , PrimUnsafe    (..)
-    , PrimUpdate    (..)
-    , PrimArray     (..)
+    , PrimUnsafe  (..)
+    , PrimUpdate  (..)
+    , PrimArray   (..)
+    , PrimOption  (..)
     , typeOfPrim
     , flatFragment
   ) where
@@ -40,8 +41,11 @@ data Prim
  -- | Safe updates
  | PrimUpdate          PrimUpdate
 
- -- | Safe updates
+ -- | Array prims
  | PrimArray           PrimArray
+
+ -- | Option prims
+ | PrimOption          PrimOption
  deriving (Eq, Ord, Show)
 
 
@@ -71,7 +75,11 @@ data PrimUpdate
  deriving (Eq, Ord, Show)
 
 data PrimArray
- = PrimArrayZip  ValType ValType
+ = PrimArrayZip ValType ValType
+ deriving (Eq, Ord, Show)
+
+data PrimOption
+ = PrimOptionPack ValType
  deriving (Eq, Ord, Show)
 
 
@@ -117,8 +125,11 @@ typeOfPrim p
     PrimUpdate  (PrimUpdateArrayPut a)
      -> FunT [funOfVal (ArrayT a), funOfVal IntT, funOfVal a] (ArrayT a)
 
-    PrimArray  (PrimArrayZip a b)
+    PrimArray   (PrimArrayZip a b)
      -> FunT [funOfVal (ArrayT a), funOfVal (ArrayT b)] (ArrayT (PairT a b))
+
+    PrimOption  (PrimOptionPack t)
+     -> FunT [funOfVal BoolT, funOfVal t] (OptionT t)
 
 
 -- Pretty -------------
@@ -159,3 +170,6 @@ instance Pretty Prim where
  pretty (PrimArray (PrimArrayZip a b))
   = text "Array_zip#" <+> brackets (pretty a) <+> brackets (pretty b)
 
+
+ pretty (PrimOption (PrimOptionPack t))
+  = text "Option_pack#" <+> brackets (pretty t)

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -236,6 +236,8 @@ primTypeOfPrim p
      -> upda pu
     PrimArray (PrimArrayZip _ _)
      -> Function "Array.zip"
+    PrimOption (PrimOptionPack _)
+     -> Function "Option.pack"
 
  where
   min' (M.PrimArithUnary ar _) = unary ar

--- a/src/Icicle/Common/Type.hs
+++ b/src/Icicle/Common/Type.hs
@@ -17,6 +17,7 @@ module Icicle.Common.Type (
     , Type
     , funOfVal
     , arrow
+    , defaultOfType
 
     , ArithType (..)
     , valTypeOfArithType
@@ -37,10 +38,12 @@ module Icicle.Common.Type (
 
 import              Icicle.Internal.Pretty
 import              Icicle.Common.Base
+import              Icicle.Data.DateTime (dateOfDays)
 
 import              P
 
 import qualified    Data.Map as Map
+import qualified    Data.Text as T
 
 
 -- | Real values.
@@ -74,6 +77,23 @@ arithTypeOfValType :: ValType -> Maybe ArithType
 arithTypeOfValType IntT         = Just ArithIntT
 arithTypeOfValType DoubleT      = Just ArithDoubleT
 arithTypeOfValType _            = Nothing
+
+
+defaultOfType :: ValType -> BaseValue
+defaultOfType typ
+ = case typ of
+     BoolT     -> VBool False
+     DateTimeT -> VDateTime (dateOfDays 0)
+     DoubleT   -> VDouble 0
+     IntT      -> VInt 0
+     StringT   -> VString T.empty
+     UnitT     -> VUnit
+     ArrayT  _ -> VArray []
+     MapT  _ _ -> VMap Map.empty
+     OptionT _ -> VNone
+     PairT a b -> VPair (defaultOfType a)
+                        (defaultOfType b)
+     StructT t -> VStruct (Map.map defaultOfType (getStructType t))
 
 
 data StructType


### PR DESCRIPTION
Adds a new transient primop `Option_pack#` which is inserted by melt, and removed by constructor.