### PR TITLE
Fix tombstone check to be (== Tombstone)

### DIFF
--- a/src/Icicle/Dictionary/Data.hs
+++ b/src/Icicle/Dictionary/Data.hs
@@ -131,7 +131,7 @@ featureMapOfDictionary (Dictionary { dictionaryEntries = ds, dictionaryFunctions
    = X.XPrim () (X.PrimMinimal $ X.PrimStruct $ X.PrimStructGet f t fs)
   xtomb t1
    = X.XApp () (X.XPrim () (X.PrimMinimal $ X.PrimRelation X.PrimRelationEq t1))
-               (X.XValue () (SumT ErrorT t1) (VLeft $ VError ExceptTombstone))
+               (X.XValue () t1 (VError ExceptTombstone))
 
   exps str e'
    = [ (var str, ( baseType e', X.XApp () (xfst e' DateTimeT)))


### PR DESCRIPTION
In ReifyPossibilities, the tombstone check needs (== Left Tombstone) but before that is introduced it should be just (== Tombstone)