### PR TITLE
remove state from the source type checker

### DIFF
--- a/src/Icicle/Source/Checker/Base.hs
+++ b/src/Icicle/Source/Checker/Base.hs
@@ -21,6 +21,7 @@ module Icicle.Source.Checker.Base (
   , lookup
   , bind
   , withBind
+  , removeElementBinds
 
   , substTQ
   , substTX
@@ -182,6 +183,14 @@ withBind
   -> Gen a n r
 withBind n t old gen
  = gen (bind n t old)
+
+removeElementBinds :: Ord n => GenEnv n -> GenEnv n
+removeElementBinds env
+ = let elts  = Map.keys $ Map.filter isElementTemporality env
+   in  foldr Map.delete env elts
+ where
+  isElementTemporality ft
+   = getTemporalityOrPure (functionReturn ft) == TemporalityElement
 
 
 substTQ :: Ord n => SubstT n -> Query'C a n -> Query'C a n

--- a/src/Icicle/Source/Checker/Constraint.hs
+++ b/src/Icicle/Source/Checker/Constraint.hs
@@ -218,8 +218,9 @@ generateQ qq@(Query (c:_) _) env cons
             retk <- Temporality TemporalityElement . TypeVar <$> fresh
             retv <- Temporality TemporalityElement . TypeVar <$> fresh
 
+            let env' = removeElementBinds env
             (q', sq, t', consr)
-                <- withBind k retk env
+                <- withBind k retk env'
                  $ (fmap flip . withBind) v retv (rest consg)
 
             cons'  <-  requireAgg  t' consr

--- a/src/Icicle/Source/Checker/Constraint.hs
+++ b/src/Icicle/Source/Checker/Constraint.hs
@@ -1,6 +1,8 @@
 -- | Generate type constraints
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE DoAndIfThenElse #-}
 module Icicle.Source.Checker.Constraint (
     constraintsQ
   , generateQ
@@ -20,11 +22,9 @@ import qualified        Icicle.Common.Fresh     as Fresh
 
 import                  P
 
-import                  Control.Monad.Trans.Class
 import                  Control.Monad.Trans.Either
-import qualified        Control.Monad.Trans.State as State
 
-import                  Data.List (zip,unzip)
+import                  Data.List (zip,unzip,unzip3)
 import qualified        Data.Map                as Map
 
 
@@ -75,15 +75,25 @@ defaults q
 
 
 -- | Generate constraints for an entire query.
--- We take the map of types of all imported functions.
+--   We take the map of types of all imported functions.
 constraintsQ
-        :: Ord n
-        => Map.Map (Name n) (FunctionType n)
-        -> Query a n
-        -> EitherT (CheckError a n) (Fresh.Fresh n) (Query'C a n)
+  :: Ord n
+  => Map.Map (Name n) (FunctionType n)
+  -> Query a n
+  -> EitherT (CheckError a n) (Fresh.Fresh n) (Query'C a n)
 constraintsQ env q
- -- Silly monad transformer gymnastics
- = evalGen (fst <$> generateQ q) (CheckState env [])
+ = do (x, _, cons) <- evalGen (generateQ q env) []
+      -- We must have been able to solve all constraints except numeric requirements.
+      if   all (isNumConstraint . snd) cons
+      then right x
+      else hoistEither
+            $ errorNoSuggestions
+            $ ErrorConstraintLeftover
+               (annotOfQuery q)
+               (filter (not . isNumConstraint . snd) cons)
+ where
+  isNumConstraint (CIsNum _) = True
+  isNumConstraint _          = False
 
 
 -- | Generate constraints for top-level query.
@@ -93,21 +103,26 @@ constraintsQ env q
 -- The constraints flow upwards, bottom-up, but are also discharged and simplified at every level.
 -- The substitutions from discharged constraints also flow upwards.
 --
--- The environment mapping flows downwards, with new names only available in lexically nested subexpressions and so on.
+-- The environment mapping flows downwards, with new names only available in lexically
+-- nested subexpressions and so on.
 --
--- Shoehorning these two differently flowing contexts into a state monad was a mistake, and is a constant source of bugs.
---
-generateQ :: Ord n => Query a n -> Gen a n (Query'C a n, SubstT n)
+generateQ
+  :: Ord n
+  => Query a n
+  -> GenEnv n
+  -> GenConstraintSet a n
+  -> Gen a n (Query'C a n, SubstT n, GenConstraintSet a n)
+
 -- End of query - at this stage it is just an expression with no contexts.
-generateQ (Query [] x)
- = do   (x',s) <- generateX x
-        return (Query [] x', s)
+generateQ (Query [] x) env cons
+ = do   (x', s, cons') <- generateX x env cons
+        return (Query [] x', s, cons')
 
 -- Query with a context
-generateQ qq@(Query (c:_) _)
+generateQ qq@(Query (c:_) _) env cons
  -- Discharge any constraints on the result
- = discharge (annAnnot.annotOfQuery) substTQ
- $ case c of
+ =   discharge (annAnnot.annotOfQuery) substTQ
+ =<< case c of
     -- In the following "rules",
     --  x't stands for "temporality of x";
     --  x'p "possibility of x";
@@ -117,18 +132,22 @@ generateQ qq@(Query (c:_) _)
     -- >   windowed n days ~> Aggregate x'p x'd
     -- > : Aggregate x'p x'd
     Windowed _ from to
-     -> do  (q',sq,t') <- rest
+     -> do  (q', sq, t', consr) <- rest cons env
+
             -- Windowed only works for aggregates
-            requireAgg t'
-            let t'' = canonT $ Temporality TemporalityAggregate t'
-            with q' sq t'' $ \a' -> Windowed a' from to
+            cons'    <- requireAgg t' consr
+            let t''   = canonT $ Temporality TemporalityAggregate t'
+
+            let q''   = with cons' q' t'' $ \a' -> Windowed a' from to
+            return (q'', sq, cons')
 
     -- >   latest n ~> x't x'p x'd
     -- > : Aggregate Possibly (ReturnOfLatest x't x'd)
     Latest _ i
-     -> do  (q',sq,tq) <- rest
-            retDat <- TypeVar <$> fresh
-            let (tmpq,_,datq) = decomposeT tq
+     -> do  (q', sq, tq, consr) <- rest cons env
+
+            let (tmpq, _, datq)  = decomposeT tq
+            retDat              <- TypeVar <$> fresh
 
             -- Latest works for aggregates or elements.
             -- If the end is an element, such as
@@ -154,84 +173,109 @@ generateQ qq@(Query (c:_) _)
             -- >    (ret = ReturnOfLatest x't x'd)
             -- > => x't x'd -> Aggregate ret
             --
-            -- The definition for ReturnOfLatest is in Icicle.Source.Type.Constraints, but is something like
+            -- The definition for ReturnOfLatest is in Icicle.Source.Type.Constraints,
+            -- but is something like
+            --
             -- > ReturnOfLatest Aggregate d = d
             -- > ReturnOfLatest Element   d = Array d
             --
-            require a $ CReturnOfLatest retDat (fromMaybe TemporalityPure tmpq) datq
-            let t'  = canonT
-                    $ Temporality TemporalityAggregate
-                    $ Possibility PossibilityPossibly retDat
-            with q' sq t' $ \a' -> Latest a' i
+            let cons' = require a (CReturnOfLatest retDat (fromMaybe TemporalityPure tmpq) datq) consr
+            let t'    = canonT
+                      $ Temporality TemporalityAggregate
+                      $ Possibility PossibilityPossibly retDat
+
+            let q''   = with cons' q' t' $ \a' -> Latest a' i
+            return (q'', sq, cons')
 
     -- >   group (Element k'p k'd) ~> Aggregate v'p v'd
     -- > : Aggregate (PossibilityJoin k'p v'p) (Group k'd v'd)
     GroupBy _ x
-     -> do  (x',sx) <- generateX x
-            (q',sq,tval) <- rest
-            let tkey = annResult $ annotOfExp x'
-            requireTemporality tkey TemporalityElement
-            requireAgg tval
+     -> do  (x', sx, consk)       <- generateX x env cons
+            (q', sq, tval, consr) <- rest consk env
 
-            poss <- requirePossibilityJoin tkey tval
+            let tkey = annResult $ annotOfExp x'
+
+            cons'          <-  requireTemporality tkey TemporalityElement consr
+                           >>= requireAgg tval
+            (poss, cons'') <-  requirePossibilityJoin tkey tval cons'
 
             let t'  = canonT
                     $ Temporality TemporalityAggregate
                     $ Possibility poss
                     $ GroupT tkey tval
 
-            with q' (compose sx sq) t' $ \a' -> GroupBy a' x'
+            let ss  = compose sx sq
+            let q'' = with cons'' q' t' $ \a' -> GroupBy a' x'
+            return (q'', ss, cons'')
 
     -- >   group fold (k, v) = ( |- Q : Aggregate g'p (Group a'k a'v))
     -- >   ~> (k: Element a'k, v: Element a'v |- Aggregate a'p a)
     -- >    : Aggregate (PossibilityJoin g'p a'p) a
     GroupFold _ k v x
-     -> do  (x',sx)    <- generateX x
-            retKey     <- Temporality TemporalityElement . TypeVar <$> fresh
-            retVal     <- Temporality TemporalityElement . TypeVar <$> fresh
-            (q',sq,t') <- withBind k retKey
-                        $ withBind v retVal rest
-            let tgroup  = annResult $ annotOfExp x'
-            requireAgg  t'
-            requireAgg  tgroup
-            requireData tgroup $ GroupT retKey retVal
-            poss <- requirePossibilityJoin tgroup t'
+     -> do  (x', sx, consg) <- generateX x env cons
+            let tgroup       = annResult $ annotOfExp x'
 
-            let t''     = canonT
-                        $ Temporality TemporalityAggregate
-                        $ Possibility poss t'
-            with q' (compose sx sq) t'' $ \a' -> GroupFold a' k v x'
+            retk <- Temporality TemporalityElement . TypeVar <$> fresh
+            retv <- Temporality TemporalityElement . TypeVar <$> fresh
+
+            (q', sq, t', consr)
+                <- withBind k retk env
+                 $ (fmap flip . withBind) v retv (rest consg)
+
+            cons'  <-  requireAgg  t' consr
+                   >>= requireAgg  tgroup
+                   >>= return . requireData tgroup (GroupT retk retv)
+
+            (poss, cons'') <- requirePossibilityJoin tgroup t' cons'
+
+            let t'' = canonT
+                    $ Temporality TemporalityAggregate
+                    $ Possibility poss t'
+
+            let ss  = compose sx sq
+            let q'' = with cons'' q' t'' $ \a' -> GroupFold a' k v x'
+            return (q'', ss, cons'')
 
     -- >   distinct (Element k'p k'd) ~> Aggregate v'p v'd
     -- > : Aggregate (PossibilityJoin k'p v'p) v'd
     Distinct _ x
-     -> do  (x',sx) <- generateX x
-            (q',sq,t') <- rest
+     -> do  (x', sx, consk)     <- generateX x env cons
+            (q', sq, t', consr) <- rest consk env
+
             let tkey = annResult $ annotOfExp x'
-            requireTemporality tkey TemporalityElement
-            requireAgg t'
-            poss <- requirePossibilityJoin tkey t'
+
+            cons'          <-  requireTemporality tkey TemporalityElement consr
+                           >>= requireAgg t'
+            (poss, cons'') <-  requirePossibilityJoin tkey t' cons'
 
             let t'' = canonT
                     $ Temporality TemporalityAggregate
                     $ Possibility poss t'
-            with q' (compose sx sq) t'' $ \a' -> Distinct a' x'
+
+            let ss  = compose sx sq
+            let q'' = with cons'' q' t'' $ \a' -> Distinct a' x'
+            return (q'', ss, cons'')
 
     -- >   filter (Element p'p Bool) ~> Aggregate x'p x'd
     -- > : Aggregate (PossibilityJoin p'p x'p) x'd
     Filter _ x
-     -> do  (x',sx)    <- generateX x
-            (q',sq,t') <- rest
-            let pred    = annResult $ annotOfExp x'
-            requireTemporality pred TemporalityElement
-            requireData        pred BoolT
-            requireAgg t'
-            poss <- requirePossibilityJoin pred t'
+     -> do  (x', sx, consp)     <- generateX x env cons
+            (q', sq, t', consr) <- rest consp env
+
+            let pred = annResult $ annotOfExp x'
+
+            cons'          <-  requireTemporality pred TemporalityElement consr
+                           >>= return . requireData pred BoolT
+                           >>= requireAgg t'
+            (poss, cons'') <-  requirePossibilityJoin pred t' cons'
 
             let t'' = canonT
                     $ Temporality TemporalityAggregate
                     $ Possibility poss t'
-            with q' (compose sx sq) t'' $ \a' -> Filter a' x'
+
+            let ss  = compose sx sq
+            let q'' = with cons'' q' t'' $ \a' -> Filter a' x'
+            return (q'', ss, cons'')
 
     -- >     let fold  bind = ( |- Pure z'p a'd) : ( bind : Element z'p a'd |- Element k'p a'd)
     -- >  ~> (bind : Aggregate k'p a'd |- Aggregate r'p r'd)
@@ -241,9 +285,9 @@ generateQ qq@(Query (c:_) _)
     -- >  ~> (bind : Aggregate Possibly a'd |- Aggregate r'p r'd)
     -- >   :  Aggregate r'p r'd
     LetFold _ f
-     -> do  (i,si) <- generateX $ foldInit f
-            (w,sw) <- withBind (foldBind f) (annResult $ annotOfExp i)
-                    $ generateX $ foldWork f
+     -> do  (i,si, csi) <- generateX (foldInit f) env cons
+            (w,sw, csw) <- withBind  (foldBind f) (annResult $ annotOfExp i) env
+                                     (fmap flip generateX (foldWork f) csi)
 
             let bindType
                  | FoldTypeFoldl1 <- foldType f
@@ -257,24 +301,27 @@ generateQ qq@(Query (c:_) _)
                  $ Temporality TemporalityAggregate
                  $ annResult $ annotOfExp w
 
-            (q',sq,t') <- withBind (foldBind f) bindType rest
+            (q', sq, t', consr) <- withBind (foldBind f) bindType env (rest csw)
 
-            case foldType f of
-             FoldTypeFoldl1
-              -> requireTemporality (annResult $ annotOfExp i) TemporalityElement
-             FoldTypeFoldl
-              -> requireTemporality (annResult $ annotOfExp i) TemporalityPure
-
-            requireAgg t'
-            requireTemporality (annResult $ annotOfExp w) TemporalityElement
+            consf
+              <- case foldType f of
+                  FoldTypeFoldl1
+                   -> requireTemporality (annResult $ annotOfExp i) TemporalityElement consr
+                  FoldTypeFoldl
+                   -> requireTemporality (annResult $ annotOfExp i) TemporalityPure consr
 
             let (_,_,it) = decomposeT $ annResult $ annotOfExp i
             let (_,_,wt) = decomposeT $ annResult $ annotOfExp w
 
-            require a $ CEquals it wt
+            cons' <-  requireAgg t' consf
+                  >>= requireTemporality (annResult $ annotOfExp w) TemporalityElement
+                  >>= return . require a (CEquals it wt)
+
             let t'' = canonT $ Temporality TemporalityAggregate t'
             let s'  = si `compose` sw `compose` sq
-            with q' s' t'' $ \a' -> LetFold a' (f { foldInit = i, foldWork = w })
+
+            let q'' = with cons' q' t'' $ \a' -> LetFold a' (f { foldInit = i, foldWork = w })
+            return (q'', s', cons')
 
     -- Lets are not allowed if it means the binding would not be able to be used in the body.
     -- For example, trying to bind an Aggregate where the body is an Element, means that the
@@ -287,109 +334,142 @@ generateQ qq@(Query (c:_) _)
     -- >    ~> ( n : def't def'p def'd |- body't body'p body'd )
     -- > : (ReturnOfLetTemporalities def't body't) body'p body'd
     Let _ n x
-     -> do  (x',sx) <- generateX x
-            (q',sq,tq) <- withBind n (annResult $ annotOfExp x') rest
+     -> do  (x', sx, consd) <- generateX x env cons
 
-            retTmp <- TypeVar <$> fresh
-            let tmpx = getTemporalityOrPure $ annResult $ annotOfExp x'
-            let tmpq = getTemporalityOrPure $ tq
-            require a $ CReturnOfLetTemporalities retTmp tmpx tmpq
-            let t' = canonT $ Temporality retTmp tq
+            (q',sq,tq,consr) <- withBind n (annResult $ annotOfExp x') env (rest consd)
 
-            with q' (compose sx sq) t' $ \a' -> Let a' n x'
+            retTmp   <- TypeVar <$> fresh
+            let tmpx  = getTemporalityOrPure $ annResult $ annotOfExp x'
+            let tmpq  = getTemporalityOrPure $ tq
+
+            let cons' = require a (CReturnOfLetTemporalities retTmp tmpx tmpq) consr
+            let t'    = canonT $ Temporality retTmp tq
+
+            let ss  = compose sx sq
+            let q'' = with cons' q' t' $ \a' -> Let a' n x'
+            return (q'', ss, cons')
 
  where
   a  = annotOfContext c
 
   -- Generate constraints for the remainder of the query, and rip out the result type
-  rest
-   = do (q',s') <- generateQ (qq { contexts = drop 1 $ contexts qq })
-        return (q', s', annResult $ annotOfQuery q')
+  rest cs e
+   = do (q',s',cx') <- generateQ (qq { contexts = drop 1 $ contexts qq }) e cs
+        return (q', s', annResult $ annotOfQuery q',cx')
 
-  -- Rebuild the result with given substitution and type,
-  -- using current constraints
-  with q' s' t' c'
-   = do cs <- stateConstraints <$> (lift $ lift State.get)
-        let a' = Annot a t' cs
-        return (q' { contexts = c' a' : contexts q' }, s')
+  -- Rebuild the result with given substitution and type, using the given constraints
+  with cs q' t' c'
+   = let a' = Annot a t' cs
+     in  q' { contexts = c' a' : contexts q' }
 
   -- Helpers for adding constraints
-  requireTemporality ty tmp
+  requireTemporality ty tmp cx
    | TemporalityPure <- getTemporalityOrPure ty
-   = return ()
+   = return cx
    | otherwise
    = do n <- fresh
-        require a $ CEquals ty (Temporality tmp $ TypeVar n)
+        return $ require a (CEquals ty (Temporality tmp $ TypeVar n)) cx
+
   requireAgg t
    = requireTemporality t TemporalityAggregate
 
-  requireData t1 t2
+  requireData t1 t2 cx
    = let (_,_,d1) = decomposeT t1
          (_,_,d2) = decomposeT t2
-     in  require a $ CEquals d1 d2
+     in  require a (CEquals d1 d2) cx
 
-  requirePossibilityJoin t1 t2
-   = do poss <- TypeVar <$> fresh
-        require a $ CPossibilityJoin poss (getPossibilityOrDefinitely t1) (getPossibilityOrDefinitely t2)
-        return poss
+  requirePossibilityJoin t1 t2 cx
+   = do poss   <- TypeVar <$> fresh
+        let pt1 = getPossibilityOrDefinitely t1
+        let pt2 = getPossibilityOrDefinitely t2
+        let c'  = require a (CPossibilityJoin poss pt1 pt2) cx
+        return (poss, c')
+
 
 -- | Generate constraints for expression
-generateX :: Ord n => Exp a n -> Gen a n (Exp'C a n, SubstT n)
-generateX x
- = discharge (annAnnot.annotOfExp) substTX
- $ case x of
-    -- Variables are super easy!
+generateX
+  :: Ord n
+  => Exp a n
+  -> GenEnv n
+  -> GenConstraintSet a n
+  -> Gen a n (Exp'C a n, SubstT n, GenConstraintSet a n)
+generateX x env cons
+ =   discharge (annAnnot.annotOfExp) substTX
+ =<< case x of
+    -- Variables can only be values, not functions.
     Var a n
-     -> do (argsT, resT, fErr) <- lookup a n
-           when (not $ null argsT)
-             $ hoistEither $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
-           annotate Map.empty resT $ \a' -> Var a' n
+     -> do (fErr, argsT, resT, cons') <- lookup a n env cons
 
-    -- Nested queries are also easy
+           when (not $ null argsT)
+             $ Gen . hoistEither
+             $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
+
+           let x' = annotate cons' resT
+                  $ \a' -> Var a' n
+           return (x', Map.empty, cons')
+
+    -- Nested just has the type of its inner query.
     Nested _ q
-     -> do (q',sq) <- generateQ q
-           annotate sq (annResult $ annotOfQuery q') $ \a' -> Nested a' q'
+     -> do (q', sq, cons') <- generateQ q env cons
+
+           let x' = annotate cons' (annResult $ annotOfQuery q')
+                  $ \a' -> Nested a' q'
+           return (x', sq, cons')
 
     -- Applications are a bit more complicated.
-    -- If your function expects an argument with a particular temporality, and you give it that temporality, it is fine; function application is as usual.
+    -- If your function expects an argument with a particular temporality,
+    -- and you give it that temporality, it is fine; function application is as usual.
     -- (This is even if it expects Pure, and you apply a Pure)
-    -- If your function expects a pure argument, and you give it a temporality such as Element, that means the argument must be
-    -- implicitly unboxed to a pure computation, and then the result of application being reboxed as an Element.
-    -- Reboxing can only work if the result type is pure or the desired temporality; you could not rebox an Aggregate result to an Element.
+    --
+    -- If your function expects a Pure argument, and you give it another temporality
+    -- such as Element, that means the argument must be implicitly unboxed to a pure computation,
+    -- and then the result of application being reboxed as an Element.
+    -- Reboxing can only work if the result type is pure or the desired temporality;
+    -- you could not rebox an Aggregate result to an Element.
     --
     -- Look at an application of (+), for example:
     --  (+) : Pure Int -> Pure Int -> Pure Int
     -- However if one of its arguments is an Element:
     --  (x : Pure Int) + (y : Element Int) : Element Int
     -- here the y is unboxed, then the result is reboxed.
+    --
     App a _ _
      -> let (f, args)   = takeApps x
             look        | Prim _ p <- f
-                        = primLookup a p
+                        = primLookup a p cons
                         | Var _ n  <- f
-                        = lookup a n
+                        = lookup a n env cons
                         | otherwise
-                        = hoistEither $ errorNoSuggestions (ErrorApplicationNotFunction a x)
-        in do   (argsT, resT, fErr) <- look
+                        = Gen . hoistEither
+                        $ errorNoSuggestions (ErrorApplicationNotFunction a x)
+        in do   (fErr, argsT, resT, cons') <- look
 
-                (args',subs') <- unzip <$> mapM generateX args
-                let argsT' = fmap (annResult.annotOfExp) args'
+                (args', subs', conss)      <- unzip3 <$> mapM ((flip . flip generateX) env cons') args
+                let argsT'                  = fmap (annResult.annotOfExp) args'
 
                 when (length argsT /= length args)
-                 $ hoistEither $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr argsT')
+                 $ Gen. hoistEither
+                 $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr argsT')
 
-                resT'   <- foldM (appType a) resT (argsT `zip` argsT')
+                let go (t, c) u     = appType a t u c
+                let (resT', cons'') = foldl' go (resT, concat conss) (argsT `zip` argsT')
 
                 let s' = foldl compose Map.empty subs'
-                (f',_) <- annotate s' resT' $ \a' -> reannotX (const a') f
-                return (foldl mkApp f' args', s')
+                let f' = annotate cons' resT' $ \a' -> reannotX (const a') f
+
+                return (foldl mkApp f' args', s', cons'')
 
     -- Unapplied primitives should be relatively easy
     Prim a p
-     -> do (argsT, resT, fErr) <- primLookup a p
+     -> do (fErr, argsT, resT, cons') <- primLookup a p cons
+
            when (not $ null argsT)
-             $ hoistEither $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
-           annotate Map.empty resT $ \a' -> Prim a' p
+             $ Gen . hoistEither
+             $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr [])
+
+           let x' = annotate cons' resT
+                  $ \a' -> Prim a' p
+           return (x', Map.empty, cons')
 
     -- Cases require:
     --
@@ -398,29 +478,35 @@ generateX x
     --  3. The type of the scrutinee is compatible with all patterns.
     --
     Case a scrut pats
-     -> do (scrut', sub) <- generateX scrut
+     -> do (scrut', sub, consS) <- generateX scrut env cons
 
            -- Destruct the scrutinee type into the base type
            -- and the temporality (defaulting to Pure).
-           let scrutT  = annResult $ annotOfExp scrut'
+           let scrutT =  annResult $ annotOfExp scrut'
            scrutTy    <- TypeVar <$> fresh
            scrutTm    <- TypeVar <$> fresh
-           require a $ CExtractTemporality scrutTm scrutTy scrutT
+           let cons'  =  require a (CExtractTemporality scrutTm scrutTy scrutT) consS
 
            -- Require the scrutinee and the alternatives to have compatible temporalities.
-           returnType    <- TypeVar <$> fresh
-           returnTemp    <- TypeVar <$> fresh
-           returnTemp'   <- TypeVar <$> fresh
-           require a $ CTemporalityJoin returnTemp' scrutTm returnTemp
-           (pats', subs) <- unzip <$> generateP a scrutT returnType returnTemp pats
+           returnType  <- TypeVar <$> fresh
+           returnTemp  <- TypeVar <$> fresh
+           returnTemp' <- TypeVar <$> fresh
+           let cons''  =  require a (CTemporalityJoin returnTemp' scrutTm returnTemp) cons'
 
-           let t' = Temporality returnTemp returnType
-           annotate (Map.unions (sub : subs)) t' $ \a' -> Case a' scrut' pats'
+           (patsubs, ctx'') <- generateP a scrutT returnType returnTemp pats env cons'
+           let (pats', subs) = unzip patsubs
+
+           let t'    = Temporality returnTemp returnType
+           let subst = Map.unions (sub : subs)
+
+           let x' = annotate cons'' t'
+                  $ \a' -> Case a' scrut' pats'
+
+           return (x', subst, ctx'')
   where
-  annotate s' t' f
-   = do cs <- stateConstraints <$> (lift $ lift State.get)
-        let a' = Annot (annotOfExp x) t' cs
-        return (f a', s')
+  annotate cs t' f
+   = let a' = Annot (annotOfExp x) t' cs
+     in  f a'
 
 
 generateP
@@ -429,40 +515,41 @@ generateP
   -> Type n                 -- ^ scrutinee type
   -> Type n                 -- ^ result base type
   -> Type n                 -- ^ result temporality
-  -> [(Pattern n, Exp a n)]
-  -> Gen a n [((Pattern n, Exp'C a n), SubstT n)]
-generateP ann _ _ resTp []
- = do   require ann $ CEquals resTp TemporalityPure
-        return []
+  -> [(Pattern n, Exp a n)] -- ^ pattern and alternative
+  -> GenEnv n
+  -> GenConstraintSet a n
+  -> Gen a n ([((Pattern n, Exp'C a n), SubstT n)], GenConstraintSet a n)
 
-generateP ann scrutTy resTy resTm ((pat, alt):rest)
- = do   e <- lift $ lift State.get
-        t <- goPat pat
+generateP ann _ _ resTm [] _ cons
+ = do   let cons' = require ann (CEquals resTm TemporalityPure) cons
+        return ([], cons')
+
+generateP ann scrutTy resTy resTm ((pat, alt):rest) env cons
+ = do   (t, envp) <- goPat pat env
 
         let (_,_,datS) = decomposeT $ canonT scrutTy
-        require (annotOfExp alt) $ CEquals datS t
+        let conss      = require (annotOfExp alt) (CEquals datS t) cons
 
-        (alt',sub) <- generateX alt
+        (alt', sub, consa) <- generateX alt envp conss
+
         let altTy'  = annResult (annotOfExp alt')
         altTy      <- TypeVar <$> fresh
         altTp      <- TypeVar <$> fresh
+        resTp'     <- TypeVar <$> fresh
 
         -- Require alternative types to have the same temporality if they
         -- do have temporalities. Otherwise defaults to TemporalityPure.
-        require (annotOfExp alt) $ CExtractTemporality altTp altTy altTy'
-
+        let cons' = require (annotOfExp alt) (CExtractTemporality altTp altTy altTy')
         -- Require the alternative types without temporality to be the same.
-        requireData resTy altTy
-
+                  . requireData resTy altTy
         -- Require return temporality to be compatible with alternative temporalities.
-        resTp' <- TypeVar <$> fresh
-        require (annotOfExp alt) $ CTemporalityJoin resTm resTp' altTp
+                  . require (annotOfExp alt) (CTemporalityJoin resTm resTp' altTp)
+                  $ consa
 
-        e'    <- lift $ lift State.get
-        lift $ lift $ State.put (e' { stateEnvironment = stateEnvironment e })
-        rest' <- generateP ann scrutTy resTy resTp' rest
+        (rest', cons'') <- generateP ann scrutTy resTy resTp' rest env cons'
+        let patsubs     = ((pat, alt'), sub) : rest'
 
-        return (((pat,alt'), sub):rest')
+        return (patsubs, cons'')
 
  where
   requireData t1 t2
@@ -470,77 +557,69 @@ generateP ann scrutTy resTy resTm ((pat, alt):rest)
          (_,_,d2) = decomposeT t2
      in  require ann $ CEquals d1 d2
 
-  goPat PatDefault
-   = TypeVar <$> fresh
-  goPat (PatVariable n)
-   = do let (tmpS,posS,_) = decomposeT $ canonT scrutTy
-        datV <- TypeVar <$> fresh
-        bind n $ recomposeT (tmpS, posS, datV)
-        return datV
+  goPat  PatDefault e
+   = (,e) . TypeVar <$> fresh
 
-  goPat (PatCon c pats)
-   = case c of
-      ConSome
-       | [p] <- pats
-       -> OptionT <$> goPat p
-       | otherwise
-       -> err
-      ConNone
-       | [] <- pats
-       -> OptionT <$> (TypeVar <$> fresh)
-       | otherwise
-       -> err
-      ConTuple
-       | [a,b] <- pats
-       -> PairT <$> goPat a <*> goPat b
-       | otherwise
-       -> err
-      ConTrue
-       | [] <- pats
-       -> return BoolT
-       | otherwise
-       -> err
-      ConFalse
-       | [] <- pats
-       -> return BoolT
-       | otherwise
-       -> err
+  goPat (PatVariable n) e
+   = do let (tmpS,posS,_)  = decomposeT $ canonT scrutTy
+        datV              <- TypeVar <$> fresh
+        let env'           = bind n (recomposeT (tmpS, posS, datV)) e
+        return (datV, env')
+
+  goPat (PatCon ConSome  [p]) e
+   = fmap (first OptionT) $ goPat p e
+  goPat (PatCon ConNone  []) e
+   = (,e) . OptionT . TypeVar <$> fresh
+  goPat (PatCon ConTrue  []) e
+   = return (BoolT, e)
+  goPat (PatCon ConFalse []) e
+   = return (BoolT, e)
+  goPat (PatCon ConTuple [a,b]) e
+   = do (ta, ea) <- goPat a e
+        (tb, eb) <- goPat b ea
+        return (PairT ta tb, eb)
+
+  goPat _ _
+   = Gen . hoistEither
+   $ errorNoSuggestions (ErrorCaseBadPattern (annotOfExp alt) pat)
 
 
-  err = hoistEither $ errorNoSuggestions (ErrorCaseBadPattern (annotOfExp alt) pat)
+appType
+ :: a
+ -> Type n
+ -> (Type n, Type n)
+ -> GenConstraintSet a n
+ -> (Type n, GenConstraintSet a n)
+appType ann resT (expT,actT) cons
+ = let (tmpE,posE,datE) = decomposeT $ canonT expT
+       (tmpA,posA,datA) = decomposeT $ canonT actT
+       (tmpR,posR,datR) = decomposeT $ canonT resT
 
+       cons' = require ann (CEquals datE datA) cons
 
-appType :: a -> Type n -> (Type n, Type n) -> Gen a n (Type n)
-appType ann resT (expT,actT)
- = do let (tmpE,posE,datE) = decomposeT $ canonT expT
-      let (tmpA,posA,datA) = decomposeT $ canonT actT
-      let (tmpR,posR,datR) = decomposeT $ canonT resT
+       (tmpR', cs)  = checkTemp (purely tmpE) (purely tmpA) (purely tmpR) cons'
+       (posR', cs') = checkPoss (definitely posE) (definitely posA) (definitely posR) cs
 
-      require ann (CEquals datE datA)
+       t = recomposeT (tmpR', posR', datR)
+   in  (t, cs')
 
-      tmpR' <- checkTemp (purely tmpE) (purely tmpA) (purely tmpR)
-      posR' <- checkPoss (definitely posE) (definitely posA) (definitely posR)
-
-      return $ recomposeT (tmpR', posR', datR)
  where
   checkTemp = check' TemporalityPure
   checkPoss = check' PossibilityDefinitely
 
-  check' pureMode modE modA modR
+  check' pureMode modE modA modR cx
    | Nothing <- modA
-   = return modR
+   = (modR, cx)
    | Just _  <- modA
    , Nothing <- modE
    , Nothing <- modR
-   = return modA
+   = (modA, cx)
    | Just a' <- modA
    , Nothing <- modE
    , Just r' <- modR
-   = do require ann $ CEquals a' r'
-        return modR
+   = (modR, require ann (CEquals a' r') cx)
    | otherwise
-   = do require ann $ CEquals (maybe pureMode id modE) (maybe pureMode id modA)
-        return modR
+   = (modR, require ann (CEquals (maybe pureMode id modE) (maybe pureMode id modA)) cx)
 
 
   purely (Just TemporalityPure) = Nothing

--- a/src/Icicle/Source/Checker/Constraint.hs
+++ b/src/Icicle/Source/Checker/Constraint.hs
@@ -24,7 +24,7 @@ import                  P
 
 import                  Control.Monad.Trans.Either
 
-import                  Data.List (zip,unzip,unzip3)
+import                  Data.List (zip,unzip)
 import qualified        Data.Map                as Map
 
 
@@ -442,22 +442,26 @@ generateX x env cons
                         | otherwise
                         = Gen . hoistEither
                         $ errorNoSuggestions (ErrorApplicationNotFunction a x)
+            -- Generate constraints for this argument and combine with the acuumulator.
+            arg (as, ss, cs) e
+                        = do (a', s', c') <- generateX e env cs
+                             return (as <> [a'], compose ss s', cs <> c')
         in do   (fErr, argsT, resT, cons') <- look
 
-                (args', subs', conss)      <- unzip3 <$> mapM ((flip . flip generateX) env cons') args
-                let argsT'                  = fmap (annResult.annotOfExp) args'
+                (args', subs', conss) <- foldM arg ([], Map.empty, cons') args
+                let argsT'             = fmap (annResult.annotOfExp) args'
 
                 when (length argsT /= length args)
                  $ Gen. hoistEither
                  $ errorNoSuggestions (ErrorFunctionWrongArgs a x fErr argsT')
 
                 let go (t, c) u     = appType a t u c
-                let (resT', cons'') = foldl' go (resT, concat conss) (argsT `zip` argsT')
+                let (resT', cons'') = foldl' go (resT, conss) (argsT `zip` argsT')
 
-                let s' = foldl compose Map.empty subs'
-                let f' = annotate cons' resT' $ \a' -> reannotX (const a') f
+                let f' = annotate cons'' resT' $ \a' -> reannotX (const a') f
+                let x' = foldl mkApp f' args'
 
-                return (foldl mkApp f' args', s', cons'')
+                return (x', subs', cons'')
 
     -- Unapplied primitives should be relatively easy
     Prim a p

--- a/src/Icicle/Source/Checker/Error.hs
+++ b/src/Icicle/Source/Checker/Error.hs
@@ -32,6 +32,7 @@ data ErrorInfo a n
  | ErrorFunctionWrongArgs      a (Exp a n) (FunctionType n) [Type n]
  | ErrorApplicationNotFunction a (Exp a n)
  | ErrorConstraintsNotSatisfied a [(a, DischargeError n)]
+ | ErrorConstraintLeftover      a [(a, Constraint n)]
  | ErrorReturnNotAggregate a (Type n)
  | ErrorDuplicateFunctionNames a (Name n)
  | ErrorEmptyCase a (Exp a n)
@@ -52,6 +53,8 @@ annotOfError (CheckError e _)
     ErrorApplicationNotFunction a _
      -> Just a
     ErrorConstraintsNotSatisfied          a _
+     -> Just a
+    ErrorConstraintLeftover a _
      -> Just a
     ErrorReturnNotAggregate          a _
      -> Just a
@@ -114,6 +117,10 @@ instance (Pretty a, Pretty n) => Pretty (ErrorInfo a n) where
      ErrorConstraintsNotSatisfied a ds
       -> "Cannot discharge constraints at" <+> pretty a <> line
       <> "Constraints: " <> line
+      <> vcat (fmap (\(an,con) -> indent 2 (pretty an) <> indent 2 (pretty con)) ds)
+
+     ErrorConstraintLeftover a ds
+      -> "Unsolvable constraint at " <+> pretty a <> line
       <> vcat (fmap (\(an,con) -> indent 2 (pretty an) <> indent 2 (pretty con)) ds)
 
      ErrorReturnNotAggregate a t

--- a/src/Icicle/Source/Checker/Prim.hs
+++ b/src/Icicle/Source/Checker/Prim.hs
@@ -2,7 +2,6 @@
 -- It is odd that we need to look up inside a Fresh monad.
 -- However, because the types are polymorphic in the variable type, we have no way of saying "forall a".
 -- So we must generate a fresh name for any forall binders.
-{-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Source.Checker.Prim (
     primLookup
@@ -18,10 +17,13 @@ import                  P
 
 
 
-primLookup :: Ord n => a -> Prim -> Gen a n ([Type n], Type n, FunctionType n)
-primLookup ann p
+primLookup
+ :: Ord n
+ => a -> Prim -> GenConstraintSet a n
+ -> Gen a n (FunctionType n, [Type n], Type n, GenConstraintSet a n)
+primLookup ann p cons
  = do ft <- primLookup' p
-      freshenFunction ann ft
+      introForalls ann ft cons
 
 primLookup' :: Prim -> Gen a n (FunctionType n)
 primLookup' p

--- a/test/Icicle/Test/Source/Convert.hs
+++ b/test/Icicle/Test/Source/Convert.hs
@@ -81,8 +81,6 @@ prop_convert_is_well_typed nm fn q
   pp = show $ pretty q
 
 
-
-
 -- For now we can't say anything about *all* programs,
 -- but we can say that a restricted subset should convert OK.
 restrict
@@ -122,4 +120,4 @@ xfst tt
 return []
 tests :: IO Bool
 -- tests = $quickCheckAll
-tests = $forAllProperties $ quickCheckWithResult (stdArgs { {- maxSuccess = 5000, -} maxSize = 10, maxDiscardRatio = 10000})
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 5000, maxSize = 10, maxDiscardRatio = 10000})

--- a/test/Icicle/Test/Source/Convert.hs
+++ b/test/Icicle/Test/Source/Convert.hs
@@ -120,4 +120,4 @@ xfst tt
 return []
 tests :: IO Bool
 -- tests = $quickCheckAll
-tests = $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 5000, maxSize = 10, maxDiscardRatio = 10000})
+tests = $forAllProperties $ quickCheckWithResult (stdArgs { {- maxSuccess = 5000, -} maxSize = 10, maxDiscardRatio = 10000})


### PR DESCRIPTION
why we want to do this: hiding both the name environment and the constraint set in a global state makes it sometimes difficult to determine which environment/constraint go where. There are some places where we had to figure out what to *remove* from the current context before doing something.

This change attempts to make it explicit what names/constraints are being brought into scope...