### PR TITLE
Don't crash when an import isn't found.

### DIFF
--- a/main/icicle-repl.hs
+++ b/main/icicle-repl.hs
@@ -248,7 +248,7 @@ handleLine state line = case readCommand line of
 
   Just (CommandImportLibrary fp) -> do
     s  <- liftIO $ T.readFile fp
-    case SR.readIcicleLibrary s of
+    case SR.readIcicleLibrary fp s of
       Left e   -> prettyHL e >> return state
       Right is -> do
         HL.outputStrLn $ "ok, loaded " <> show (Map.size is) <> " functions from " <> fp

--- a/src/Icicle/Repl.hs
+++ b/src/Icicle/Repl.hs
@@ -210,14 +210,15 @@ loadDictionary load
      -> do  firstEitherT ReplErrorDictionaryLoad $ DictionaryToml.loadDictionary fp
 
 readIcicleLibrary
-    :: Text
+    :: Parsec.SourceName
+    -> Text
     -> Either ReplError
       (M.Map (CommonBase.Name Var)
              ( ST.FunctionType Var
              , SQ.Function (ST.Annot Parsec.SourcePos Var) Var))
-readIcicleLibrary input
+readIcicleLibrary source input
  = do
-  input' <- mapLeft ReplErrorParse $ SP.parseFunctions input
+  input' <- mapLeft ReplErrorParse $ SP.parseFunctions source input
   mapLeft ReplErrorCheck
          $ snd
          $ flip Fresh.runFresh (freshNamer "t")

--- a/src/Icicle/Source/Parser.hs
+++ b/src/Icicle/Source/Parser.hs
@@ -24,10 +24,10 @@ import Text.Parsec
 
 import P
 
-parseFunctions :: Text -> Either ParseError [((SourcePos, Name Variable), (Function SourcePos Variable))]
-parseFunctions inp
- = let toks = lexer "" inp
-   in  runParser functions () "" toks
+parseFunctions :: SourceName -> Text -> Either ParseError [((SourcePos, Name Variable), (Function SourcePos Variable))]
+parseFunctions source inp
+ = let toks = lexer source inp
+   in  runParser functions () source toks
 
 parseQueryTop :: OutputName -> Text -> Either ParseError (QueryTop SourcePos Variable)
 parseQueryTop name inp

--- a/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/src/Icicle/Storage/Dictionary/Toml.hs
@@ -83,10 +83,15 @@ loadDictionary' parentFuncs parentConf parentConcrete fp
      $ tomlDict parentConf rawToml
 
   parsedImports
-    <- (\fp' ->
-         EitherT
-         $ ((A.left DictionaryErrorParsecFunc) . SP.parseFunctions)
-        <$> T.readFile (rp </> (T.unpack fp'))
+    <- (\fp' -> do
+         let fp'' = T.unpack fp'
+         importsText
+           <- EitherT
+            $ A.left DictionaryErrorIO
+           <$> E.try (T.readFile (rp </> fp''))
+         hoistEither
+            $ A.left DictionaryErrorParsecFunc
+            $ SP.parseFunctions fp'' importsText
        ) `traverse` (imports conf)
 
   importedFunctions

--- a/test/cli/repl/t12-broken-dictionaries/bad.icicle
+++ b/test/cli/repl/t12-broken-dictionaries/bad.icicle
@@ -1,0 +1,1 @@
+sum v = let fld s = 0 : v + s ~> s.

--- a/test/cli/repl/t12-broken-dictionaries/broken.toml
+++ b/test/cli/repl/t12-broken-dictionaries/broken.toml
@@ -1,0 +1,5 @@
+title = "Broken dictionary"
+version = 1
+import = [
+  "non-existant.icicle"
+]

--- a/test/cli/repl/t12-broken-dictionaries/broken2.toml
+++ b/test/cli/repl/t12-broken-dictionaries/broken2.toml
@@ -1,0 +1,5 @@
+title = "Broken dictionary 2"
+version = 1
+import = [
+  "bad.icicle"
+]

--- a/test/cli/repl/t12-broken-dictionaries/expected
+++ b/test/cli/repl/t12-broken-dictionaries/expected
@@ -1,0 +1,10 @@
+welcome to iREPL
+ok, loaded 8 functions from data/libs/prelude.icicle
+ok, loaded test/cli/repl/data.psv, 8 rows
+> -- Load dictionary
+> Dictionary load error:
+  IO Exception: test/cli/repl/t12-broken-dictionaries/non-existant.icicle: openFile: does not exist (No such file or directory)
+> Dictionary load error:
+  Function parse error: "bad.icicle" (line 1, column 13):
+unexpected (TVariable (Variable "s"),"bad.icicle" (line 1, column 17))
+> 

--- a/test/cli/repl/t12-broken-dictionaries/script
+++ b/test/cli/repl/t12-broken-dictionaries/script
@@ -1,0 +1,3 @@
+-- Load dictionary
+:dictionary test/cli/repl/t12-broken-dictionaries/broken.toml
+:dictionary test/cli/repl/t12-broken-dictionaries/broken2.toml


### PR DESCRIPTION
Preserve the source file name when parsing
import for better error messages.