### PR TITLE
remove Latest

### DIFF
--- a/src/Icicle/Avalanche/Annot.hs
+++ b/src/Icicle/Avalanche/Annot.hs
@@ -53,9 +53,6 @@ reannotS f ss
     Write n x
      -> Write n (reannotX f x)
 
-    Push n x
-     -> Push n (reannotX  f x)
-
     Output n vt xs
      -> Output n vt (fmap (first (reannotX f)) xs)
 

--- a/src/Icicle/Avalanche/Annot.hs
+++ b/src/Icicle/Avalanche/Annot.hs
@@ -47,8 +47,8 @@ reannotS f ss
     InitAccumulator a s
      -> InitAccumulator (reannotA f a) (reannotS f s)
 
-    Read n1 n2 at vt s
-     -> Read n1 n2 at vt (reannotS f s)
+    Read n1 n2 vt s
+     -> Read n1 n2 vt (reannotS f s)
 
     Write n x
      -> Write n (reannotX f x)

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -122,18 +122,6 @@ checkStatement frag ctx stmt
                requireSame (ProgramErrorWrongType x) t (FunT [] vt)
                return (Write n x')
 
-        Push n x
-         -> do x' <- mapLeft ProgramErrorExp
-                   $ checkExp frag (ctxExp ctx) x
-
-               vt <- maybeToRight (ProgramErrorNoSuchAccumulator n)
-                   $ Map.lookup n $ ctxAcc ctx
-
-               let t = annType (annotOfExp x')
-
-               requireSame (ProgramErrorWrongType x) t (FunT [] vt)
-               return (Push n x')
-
         Output n t xts
          -> do let xs = fmap fst xts
                    ts = fmap snd xts
@@ -212,9 +200,6 @@ statementContext frag ctx stmt
      -> return (ctx { ctxExp = Map.insert n (FunT [] vt) $ ctxExp ctx })
 
     Write _ _
-     -> return ctx
-
-    Push _ _
      -> return ctx
 
     Output _ _ _

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -285,12 +285,6 @@ evalStmt evalPrim now xh values bubblegum ah stmt
             ah' <- updateOrPush ah n v
             return (ah', [])
 
-    -- Push a value to a latest accumulator.
-    Push n x
-     -> do  v   <- eval x >>= baseValue
-            ah' <- updateOrPush ah n v
-            return (ah', [])
-
     Output n t xts
      -> do  vs  <- traverse ((baseValue =<<) . eval . fst) xts
             case (vs, unmeltValue vs t) of

--- a/src/Icicle/Avalanche/Eval.hs
+++ b/src/Icicle/Avalanche/Eval.hs
@@ -24,7 +24,7 @@ import              Icicle.Data         (AsAt(..))
 import              P
 
 import              Data.Either.Combinators
-import              Data.List   (take, sort, zip)
+import              Data.List   (zip)
 import qualified    Data.Map    as Map
 
 import              Icicle.Internal.Pretty
@@ -38,12 +38,7 @@ data AccumulatorHeap n
 
 -- | The value of an accumulator
 data AccumulatorValue
- -- | Accumulator storing latest N values
- -- Stored in reverse so we can just cons or take it
- = AVLatest Int [BaseValue]
-
- -- | A mutable value with no history attached
- | AVMutable BaseValue
+ = AVMutable BaseValue
  deriving (Eq, Ord, Show)
 
 
@@ -97,56 +92,32 @@ baseValue v
  = getBaseValue (RuntimeErrorNotBaseValue v) v
 
 
--- | Update value or push value to an accumulator, taking care of history
+-- | Update accumulator value, taking care of history
 updateOrPush
         :: Ord n
         => AccumulatorHeap n
         -> Name n
-        -> Maybe BubbleGumFact
         -> BaseValue
         -> Either (RuntimeError a n p) (AccumulatorHeap n)
 
-updateOrPush heap n bg v
+updateOrPush heap n v
  = do   let map          = accumulatorHeapMap heap
 
         let replace map' = return
                          $ heap { accumulatorHeapMap = map' }
 
-        v' <- maybeToRight (RuntimeErrorNoAccumulator n)
+        -- Just make sure it exists
+        _ <- maybeToRight (RuntimeErrorNoAccumulator n)
                            (Map.lookup n map)
-        case v' of
-         (bgs, AVLatest num vs)
-          -> replace
-           $ Map.insert n
-           ( take num (insbgs bgs)
-           , AVLatest num (take num (v : vs)) ) map
-         (_, AVMutable _)
-          -> replace
-           $ Map.insert n ([], AVMutable v) map
- where
-  insbgs bgs
-   = case bg of
-      Nothing  -> bgs
-      Just bg' -> bg' : bgs
-
+        replace $ Map.insert n ([], AVMutable v) map
 
 -- | For each accumulator value, get the history information
 bubbleGumOutputOfAccumulatorHeap
         :: Ord n
         => AccumulatorHeap n
         -> [BubbleGumOutput n (BaseValue)]
-
 bubbleGumOutputOfAccumulatorHeap acc
- = bubbleGumNubOutputs
- (accumulatorHeapMarked acc <> concatMap mk (Map.toList $ accumulatorHeapMap acc))
- where
-  mk (_, (bgs, AVLatest _ _))
-   = [BubbleGumFacts $ sort $ fmap flav bgs]
-  mk (_, (_, AVMutable _))
-   = []
-
-  flav (BubbleGumFact f) = f
-
+ = bubbleGumNubOutputs (accumulatorHeapMarked acc)
 
 -- | Evaluate an entire program
 -- with given primitive evaluator and values
@@ -181,7 +152,7 @@ initAcc :: Ord n
         -> Accumulator a n p
         -> Either (RuntimeError a n p) (Name n, ([BubbleGumFact], AccumulatorValue))
 
-initAcc evalPrim env (Accumulator n at _ x)
+initAcc evalPrim env (Accumulator n _ x)
  = do av <- getValue
       -- There is no history yet, just a value
       return (n, ([], av))
@@ -192,20 +163,7 @@ initAcc evalPrim env (Accumulator n at _ x)
         baseValue v
 
   getValue
-   = case at of
-     -- Start with initial value.
-     Mutable
-      -> AVMutable <$> ev
-     Latest
-            -- Figure out how many latest to store,
-            -- but nothing is stored yet
-      -> do v    <- ev
-            case v of
-             VInt i
-              -> return $ AVLatest i []
-             _
-              -> Left (RuntimeErrorAccumulatorLatestNotInt v)
-
+   = AVMutable <$> ev
 
 -- | Evaluate a single statement for a single value
 evalStmt
@@ -312,13 +270,11 @@ evalStmt evalPrim now xh values bubblegum ah stmt
            go xh (ah { accumulatorHeapMap = map' }) stmts
 
     -- Read from an accumulator
-    Read n acc _ _ stmts
+    Read n acc _ stmts
      -> do  -- Get the current value and apply the function
             v   <- case Map.lookup acc $ accumulatorHeapMap ah of
                     Just (_, AVMutable vacc)
                      -> return $ VBase vacc
-                    Just (_, AVLatest _ vals)
-                     -> return $ VBase $ VArray $ reverse vals
                     _
                      -> Left (RuntimeErrorLoopAccumulatorBad acc)
             go (Map.insert n v xh) ah stmts
@@ -326,13 +282,13 @@ evalStmt evalPrim now xh values bubblegum ah stmt
     -- Update accumulator
     Write n x
      -> do  v   <- eval x >>= baseValue
-            ah' <- updateOrPush ah n bubblegum v
+            ah' <- updateOrPush ah n v
             return (ah', [])
 
     -- Push a value to a latest accumulator.
     Push n x
      -> do  v   <- eval x >>= baseValue
-            ah' <- updateOrPush ah n bubblegum v
+            ah' <- updateOrPush ah n v
             return (ah', [])
 
     Output n t xts
@@ -367,8 +323,6 @@ evalStmt evalPrim now xh values bubblegum ah stmt
      -> do  v   <- case Map.lookup acc $ accumulatorHeapMap ah of
                     Just (_, AVMutable vacc)
                      -> return $ vacc
-                    Just (_, AVLatest _ vals)
-                     -> return $ VArray $ reverse vals
                     _
                      -> Left (RuntimeErrorLoopAccumulatorBad acc)
             return (ah { accumulatorHeapMarked = BubbleGumReduction acc v : accumulatorHeapMarked ah }, [])

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -124,7 +124,7 @@ programFromCore namer p
 
   -- Fold accumulator
   accum (n, CR.RFold _ ty _ x _)
-   = A.Accumulator (namerAccPrefix namer n) A.Mutable ty x
+   = A.Accumulator (namerAccPrefix namer n) ty x
 
   loadResumables (n, CR.RFold _ ty _ _ _)
    = LoadResumable (namerAccPrefix namer n) ty
@@ -133,7 +133,7 @@ programFromCore namer p
    = SaveResumable (namerAccPrefix namer n) ty
 
   readaccum (n, CR.RFold _ ty _ _ _)
-   = Read n (namerAccPrefix namer n) A.Mutable ty
+   = Read n (namerAccPrefix namer n) ty
 
   readaccums inner
    = foldr readaccum inner (C.reduces p)
@@ -262,5 +262,5 @@ statementOfReduce namer strs (n,r)
             x  = Beta.betaToLets () (k `xApp` (xVar n')
                                        `xApp` (xVar $ namerElemPrefix namer inp))
 
-        in  Read n' n' A.Mutable ty (Write n' x <> k')
+        in  Read n' n' ty (Write n' x <> k')
 

--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -81,11 +81,6 @@ flatten a_fresh s
      $ \x'
      -> return $ Write n x'
 
-    Push n x
-     -> flatX a_fresh x
-     $ \x'
-     -> return $ Push n x'
-
     Output n t xts
      | xs <- fmap fst xts
      , ts <- fmap snd xts

--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -73,8 +73,8 @@ flatten a_fresh s
      $ \x'
      -> InitAccumulator (acc { accInit = x' }) <$> flatten a_fresh ss
 
-    Read n m at vt ss
-     -> Read n m at vt <$> flatten a_fresh ss
+    Read n m vt ss
+     -> Read n m vt <$> flatten a_fresh ss
 
     Write n x
      -> flatX a_fresh x
@@ -209,16 +209,16 @@ flatX a_fresh xx stm
              n'map'k     <- fresh
              n'map'v     <- fresh
              n'map'sz    <- fresh
-             let acc'done = Accumulator n'done  Mutable BoolT $ xValue BoolT $ VBool False
-                 acc'map'k= Accumulator n'map'k Mutable (ArrayT tk) (fpMapKeys tk tv `xApp` map')
-                 acc'map'v= Accumulator n'map'v Mutable (ArrayT tv) (fpMapVals tk tv `xApp` map')
+             let acc'done = Accumulator n'done  BoolT $ xValue BoolT $ VBool False
+                 acc'map'k= Accumulator n'map'k (ArrayT tk) (fpMapKeys tk tv `xApp` map')
+                 acc'map'v= Accumulator n'map'v (ArrayT tv) (fpMapVals tk tv `xApp` map')
 
                  x'done   = xVar n'done
                  x'map'k  = xVar n'map'k
                  x'map'v  = xVar n'map'v
 
-                 read'k   = Read n'map'k n'map'k Mutable (ArrayT tk)
-                 read'v   = Read n'map'v n'map'v Mutable (ArrayT tv)
+                 read'k   = Read n'map'k n'map'k (ArrayT tk)
+                 read'v   = Read n'map'v n'map'v (ArrayT tv)
 
                  sz       = xVar n'map'sz -- fpArrLen tk `xApp` x'map'k
                  eq       = xPrim $ Flat.PrimMinimal $ Min.PrimRelation Min.PrimRelationEq tk
@@ -246,7 +246,7 @@ flatX a_fresh xx stm
              n'map'      <- fresh
              stm'        <- stm $ xVar n'map'
 
-             let if_ins   = Read n'done n'done Mutable BoolT
+             let if_ins   = Read n'done n'done BoolT
                           $ If x'done mempty (loop2 <> loop3)
 
                  stm''    = read'k
@@ -298,18 +298,17 @@ flatX a_fresh xx stm
                 stm' <- stm (xVar accN)
 
                 let arrT = ArrayT tb
-                    accT = Mutable
 
                 loop <- forI (fpArrLen ta `xApp` arr')                 $ \iter
-                     -> fmap    (Read accN accN accT arrT)          $
+                     -> fmap    (Read accN accN arrT)                  $
                         slet    (fpArrIx ta `makeApps'` [arr', iter])  $ \elm
                      -> flatX'  (upd `xApp` elm)                    $ \elm'
                      -> slet    (fpArrUpd tb `makeApps'` [xVar accN, iter, elm']) $ \arr''
                      -> return  (Write accN arr'')
 
                 return $ InitAccumulator
-                            (Accumulator accN accT arrT (fpArrNew tb `xApp` (fpArrLen ta `xApp` arr')))
-                            (loop <> Read accN accN accT arrT stm')
+                            (Accumulator accN arrT (fpArrNew tb `xApp` (fpArrLen ta `xApp` arr')))
+                            (loop <> Read accN accN arrT stm')
 
 
        -- Map with wrong arguments
@@ -386,7 +385,7 @@ flatX a_fresh xx stm
 
   -- Update an accumulator
   update acc t x
-   = Read acc acc Mutable t
+   = Read acc acc t
    $ Write acc x
 
 
@@ -405,30 +404,27 @@ flatX a_fresh xx stm
          selse <- flatX' else_ $ (return . Write acc)
          -- Perform if and write result
          let if_ =  If pred' sthen selse
-         let accT = Mutable
          -- After if, read back result from accumulator and then go do the rest of the statements
-         let read_ = Read acc acc accT valT stm'
-         return (InitAccumulator (Accumulator acc accT valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
+         let read_ = Read acc acc valT stm'
+         return (InitAccumulator (Accumulator acc valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
 
   -- Array fold becomes a loop
   flatFold (Core.PrimFoldArray telem) valT [k, z, arr]
    = do accN <- fresh
         stm' <- stm (xVar accN)
 
-        let accT = Mutable
-
         -- Loop body updates accumulator with k function
-        loop <-  flatX' arr                                  $ \arr'
-             ->  forI   (fpArrLen telem `xApp` arr')             $ \iter
-             ->  fmap   (Read accN accN accT valT)           $
+        loop <-  flatX' arr                                       $ \arr'
+             ->  forI   (fpArrLen telem `xApp` arr')              $ \iter
+             ->  fmap   (Read accN accN valT)                     $
                  slet   (fpArrIx  telem `makeApps'` [arr', iter]) $ \elm
-             ->  flatX' (makeApps' k [xVar accN, elm])       $ \x
+             ->  flatX' (makeApps' k [xVar accN, elm])            $ \x
              ->  return (Write accN x)
 
         -- Initialise accumulator with value z, execute loop, read from accumulator
         flatX' z $ \z' ->
-            return (InitAccumulator (Accumulator accN accT valT z')
-                   (loop <> Read accN accN accT valT stm'))
+            return (InitAccumulator (Accumulator accN valT z')
+                   (loop <> Read accN accN valT stm'))
 
 
   -- Fold over map. Very similar to above
@@ -469,10 +465,9 @@ flatX a_fresh xx stm
       ssome <- flatX' (xsome `xApp` (xVar tmp)) $ (return . Write acc)
       snone <- flatX' xnone $ (return . Write acc)
       let if_   = If (fpIsSome ta `xApp` opt') (Let tmp (fpOptionGet ta `xApp` opt') ssome) snone
-          accT  = Mutable
           -- After if, read back result from accumulator and then go do the rest of the statements
-          read_ = Read acc acc accT valT stm'
-      return (InitAccumulator (Accumulator acc accT valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
+          read_ = Read acc acc valT stm'
+      return (InitAccumulator (Accumulator acc valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
 
   -- Fold over an either
   flatFold (Core.PrimFoldSum ta tb) valT [xleft, xright, scrut]
@@ -490,10 +485,9 @@ flatX a_fresh xx stm
          sright  <- flatX' (xright `xApp` (xVar tmp')) $ (return . Write acc)
 
          let if_   = If (fpIsRight `xApp` scrut') (Let tmp' (fpRight `xApp` scrut') sright) (Let tmp (fpLeft `xApp` scrut') sleft)
-             accT  = Mutable
            -- After if, read back result from accumulator and then go do the rest of the statements
-             read_ = Read acc acc accT valT stm'
-         return (InitAccumulator (Accumulator acc accT valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
+             read_ = Read acc acc valT stm'
+         return (InitAccumulator (Accumulator acc valT $ xValue valT $ defaultOfType valT) (if_ <> read_))
 
 
   -- None of the above cases apply, so must be bad arguments
@@ -532,7 +526,7 @@ flatX a_fresh xx stm
             sz'  = xPrim (Flat.PrimMinimal $ Min.PrimArithBinary Min.PrimArithPlus ArithIntT)
                  `makeApps'` [sz, xValue IntT $ VInt 1]
 
-            acc  = Accumulator n'arr Mutable t' (fpArrNew t `xApp` sz')
+            acc  = Accumulator n'arr t' (fpArrNew t `xApp` sz')
 
             get i   = fpArrIx t  `makeApps'` [from, i]
             put i x = fpArrUpd t `makeApps'` [xVar n'arr, i, x]
@@ -542,9 +536,9 @@ flatX a_fresh xx stm
 
         let put' = update n'arr t'
                  $ put sz push
-            read = Read n'arr n'arr Mutable t'
+            read = Read n'arr n'arr t'
                  $ Write n'acc $ xVar n'arr
 
-        return $ Read n'from n'acc Mutable t'
+        return $ Read n'from n'acc t'
                $ InitAccumulator acc (loop <> put' <> read)
 

--- a/src/Icicle/Avalanche/Statement/Scoped.hs
+++ b/src/Icicle/Avalanche/Statement/Scoped.hs
@@ -34,7 +34,6 @@ data Scoped a n p
  | ForeachFacts [(Name n, ValType)] ValType S.FactLoopType (Scoped a n p)
  | Block     [Either (Binding a n p) (Scoped a n p)]
  | Write (Name n)    (Exp a n p)
- | Push  (Name n)    (Exp a n p)
  | Output OutputName ValType [(Exp a n p, ValType)]
  | KeepFactInHistory
  | LoadResumable (Name n) ValType
@@ -65,8 +64,6 @@ bindsOfStatement s
      -> concatMap bindsOfStatement ss
     S.Write n x
      -> [Right $ Write n x]
-    S.Push n x
-     -> [Right $ Push n x]
     S.Output n t xs
      -> [Right $ Output n t xs]
     S.KeepFactInHistory
@@ -119,8 +116,6 @@ statementOfScoped s
 
     Write n x
      -> S.Write n x
-    Push n x
-     -> S.Push n x
     Output n t xs
      -> S.Output n t xs
     KeepFactInHistory
@@ -178,9 +173,6 @@ instance (Pretty n, Pretty p) => Pretty (Scoped a n p) where
 
      Write n x
       -> text "write" <+> pretty n <+> text "=" <+> pretty x
-      <> text ";"
-     Push  n x
-      -> text "push" <+> pretty n <> text "(" <> pretty x <> text ")"
       <> text ";"
 
      Output n t xs

--- a/src/Icicle/Avalanche/Statement/Scoped.hs
+++ b/src/Icicle/Avalanche/Statement/Scoped.hs
@@ -43,7 +43,7 @@ data Scoped a n p
 data Binding a n p
  = InitAccumulator (S.Accumulator a n p)
  | Let             (Name n) (Exp  a n p)
- | Read            (Name n) (Name n) S.AccumulatorType ValType
+ | Read            (Name n) (Name n) ValType
 
 scopedOfStatement :: S.Statement a n p -> Scoped a n p
 scopedOfStatement s
@@ -81,9 +81,9 @@ bindsOfStatement s
     S.Let n x ss
      -> let bs = bindsOfStatement ss
         in  Left (Let n x) : bs
-    S.Read n acc at vt ss
+    S.Read n acc vt ss
      -> let bs = bindsOfStatement ss
-        in  Left (Read n acc at vt) : bs
+        in  Left (Read n acc vt) : bs
 
 
 statementOfScoped :: Scoped a n p -> S.Statement a n p
@@ -114,8 +114,8 @@ statementOfScoped s
               -> S.InitAccumulator acc rest
              Let n x
               -> S.Let n x rest
-             Read n acc at vt
-              -> S.Read n acc at vt rest
+             Read n acc vt
+              -> S.Read n acc vt rest
 
     Write n x
      -> S.Write n x
@@ -217,8 +217,8 @@ instance (Pretty n, Pretty p) => Pretty (Binding a n p) where
      Let n x
       -> text "let" <+> pretty n <+> text "=" <+> pretty x
       <> text ";"
-     Read n acc at vt
-      -> annotate (AnnType $ (pretty at) <+> (pretty vt)) (text "read")
+     Read n acc vt
+      -> annotate (AnnType (pretty vt)) (text "read")
                      <+> pretty n
                      <+> text "=" <+> pretty acc
       <> text ";"

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -52,8 +52,6 @@ pullLets statements
 
       Write n x
        -> pres x $ Write n
-      Push n x
-       -> pres x $ Push n
 
       Output n t xs
        -> presN xs $ Output n t
@@ -150,8 +148,6 @@ substXinS a_fresh name payload statements
 
       Write n x
        -> sub1 x $ Write n
-      Push  n x
-       -> sub1 x $ Push n
 
       Output n t xs
        -> subN xs $ Output n t
@@ -270,8 +266,6 @@ hasEffect statements
    -- unless we're explicitly ignoring this accumulator
    | Write n _ <- s
    = return $ not $ Set.member n ignore
-   | Push  n _ <- s
-   = return $ not $ Set.member n ignore
 
     -- Outputting is an effect
    | Output _ _ _       <- s
@@ -331,8 +325,6 @@ stmtFreeX statements
           -- Leaves that use expressions.
           -- Here, the name is an accumulator variable, so doesn't affect expressions.
           Write _ x
-           -> ret x
-          Push  _ x
            -> ret x
           Output _ _ xs
            -> return (Set.unions (fmap (freevars . fst) xs) `Set.union` subvars)
@@ -430,9 +422,6 @@ accumulatorUsed acc statements
    | Write n _ <- s
    , n == acc
    = return (AccumulatorUsage True False)
-   | Push  n _ <- s
-   , n == acc
-   = return (AccumulatorUsage True False)
 
    | Read _ n _ _ <- s
    , n == acc
@@ -451,9 +440,6 @@ killAccumulator acc xx statements
    , acc == acc'
    = return ((), Let n xx ss)
    | Write acc' _ <- s
-   , acc == acc'
-   = return ((), mempty)
-   | Push acc' _ <- s
    , acc == acc'
    = return ((), mempty)
    | LoadResumable acc' _ <- s
@@ -482,7 +468,6 @@ simpStatementExps a_fresh statements
       Let n x s             -> Let n (goX x) s
       ForeachInts n x1 x2 s -> ForeachInts n (goX x1) (goX x2) s
       Write n x             -> Write n (goX x)
-      Push  n x             -> Push n (goX x)
       InitAccumulator a s   -> InitAccumulator (goA a) s
       Output n t xs         -> Output n t (fmap (first goX) xs)
       _                     -> ss

--- a/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -48,8 +48,6 @@ constructor a_fresh statements
            -> ret $ InitAccumulator (Accumulator n vt (go x)) ss
           Write n x
            -> ret $ Write n (go x)
-          Push n x
-           -> ret $ Push n (go x)
           Output n t xts
            | xs <- fmap (go . fst) xts
            , ts <- fmap snd xts

--- a/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -44,8 +44,8 @@ constructor a_fresh statements
            -> ret $ Let n (go x) ss
           ForeachInts n from to ss
            -> ret $ ForeachInts n (go from) (go to) ss
-          InitAccumulator (Accumulator n at vt x) ss
-           -> ret $ InitAccumulator (Accumulator n at vt (go x)) ss
+          InitAccumulator (Accumulator n vt x) ss
+           -> ret $ InitAccumulator (Accumulator n vt (go x)) ss
           Write n x
            -> ret $ Write n (go x)
           Push n x

--- a/src/Icicle/Avalanche/Statement/Simp/ExpEnv.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/ExpEnv.hs
@@ -38,7 +38,7 @@ updateExpEnv s env
       ForeachFacts ns _ _ _
        -> foldr (clearFromExpEnv . fst) env ns
 
-      Read n _ _ _ _
+      Read n _ _ _
       -- we need to clear any mentions of "n" from the environment
        -> clearFromExpEnv n env
 

--- a/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Statement.hs
@@ -50,9 +50,6 @@ data Statement a n p
  -- | Update a resumable or windowed fold accumulator,
  -- with Exp : acc
  | Write  (Name n) (Exp a n p)
- -- | Push to a latest accumulator
- -- with Exp : elem
- | Push   (Name n) (Exp a n p)
 
  -- | Emit a value to output
  | Output OutputName ValType [(Exp a n p, ValType)]
@@ -146,8 +143,6 @@ transformUDStmt fun env statements
            -> Read n acc vt <$> go e' ss
           Write n x
            -> return $ Write n x
-          Push n x
-           -> return $ Push n x
           Output n t xs
            -> return $ Output n t xs
           KeepFactInHistory
@@ -195,8 +190,6 @@ foldStmt down up rjoin env res statements
            -> sub1 ss
           Write{}
            -> up e' res s
-          Push{}
-           -> up e' res s
           Output{}
            -> up e' res s
           KeepFactInHistory
@@ -233,8 +226,6 @@ instance TransformX Statement where
       -> Read <$> names n <*> names acc <*> pure vt <*> go ss
      Write n x
       -> Write <$> names n <*> exps x
-     Push n x
-      -> Push <$> names n <*> exps x
 
      Output n ty xs
       -> Output n ty <$> traverse (\(x,t) -> (,) <$> exps x <*> pure t) xs
@@ -300,9 +291,6 @@ instance (Pretty n, Pretty p) => Pretty (Statement a n p) where
 
      Write n x
       -> text "write" <+> pretty n <+> text "=" <+> pretty x <> line
-
-     Push n x
-      -> text "push" <+> pretty n <+> text "=" <+> pretty x
 
      Output n t xs
       -> text "output" <+> pretty n <+> pretty t <+> pretty xs

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -88,9 +88,6 @@ statementsToJava ss
     Write n x
      -> acc_name n <> " = " <> expToJava Unboxed x <> ";"
 
-    Push n x
-     -> "icicle.pushLatest(" <> acc_name n <> ", " <> expToJava Boxed x <> ");"
-
     Output n _ _
      -> "icicle.output(" <> stringy n <> ");"
 

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -111,24 +111,14 @@ statementsToJava ss
 bindingToJava :: (Show a, Show n, Pretty n, Ord n) => Binding (Annot a) n Prim -> Doc
 bindingToJava bb
  = case bb of
-    InitAccumulator acc@(S.Accumulator { S.accKind = S.Latest })
-     -> "Latest" <> angled (boxedType $ S.accValType acc)
-     <+> (acc_name $ S.accName acc)
-     <> " = icicle."
-     <> "makeLatest"
-     <> "(" <> expToJava Unboxed (S.accInit acc) <> ");"
-
-    InitAccumulator acc@(S.Accumulator { S.accKind = S.Mutable })
+    InitAccumulator acc@(S.Accumulator{})
      -> unboxedType (S.accValType acc) <+> (acc_name $ S.accName acc)
      <> " = " <> expToJava Unboxed (S.accInit acc) <> ";"
 
     Let n x
      -> local (typeOfExp x) n <> " = " <> expToJava Unboxed x <> ";"
 
-    Read n acc S.Latest t
-     -> local (ArrayT t) n <> " = icicle.readLatest(" <> acc_name acc <> ");"
-
-    Read n acc S.Mutable t
+    Read n acc t
      -> local t n <> " = " <> acc_name acc <> ";"
 
 

--- a/src/Icicle/Sea/FromAvalanche/Analysis.hs
+++ b/src/Icicle/Sea/FromAvalanche/Analysis.hs
@@ -50,7 +50,7 @@ factVarsOfStatement loopType stmt
                               factVarsOfStatement loopType ee
      ForeachInts  _ _ _ ss -> factVarsOfStatement loopType ss
      InitAccumulator _ ss  -> factVarsOfStatement loopType ss
-     Read _ _ _ _ ss       -> factVarsOfStatement loopType ss
+     Read _ _ _ ss         -> factVarsOfStatement loopType ss
      Write _ _             -> Nothing
      Push  _ _             -> Nothing
      LoadResumable _ _     -> Nothing
@@ -82,7 +82,7 @@ resumablesOfStatement stmt
      ForeachInts  _ _ _ ss -> resumablesOfStatement ss
      ForeachFacts _ _ _ ss -> resumablesOfStatement ss
      InitAccumulator  _ ss -> resumablesOfStatement ss
-     Read _ _ _ _ ss       -> resumablesOfStatement ss
+     Read _ _ _ ss         -> resumablesOfStatement ss
      Write _ _             -> Map.empty
      Push  _ _             -> Map.empty
      Output _ _ _          -> Map.empty
@@ -93,10 +93,10 @@ resumablesOfStatement stmt
 
 ------------------------------------------------------------------------
 
-accumsOfProgram :: Ord n => Program (Annot a) n Prim -> Map (Name n) (AccumulatorType, ValType)
+accumsOfProgram :: Ord n => Program (Annot a) n Prim -> Map (Name n) (ValType)
 accumsOfProgram = accumsOfStatement . statements
 
-accumsOfStatement :: Ord n => Statement (Annot a) n Prim -> Map (Name n) (AccumulatorType, ValType)
+accumsOfStatement :: Ord n => Statement (Annot a) n Prim -> Map (Name n) (ValType)
 accumsOfStatement stmt
  = case stmt of
      Block []              -> Map.empty
@@ -107,7 +107,7 @@ accumsOfStatement stmt
                               accumsOfStatement ee
      ForeachInts  _ _ _ ss -> accumsOfStatement ss
      ForeachFacts _ _ _ ss -> accumsOfStatement ss
-     Read _ _ _ _ ss       -> accumsOfStatement ss
+     Read _ _ _ ss         -> accumsOfStatement ss
      Write _ _             -> Map.empty
      Push  _ _             -> Map.empty
      LoadResumable _ _     -> Map.empty
@@ -115,16 +115,16 @@ accumsOfStatement stmt
      Output _ _ _          -> Map.empty
      KeepFactInHistory     -> Map.empty
 
-     InitAccumulator (Accumulator n at avt _) ss
-      -> Map.singleton n (at, avt) `Map.union`
+     InitAccumulator (Accumulator n avt _) ss
+      -> Map.singleton n avt `Map.union`
          accumsOfStatement ss
 
 ------------------------------------------------------------------------
 
-readsOfProgram :: Ord n => Program (Annot a) n Prim -> Map (Name n) (AccumulatorType, ValType)
+readsOfProgram :: Ord n => Program (Annot a) n Prim -> Map (Name n) (ValType)
 readsOfProgram = readsOfStatement . statements
 
-readsOfStatement :: Ord n => Statement (Annot a) n Prim -> Map (Name n) (AccumulatorType, ValType)
+readsOfStatement :: Ord n => Statement (Annot a) n Prim -> Map (Name n) (ValType)
 readsOfStatement stmt
  = case stmt of
      Block []              -> Map.empty
@@ -143,8 +143,8 @@ readsOfStatement stmt
      Output _ _ _          -> Map.empty
      KeepFactInHistory     -> Map.empty
 
-     Read n _ at vt ss
-      -> Map.singleton n (at, vt) `Map.union`
+     Read n _ vt ss
+      -> Map.singleton n vt `Map.union`
          readsOfStatement ss
 
 ------------------------------------------------------------------------
@@ -164,7 +164,7 @@ outputsOfStatement stmt
      ForeachInts  _ _ _ ss -> outputsOfStatement ss
      ForeachFacts _ _ _ ss -> outputsOfStatement ss
      InitAccumulator _ ss  -> outputsOfStatement ss
-     Read _ _ _ _ ss       -> outputsOfStatement ss
+     Read _ _ _ ss         -> outputsOfStatement ss
      Write _ _             -> Map.empty
      Push  _ _             -> Map.empty
      LoadResumable _ _     -> Map.empty

--- a/src/Icicle/Sea/FromAvalanche/Analysis.hs
+++ b/src/Icicle/Sea/FromAvalanche/Analysis.hs
@@ -52,7 +52,6 @@ factVarsOfStatement loopType stmt
      InitAccumulator _ ss  -> factVarsOfStatement loopType ss
      Read _ _ _ ss         -> factVarsOfStatement loopType ss
      Write _ _             -> Nothing
-     Push  _ _             -> Nothing
      LoadResumable _ _     -> Nothing
      SaveResumable _ _     -> Nothing
      Output _ _ _          -> Nothing
@@ -84,7 +83,6 @@ resumablesOfStatement stmt
      InitAccumulator  _ ss -> resumablesOfStatement ss
      Read _ _ _ ss         -> resumablesOfStatement ss
      Write _ _             -> Map.empty
-     Push  _ _             -> Map.empty
      Output _ _ _          -> Map.empty
      KeepFactInHistory     -> Map.empty
 
@@ -109,7 +107,6 @@ accumsOfStatement stmt
      ForeachFacts _ _ _ ss -> accumsOfStatement ss
      Read _ _ _ ss         -> accumsOfStatement ss
      Write _ _             -> Map.empty
-     Push  _ _             -> Map.empty
      LoadResumable _ _     -> Map.empty
      SaveResumable _ _     -> Map.empty
      Output _ _ _          -> Map.empty
@@ -137,7 +134,6 @@ readsOfStatement stmt
      ForeachFacts _ _ _ ss -> readsOfStatement ss
      InitAccumulator _ ss  -> readsOfStatement ss
      Write _ _             -> Map.empty
-     Push  _ _             -> Map.empty
      LoadResumable _ _     -> Map.empty
      SaveResumable _ _     -> Map.empty
      Output _ _ _          -> Map.empty
@@ -166,7 +162,6 @@ outputsOfStatement stmt
      InitAccumulator _ ss  -> outputsOfStatement ss
      Read _ _ _ ss         -> outputsOfStatement ss
      Write _ _             -> Map.empty
-     Push  _ _             -> Map.empty
      LoadResumable _ _     -> Map.empty
      SaveResumable _ _     -> Map.empty
      KeepFactInHistory     -> Map.empty

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -102,13 +102,9 @@ stateWordsOfProgram program
  + 2 * Map.size (resumablesOfProgram program)
 
 defOfAccumulator :: (Show n, Pretty n, Ord n)
-                  => (Name n, (AccumulatorType, ValType)) -> Doc
-defOfAccumulator (n, (at, vt))
- = case at of
-     Mutable
-      -> seaOfValType vt <+> seaOfName n <> semi
-     Latest
-      -> seaError "defOfAccumulator" (n, at, vt)
+                  => (Name n, ValType) -> Doc
+defOfAccumulator (n, vt)
+ = seaOfValType vt <+> seaOfName n <> semi
 
 defOfResumable :: (Show n, Pretty n, Ord n) => (Name n, ValType) -> Doc
 defOfResumable (n, t)
@@ -183,12 +179,11 @@ seaOfStatement stmt
                 ]
 
      InitAccumulator acc stmt'
-      | Accumulator n Mutable _ xx <- acc
+      | Accumulator n _ xx <- acc
       -> assign (seaOfName n) (seaOfExp xx) <> semi <> suffix "init" <> line
       <> seaOfStatement stmt'
 
-     Read n_val n_acc at _ stmt'
-      | Mutable <- at
+     Read n_val n_acc _ stmt'
       -> assign (seaOfName n_val) (seaOfName n_acc) <> semi <> suffix "read" <> line
       <> seaOfStatement stmt'
 

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -8,12 +8,12 @@ ok, avalanche is now on
 > - Avalanche:
 gen$date = DATE
 {
-  init acc$c$conv$13@{Mutable (Sum Error Int)} = Right 0@{(Sum Error Int)};
-  init acc$conv$30@{Mutable Buf (Sum Error Int)} = Buf 3 []@{Buf (Sum Error Int)};
+  init acc$c$conv$13@{(Sum Error Int)} = Right 0@{(Sum Error Int)};
+  init acc$conv$30@{Buf (Sum Error Int)} = Buf 3 []@{Buf (Sum Error Int)};
   load_resumable@{(Sum Error Int)} acc$c$conv$13;
   load_resumable@{Buf (Sum Error Int)} acc$conv$30;
   for_facts (gen$fact@{((Sum Error Int), DateTime)}) in new {
-    read@{Mutable Buf (Sum Error Int)} acc$conv$30 = acc$conv$30;
+    read@{Buf (Sum Error Int)} acc$conv$30 = acc$conv$30;
     let anf$3 = fst#@{(Sum Error Int), DateTime} gen$fact;
     write acc$conv$30 = Latest_push#@{(Sum Error Int)}
                         acc$conv$30 anf$3;
@@ -31,7 +31,7 @@ gen$date = DATE
         anf$5) {
       let elem$conv$11 = pair#@{(Sum Error Int) ((Sum Error Int), DateTime)} anf$4
                          gen$fact;
-      read@{Mutable (Sum Error Int)} acc$c$conv$13 = acc$c$conv$13;
+      read@{(Sum Error Int)} acc$c$conv$13 = acc$c$conv$13;
       let anf$7 = fst#@{(Sum Error Int), ((Sum Error Int), DateTime)} elem$conv$11;
       write acc$c$conv$13 = Sum_fold#@{(Error
 ,Int)}@{(Sum Error Int)}
@@ -57,8 +57,8 @@ gen$date = DATE
   }
   save_resumable@{(Sum Error Int)} acc$c$conv$13;
   save_resumable@{Buf (Sum Error Int)} acc$conv$30;
-  read@{Mutable (Sum Error Int)} c$conv$13 = acc$c$conv$13;
-  read@{Mutable Buf (Sum Error Int)} conv$30 = acc$conv$30;
+  read@{(Sum Error Int)} c$conv$13 = acc$c$conv$13;
+  read@{Buf (Sum Error Int)} conv$30 = acc$conv$30;
   let conv$35 = Sum_fold#@{(Error
 ,Int)}@{(Sum Error (Int, Array (Sum Error Int)))} (
                 \reify$10$conv$23@{Error} 
@@ -85,10 +85,10 @@ gen$date = DATE
 > - Avalanche:
 gen$date = DATE
 {
-  init acc$conv$2@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} = Map []@{Map DateTime (Buf ((Sum Error Int), DateTime))};
+  init acc$conv$2@{Map DateTime (Buf ((Sum Error Int), DateTime))} = Map []@{Map DateTime (Buf ((Sum Error Int), DateTime))};
   load_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
   for_facts (gen$fact@{((Sum Error Int), DateTime)}) in new {
-    read@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2 = acc$conv$2;
+    read@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2 = acc$conv$2;
     let anf$0 = Latest_push#@{((Sum Error Int), DateTime)}
                 (Buf 2 []@{Buf ((Sum Error Int), DateTime)}) gen$fact;
     let anf$1 = snd#@{(Sum Error Int), DateTime} gen$fact;
@@ -100,7 +100,7 @@ gen$date = DATE
                        acc$conv$2;
   }
   save_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
-  read@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} conv$2 = acc$conv$2;
+  read@{Map DateTime (Buf ((Sum Error Int), DateTime))} conv$2 = acc$conv$2;
   let conv$3 = Map_fold#@{(DateTime
 ,Buf ((Sum Error Int), DateTime))}@{(Sum Error (Map DateTime Int))} (
                \conv$4@{(Sum Error (Map DateTime Int))} 

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -8,10 +8,10 @@ ok, flatten is now on
 > - Flattened:
 gen$date = DATE
 {
-  init acc$c$conv$13$simp$4@{Mutable Bool} = True@{Bool};
-  init acc$c$conv$13$simp$5@{Mutable Error} = ExceptTombstone@{Error};
-  init acc$c$conv$13$simp$6@{Mutable Int} = 0@{Int};
-  init acc$conv$30@{Mutable Buf (Sum Error Int)} = Buf 3 []@{Buf (Sum Error Int)};
+  init acc$c$conv$13$simp$4@{Bool} = True@{Bool};
+  init acc$c$conv$13$simp$5@{Error} = ExceptTombstone@{Error};
+  init acc$c$conv$13$simp$6@{Int} = 0@{Int};
+  init acc$conv$30@{Buf (Sum Error Int)} = Buf 3 []@{Buf (Sum Error Int)};
   load_resumable@{Bool} acc$c$conv$13$simp$4;
   load_resumable@{Error} acc$c$conv$13$simp$5;
   load_resumable@{Int} acc$c$conv$13$simp$6;
@@ -20,7 +20,7 @@ gen$date = DATE
              gen$fact$simp$62$simp$65@{Error},
              gen$fact$simp$62$simp$66@{Int},
              gen$fact$simp$63@{DateTime}) in new {
-    read@{Mutable Buf (Sum Error Int)} acc$conv$30 = acc$conv$30;
+    read@{Buf (Sum Error Int)} acc$conv$30 = acc$conv$30;
     let simp$69 = Sum_pack#@{Error, Int}
                   gen$fact$simp$62$simp$64
                   gen$fact$simp$62$simp$65
@@ -28,8 +28,8 @@ gen$date = DATE
     let flat$0 = Buf_push#@{(Sum Error Int)}
                  acc$conv$30 simp$69;
     write acc$conv$30 = flat$0;
-    init flat$1$simp$7@{Mutable Bool} = False@{Bool};
-    init flat$1$simp$9@{Mutable Bool} = False@{Bool};
+    init flat$1$simp$7@{Bool} = False@{Bool};
+    init flat$1$simp$9@{Bool} = False@{Bool};
     if (gen$fact$simp$62$simp$64) {
       write flat$1$simp$7 = True@{Bool};
       let simp$79 = gt#@{Int}
@@ -39,9 +39,9 @@ gen$date = DATE
       write flat$1$simp$7 = False@{Bool};
       write flat$1$simp$9 = False@{Bool};
     }
-    read@{Mutable Bool} flat$1$simp$10 = flat$1$simp$7;
-    read@{Mutable Bool} flat$1$simp$12 = flat$1$simp$9;
-    init flat$2@{Mutable Bool} = False@{Bool};
+    read@{Bool} flat$1$simp$10 = flat$1$simp$7;
+    read@{Bool} flat$1$simp$12 = flat$1$simp$9;
+    init flat$2@{Bool} = False@{Bool};
     if (flat$1$simp$10) {
       write flat$2 = flat$1$simp$12;
     } 
@@ -49,18 +49,18 @@ gen$date = DATE
       write flat$2 = True@{Bool};
     } 
     
-    read@{Mutable Bool} flat$2 = flat$2;
+    read@{Bool} flat$2 = flat$2;
     if (flat$2) {
-      read@{Mutable Bool} acc$c$conv$13$simp$13 = acc$c$conv$13$simp$4;
-      read@{Mutable Error} acc$c$conv$13$simp$14 = acc$c$conv$13$simp$5;
-      read@{Mutable Int} acc$c$conv$13$simp$15 = acc$c$conv$13$simp$6;
-      init flat$3$simp$16@{Mutable Bool} = False@{Bool};
-      init flat$3$simp$17@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$3$simp$18@{Mutable Int} = 0@{Int};
+      read@{Bool} acc$c$conv$13$simp$13 = acc$c$conv$13$simp$4;
+      read@{Error} acc$c$conv$13$simp$14 = acc$c$conv$13$simp$5;
+      read@{Int} acc$c$conv$13$simp$15 = acc$c$conv$13$simp$6;
+      init flat$3$simp$16@{Bool} = False@{Bool};
+      init flat$3$simp$17@{Error} = ExceptTombstone@{Error};
+      init flat$3$simp$18@{Int} = 0@{Int};
       if (gen$fact$simp$62$simp$64) {
-        init flat$6$simp$19@{Mutable Bool} = False@{Bool};
-        init flat$6$simp$20@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$6$simp$21@{Mutable Int} = 0@{Int};
+        init flat$6$simp$19@{Bool} = False@{Bool};
+        init flat$6$simp$20@{Error} = ExceptTombstone@{Error};
+        init flat$6$simp$21@{Int} = 0@{Int};
         if (acc$c$conv$13$simp$13) {
           write flat$6$simp$19 = True@{Bool};
           let simp$100 = add#@{Int}
@@ -72,12 +72,12 @@ gen$date = DATE
           write flat$6$simp$20 = acc$c$conv$13$simp$14;
           write flat$6$simp$21 = 0@{Int};
         }
-        read@{Mutable Bool} flat$6$simp$22 = flat$6$simp$19;
-        read@{Mutable Error} flat$6$simp$23 = flat$6$simp$20;
-        read@{Mutable Int} flat$6$simp$24 = flat$6$simp$21;
-        init flat$7$simp$25@{Mutable Bool} = False@{Bool};
-        init flat$7$simp$26@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$7$simp$27@{Mutable Int} = 0@{Int};
+        read@{Bool} flat$6$simp$22 = flat$6$simp$19;
+        read@{Error} flat$6$simp$23 = flat$6$simp$20;
+        read@{Int} flat$6$simp$24 = flat$6$simp$21;
+        init flat$7$simp$25@{Bool} = False@{Bool};
+        init flat$7$simp$26@{Error} = ExceptTombstone@{Error};
+        init flat$7$simp$27@{Int} = 0@{Int};
         if (flat$6$simp$22) {
           write flat$7$simp$25 = True@{Bool};
           write flat$7$simp$26 = ExceptTombstone@{Error};
@@ -87,9 +87,9 @@ gen$date = DATE
           write flat$7$simp$26 = flat$6$simp$23;
           write flat$7$simp$27 = 0@{Int};
         }
-        read@{Mutable Bool} flat$7$simp$28 = flat$7$simp$25;
-        read@{Mutable Error} flat$7$simp$29 = flat$7$simp$26;
-        read@{Mutable Int} flat$7$simp$30 = flat$7$simp$27;
+        read@{Bool} flat$7$simp$28 = flat$7$simp$25;
+        read@{Error} flat$7$simp$29 = flat$7$simp$26;
+        read@{Int} flat$7$simp$30 = flat$7$simp$27;
         write flat$3$simp$16 = flat$7$simp$28;
         write flat$3$simp$17 = flat$7$simp$29;
         write flat$3$simp$18 = flat$7$simp$30;
@@ -98,9 +98,9 @@ gen$date = DATE
         write flat$3$simp$17 = gen$fact$simp$62$simp$65;
         write flat$3$simp$18 = 0@{Int};
       }
-      read@{Mutable Bool} flat$3$simp$31 = flat$3$simp$16;
-      read@{Mutable Error} flat$3$simp$32 = flat$3$simp$17;
-      read@{Mutable Int} flat$3$simp$33 = flat$3$simp$18;
+      read@{Bool} flat$3$simp$31 = flat$3$simp$16;
+      read@{Error} flat$3$simp$32 = flat$3$simp$17;
+      read@{Int} flat$3$simp$33 = flat$3$simp$18;
       write acc$c$conv$13$simp$4 = flat$3$simp$31;
       write acc$c$conv$13$simp$5 = flat$3$simp$32;
       write acc$c$conv$13$simp$6 = flat$3$simp$33;
@@ -110,16 +110,16 @@ gen$date = DATE
   save_resumable@{Error} acc$c$conv$13$simp$5;
   save_resumable@{Int} acc$c$conv$13$simp$6;
   save_resumable@{Buf (Sum Error Int)} acc$conv$30;
-  read@{Mutable Bool} c$conv$13$simp$34 = acc$c$conv$13$simp$4;
-  read@{Mutable Error} c$conv$13$simp$35 = acc$c$conv$13$simp$5;
-  read@{Mutable Int} c$conv$13$simp$36 = acc$c$conv$13$simp$6;
-  read@{Mutable Buf (Sum Error Int)} conv$30 = acc$conv$30;
-  init flat$16$simp$37@{Mutable Bool} = False@{Bool};
-  init flat$16$simp$38@{Mutable Error} = ExceptTombstone@{Error};
-  init flat$16$simp$39$simp$40@{Mutable Int} = 0@{Int};
-  init flat$16$simp$39$simp$41$simp$45@{Mutable Array Bool} = []@{Array Bool};
-  init flat$16$simp$39$simp$41$simp$46@{Mutable Array Error} = []@{Array Error};
-  init flat$16$simp$39$simp$41$simp$47@{Mutable Array Int} = []@{Array Int};
+  read@{Bool} c$conv$13$simp$34 = acc$c$conv$13$simp$4;
+  read@{Error} c$conv$13$simp$35 = acc$c$conv$13$simp$5;
+  read@{Int} c$conv$13$simp$36 = acc$c$conv$13$simp$6;
+  read@{Buf (Sum Error Int)} conv$30 = acc$conv$30;
+  init flat$16$simp$37@{Bool} = False@{Bool};
+  init flat$16$simp$38@{Error} = ExceptTombstone@{Error};
+  init flat$16$simp$39$simp$40@{Int} = 0@{Int};
+  init flat$16$simp$39$simp$41$simp$45@{Array Bool} = []@{Array Bool};
+  init flat$16$simp$39$simp$41$simp$46@{Array Error} = []@{Array Error};
+  init flat$16$simp$39$simp$41$simp$47@{Array Int} = []@{Array Int};
   if (c$conv$13$simp$34) {
     let flat$19 = Buf_read#@{(Sum Error Int)}
                   conv$30;
@@ -146,12 +146,12 @@ gen$date = DATE
     write flat$16$simp$39$simp$41$simp$46 = []@{Array Error};
     write flat$16$simp$39$simp$41$simp$47 = []@{Array Int};
   }
-  read@{Mutable Bool} flat$16$simp$48 = flat$16$simp$37;
-  read@{Mutable Error} flat$16$simp$49 = flat$16$simp$38;
-  read@{Mutable Int} flat$16$simp$50$simp$51 = flat$16$simp$39$simp$40;
-  read@{Mutable Array Bool} flat$16$simp$50$simp$52$simp$53 = flat$16$simp$39$simp$41$simp$45;
-  read@{Mutable Array Error} flat$16$simp$50$simp$52$simp$54 = flat$16$simp$39$simp$41$simp$46;
-  read@{Mutable Array Int} flat$16$simp$50$simp$52$simp$55 = flat$16$simp$39$simp$41$simp$47;
+  read@{Bool} flat$16$simp$48 = flat$16$simp$37;
+  read@{Error} flat$16$simp$49 = flat$16$simp$38;
+  read@{Int} flat$16$simp$50$simp$51 = flat$16$simp$39$simp$40;
+  read@{Array Bool} flat$16$simp$50$simp$52$simp$53 = flat$16$simp$39$simp$41$simp$45;
+  read@{Array Error} flat$16$simp$50$simp$52$simp$54 = flat$16$simp$39$simp$41$simp$46;
+  read@{Array Int} flat$16$simp$50$simp$52$simp$55 = flat$16$simp$39$simp$41$simp$47;
   let simp$241 = Array_sum#@{Error, Int}
                  flat$16$simp$50$simp$52$simp$53
                  flat$16$simp$50$simp$52$simp$54
@@ -170,13 +170,13 @@ gen$date = DATE
 > - Flattened:
 gen$date = DATE
 {
-  init acc$conv$2@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} = Map []@{Map DateTime (Buf ((Sum Error Int), DateTime))};
+  init acc$conv$2@{Map DateTime (Buf ((Sum Error Int), DateTime))} = Map []@{Map DateTime (Buf ((Sum Error Int), DateTime))};
   load_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
   for_facts (gen$fact$simp$108$simp$110@{Bool},
              gen$fact$simp$108$simp$111@{Error},
              gen$fact$simp$108$simp$112@{Int},
              gen$fact$simp$109@{DateTime}) in new {
-    read@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2 = acc$conv$2;
+    read@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2 = acc$conv$2;
     let simp$115 = Sum_pack#@{Error, Int}
                    gen$fact$simp$108$simp$110
                    gen$fact$simp$108$simp$111
@@ -185,17 +185,17 @@ gen$date = DATE
                    gen$fact$simp$109;
     let flat$0 = Buf_push#@{((Sum Error Int), DateTime)}
                  (Buf 2 []@{Buf ((Sum Error Int), DateTime)}) simp$116;
-    init flat$1@{Mutable Bool} = False@{Bool};
-    init flat$2@{Mutable Array DateTime} = Map_unpack_keys#@{DateTime Buf ((Sum Error Int), DateTime)}
+    init flat$1@{Bool} = False@{Bool};
+    init flat$2@{Array DateTime} = Map_unpack_keys#@{DateTime Buf ((Sum Error Int), DateTime)}
                   acc$conv$2;
-    init flat$3@{Mutable Array (Buf ((Sum Error Int), DateTime))} = Map_unpack_values#@{DateTime Buf ((Sum Error Int), DateTime)}
+    init flat$3@{Array (Buf ((Sum Error Int), DateTime))} = Map_unpack_values#@{DateTime Buf ((Sum Error Int), DateTime)}
                   acc$conv$2;
-    read@{Mutable Array DateTime} flat$2 = flat$2;
+    read@{Array DateTime} flat$2 = flat$2;
     let flat$4 = Array_length#@{DateTime}
                  flat$2;
     foreach (flat$5 in 0@{Int}..flat$4) {
-      read@{Mutable Array DateTime} flat$2 = flat$2;
-      read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
+      read@{Array DateTime} flat$2 = flat$2;
+      read@{Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
       let simp$1 = unsafe_Array_index#@{DateTime}
                    flat$2 flat$5;
       if (eq#@{DateTime} simp$1
@@ -209,76 +209,76 @@ gen$date = DATE
         write flat$1 = True@{Bool};
       }
     }
-    read@{Mutable Bool} flat$1 = flat$1;
+    read@{Bool} flat$1 = flat$1;
     if (flat$1) {
       
     } else {
-      read@{Mutable Array DateTime} flat$9 = flat$2;
+      read@{Array DateTime} flat$9 = flat$2;
       let simp$4 = Array_length#@{DateTime}
                    flat$9;
       let simp$5 = add#@{Int} simp$4 (1@{Int});
-      init flat$8@{Mutable Array DateTime} = unsafe_Array_create#@{DateTime}
+      init flat$8@{Array DateTime} = unsafe_Array_create#@{DateTime}
                     simp$5;
       foreach (flat$10 in 0@{Int}..Array_length#@{DateTime}
                              flat$9) {
-        read@{Mutable Array DateTime} flat$8 = flat$8;
+        read@{Array DateTime} flat$8 = flat$8;
         let simp$7 = unsafe_Array_index#@{DateTime}
                      flat$9 flat$10;
         write flat$8 = Array_put#@{DateTime} flat$8
                        flat$10 simp$7;
       }
-      read@{Mutable Array DateTime} flat$8 = flat$8;
+      read@{Array DateTime} flat$8 = flat$8;
       write flat$8 = Array_put#@{DateTime} flat$8
                      simp$4 gen$fact$simp$109;
-      read@{Mutable Array DateTime} flat$8 = flat$8;
+      read@{Array DateTime} flat$8 = flat$8;
       write flat$2 = flat$8;
-      read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$12 = flat$3;
+      read@{Array (Buf ((Sum Error Int), DateTime))} flat$12 = flat$3;
       let simp$12 = Array_length#@{Buf ((Sum Error Int), DateTime)}
                     flat$12;
       let simp$13 = add#@{Int} simp$12 (1@{Int});
-      init flat$11@{Mutable Array (Buf ((Sum Error Int), DateTime))} = unsafe_Array_create#@{Buf ((Sum Error Int), DateTime)}
+      init flat$11@{Array (Buf ((Sum Error Int), DateTime))} = unsafe_Array_create#@{Buf ((Sum Error Int), DateTime)}
                      simp$13;
       foreach (flat$13 in 0@{Int}..Array_length#@{Buf ((Sum Error Int), DateTime)}
                              flat$12) {
-        read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
+        read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
         let simp$15 = unsafe_Array_index#@{Buf ((Sum Error Int), DateTime)}
                       flat$12 flat$13;
         write flat$11 = Array_put#@{Buf ((Sum Error Int), DateTime)}
                         flat$11 flat$13 simp$15;
       }
-      read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
+      read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
       write flat$11 = Array_put#@{Buf ((Sum Error Int), DateTime)}
                       flat$11 simp$12 flat$0;
-      read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
+      read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
       write flat$3 = flat$11;
     }
-    read@{Mutable Array DateTime} flat$2 = flat$2;
-    read@{Mutable Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
+    read@{Array DateTime} flat$2 = flat$2;
+    read@{Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
     let flat$14 = Map_pack#@{DateTime Buf ((Sum Error Int), DateTime)} flat$2
                   flat$3;
     write acc$conv$2 = flat$14;
   }
   save_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
-  read@{Mutable Map DateTime (Buf ((Sum Error Int), DateTime))} conv$2 = acc$conv$2;
+  read@{Map DateTime (Buf ((Sum Error Int), DateTime))} conv$2 = acc$conv$2;
   let flat$15 = Map_unpack_keys#@{DateTime Buf ((Sum Error Int), DateTime)}
                 conv$2;
   let flat$16 = Map_unpack_values#@{DateTime Buf ((Sum Error Int), DateTime)}
                 conv$2;
-  init flat$20$simp$40@{Mutable Bool} = True@{Bool};
-  init flat$20$simp$41@{Mutable Error} = ExceptTombstone@{Error};
-  init flat$20$simp$42@{Mutable Map DateTime Int} = Map []@{Map DateTime Int};
+  init flat$20$simp$40@{Bool} = True@{Bool};
+  init flat$20$simp$41@{Error} = ExceptTombstone@{Error};
+  init flat$20$simp$42@{Map DateTime Int} = Map []@{Map DateTime Int};
   foreach (flat$21 in 0@{Int}..Array_length#@{DateTime}
                          flat$15) {
-    read@{Mutable Bool} flat$20$simp$43 = flat$20$simp$40;
-    read@{Mutable Error} flat$20$simp$44 = flat$20$simp$41;
-    read@{Mutable Map DateTime Int} flat$20$simp$45 = flat$20$simp$42;
+    read@{Bool} flat$20$simp$43 = flat$20$simp$40;
+    read@{Error} flat$20$simp$44 = flat$20$simp$41;
+    read@{Map DateTime Int} flat$20$simp$45 = flat$20$simp$42;
     let conv$26 = unsafe_Array_index#@{DateTime}
                   flat$15 flat$21;
     let conv$5 = unsafe_Array_index#@{Buf ((Sum Error Int), DateTime)}
                  flat$16 flat$21;
-    init flat$23$simp$46@{Mutable Bool} = False@{Bool};
-    init flat$23$simp$47@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$23$simp$48@{Mutable Map DateTime Int} = Map []@{Map DateTime Int};
+    init flat$23$simp$46@{Bool} = False@{Bool};
+    init flat$23$simp$47@{Error} = ExceptTombstone@{Error};
+    init flat$23$simp$48@{Map DateTime Int} = Map []@{Map DateTime Int};
     if (flat$20$simp$43) {
       let flat$26 = Buf_read#@{((Sum Error Int), DateTime)}
                     conv$5;
@@ -286,26 +286,26 @@ gen$date = DATE
                      flat$26;
       let conv$6$simp$103 = fst#@{Array (Sum Error Int), Array DateTime}
                             simp$130;
-      init flat$27$simp$50$simp$54$simp$56@{Mutable Bool} = True@{Bool};
-      init flat$27$simp$50$simp$54$simp$57@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$27$simp$50$simp$54$simp$58@{Mutable Int} = 0@{Int};
+      init flat$27$simp$50$simp$54$simp$56@{Bool} = True@{Bool};
+      init flat$27$simp$50$simp$54$simp$57@{Error} = ExceptTombstone@{Error};
+      init flat$27$simp$50$simp$54$simp$58@{Int} = 0@{Int};
       foreach (flat$44 in 0@{Int}..Array_length#@{(Sum Error Int)}
                              conv$6$simp$103) {
-        read@{Mutable Bool} flat$27$simp$60$simp$64$simp$66 = flat$27$simp$50$simp$54$simp$56;
-        read@{Mutable Error} flat$27$simp$60$simp$64$simp$67 = flat$27$simp$50$simp$54$simp$57;
-        read@{Mutable Int} flat$27$simp$60$simp$64$simp$68 = flat$27$simp$50$simp$54$simp$58;
+        read@{Bool} flat$27$simp$60$simp$64$simp$66 = flat$27$simp$50$simp$54$simp$56;
+        read@{Error} flat$27$simp$60$simp$64$simp$67 = flat$27$simp$50$simp$54$simp$57;
+        read@{Int} flat$27$simp$60$simp$64$simp$68 = flat$27$simp$50$simp$54$simp$58;
         let v$inline$0$conv$13 = unsafe_Array_index#@{(Sum Error Int)}
                                  conv$6$simp$103 flat$44;
-        init flat$46$simp$69@{Mutable Bool} = False@{Bool};
-        init flat$46$simp$70@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$46$simp$71@{Mutable Int} = 0@{Int};
+        init flat$46$simp$69@{Bool} = False@{Bool};
+        init flat$46$simp$70@{Error} = ExceptTombstone@{Error};
+        init flat$46$simp$71@{Int} = 0@{Int};
         if (Sum_isRight#@{Error, Int}
             v$inline$0$conv$13) {
           let flat$48 = unsafe_Sum_right#@{Error, Int}
                         v$inline$0$conv$13;
-          init flat$49$simp$72@{Mutable Bool} = False@{Bool};
-          init flat$49$simp$73@{Mutable Error} = ExceptTombstone@{Error};
-          init flat$49$simp$74@{Mutable Int} = 0@{Int};
+          init flat$49$simp$72@{Bool} = False@{Bool};
+          init flat$49$simp$73@{Error} = ExceptTombstone@{Error};
+          init flat$49$simp$74@{Int} = 0@{Int};
           if (flat$27$simp$60$simp$64$simp$66) {
             let simp$164 = add#@{Int} flat$48
                            flat$27$simp$60$simp$64$simp$68;
@@ -317,9 +317,9 @@ gen$date = DATE
             write flat$49$simp$73 = flat$27$simp$60$simp$64$simp$67;
             write flat$49$simp$74 = 0@{Int};
           }
-          read@{Mutable Bool} flat$49$simp$75 = flat$49$simp$72;
-          read@{Mutable Error} flat$49$simp$76 = flat$49$simp$73;
-          read@{Mutable Int} flat$49$simp$77 = flat$49$simp$74;
+          read@{Bool} flat$49$simp$75 = flat$49$simp$72;
+          read@{Error} flat$49$simp$76 = flat$49$simp$73;
+          read@{Int} flat$49$simp$77 = flat$49$simp$74;
           write flat$46$simp$69 = flat$49$simp$75;
           write flat$46$simp$70 = flat$49$simp$76;
           write flat$46$simp$71 = flat$49$simp$77;
@@ -330,31 +330,31 @@ gen$date = DATE
           write flat$46$simp$70 = flat$47;
           write flat$46$simp$71 = 0@{Int};
         }
-        read@{Mutable Bool} flat$46$simp$78 = flat$46$simp$69;
-        read@{Mutable Error} flat$46$simp$79 = flat$46$simp$70;
-        read@{Mutable Int} flat$46$simp$80 = flat$46$simp$71;
+        read@{Bool} flat$46$simp$78 = flat$46$simp$69;
+        read@{Error} flat$46$simp$79 = flat$46$simp$70;
+        read@{Int} flat$46$simp$80 = flat$46$simp$71;
         write flat$27$simp$50$simp$54$simp$56 = flat$46$simp$78;
         write flat$27$simp$50$simp$54$simp$57 = flat$46$simp$79;
         write flat$27$simp$50$simp$54$simp$58 = flat$46$simp$80;
       }
-      read@{Mutable Bool} flat$27$simp$82$simp$86$simp$88 = flat$27$simp$50$simp$54$simp$56;
-      read@{Mutable Error} flat$27$simp$82$simp$86$simp$89 = flat$27$simp$50$simp$54$simp$57;
-      read@{Mutable Int} flat$27$simp$82$simp$86$simp$90 = flat$27$simp$50$simp$54$simp$58;
-      init flat$28$simp$91@{Mutable Bool} = False@{Bool};
-      init flat$28$simp$92@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$28$simp$93@{Mutable Map DateTime Int} = Map []@{Map DateTime Int};
+      read@{Bool} flat$27$simp$82$simp$86$simp$88 = flat$27$simp$50$simp$54$simp$56;
+      read@{Error} flat$27$simp$82$simp$86$simp$89 = flat$27$simp$50$simp$54$simp$57;
+      read@{Int} flat$27$simp$82$simp$86$simp$90 = flat$27$simp$50$simp$54$simp$58;
+      init flat$28$simp$91@{Bool} = False@{Bool};
+      init flat$28$simp$92@{Error} = ExceptTombstone@{Error};
+      init flat$28$simp$93@{Map DateTime Int} = Map []@{Map DateTime Int};
       if (flat$27$simp$82$simp$86$simp$88) {
-        init flat$31@{Mutable Bool} = False@{Bool};
-        init flat$32@{Mutable Array DateTime} = Map_unpack_keys#@{DateTime Int}
+        init flat$31@{Bool} = False@{Bool};
+        init flat$32@{Array DateTime} = Map_unpack_keys#@{DateTime Int}
                        flat$20$simp$45;
-        init flat$33@{Mutable Array Int} = Map_unpack_values#@{DateTime Int}
+        init flat$33@{Array Int} = Map_unpack_values#@{DateTime Int}
                        flat$20$simp$45;
-        read@{Mutable Array DateTime} flat$32 = flat$32;
+        read@{Array DateTime} flat$32 = flat$32;
         let flat$34 = Array_length#@{DateTime}
                       flat$32;
         foreach (flat$35 in 0@{Int}..flat$34) {
-          read@{Mutable Array DateTime} flat$32 = flat$32;
-          read@{Mutable Array Int} flat$33 = flat$33;
+          read@{Array DateTime} flat$32 = flat$32;
+          read@{Array Int} flat$33 = flat$33;
           let simp$23 = unsafe_Array_index#@{DateTime}
                         flat$32 flat$35;
           if (eq#@{DateTime} simp$23 conv$26) {
@@ -365,52 +365,52 @@ gen$date = DATE
             write flat$31 = True@{Bool};
           }
         }
-        read@{Mutable Bool} flat$31 = flat$31;
+        read@{Bool} flat$31 = flat$31;
         if (flat$31) {
           
         } else {
-          read@{Mutable Array DateTime} flat$38 = flat$32;
+          read@{Array DateTime} flat$38 = flat$32;
           let simp$26 = Array_length#@{DateTime}
                         flat$38;
           let simp$27 = add#@{Int} simp$26 (1@{Int});
-          init flat$37@{Mutable Array DateTime} = unsafe_Array_create#@{DateTime}
+          init flat$37@{Array DateTime} = unsafe_Array_create#@{DateTime}
                          simp$27;
           foreach (flat$39 in 0@{Int}..Array_length#@{DateTime}
                                  flat$38) {
-            read@{Mutable Array DateTime} flat$37 = flat$37;
+            read@{Array DateTime} flat$37 = flat$37;
             let simp$29 = unsafe_Array_index#@{DateTime}
                           flat$38 flat$39;
             write flat$37 = Array_put#@{DateTime}
                             flat$37 flat$39 simp$29;
           }
-          read@{Mutable Array DateTime} flat$37 = flat$37;
+          read@{Array DateTime} flat$37 = flat$37;
           write flat$37 = Array_put#@{DateTime}
                           flat$37 simp$26 conv$26;
-          read@{Mutable Array DateTime} flat$37 = flat$37;
+          read@{Array DateTime} flat$37 = flat$37;
           write flat$32 = flat$37;
-          read@{Mutable Array Int} flat$41 = flat$33;
+          read@{Array Int} flat$41 = flat$33;
           let simp$34 = Array_length#@{Int}
                         flat$41;
           let simp$35 = add#@{Int} simp$34 (1@{Int});
-          init flat$40@{Mutable Array Int} = unsafe_Array_create#@{Int}
+          init flat$40@{Array Int} = unsafe_Array_create#@{Int}
                          simp$35;
           foreach (flat$42 in 0@{Int}..Array_length#@{Int}
                                  flat$41) {
-            read@{Mutable Array Int} flat$40 = flat$40;
+            read@{Array Int} flat$40 = flat$40;
             let simp$37 = unsafe_Array_index#@{Int}
                           flat$41 flat$42;
             write flat$40 = Array_put#@{Int}
                             flat$40 flat$42 simp$37;
           }
-          read@{Mutable Array Int} flat$40 = flat$40;
+          read@{Array Int} flat$40 = flat$40;
           write flat$40 = Array_put#@{Int}
                           flat$40 simp$34
                           flat$27$simp$82$simp$86$simp$90;
-          read@{Mutable Array Int} flat$40 = flat$40;
+          read@{Array Int} flat$40 = flat$40;
           write flat$33 = flat$40;
         }
-        read@{Mutable Array DateTime} flat$32 = flat$32;
-        read@{Mutable Array Int} flat$33 = flat$33;
+        read@{Array DateTime} flat$32 = flat$32;
+        read@{Array Int} flat$33 = flat$33;
         let flat$43 = Map_pack#@{DateTime Int} flat$32
                       flat$33;
         write flat$28$simp$91 = True@{Bool};
@@ -421,9 +421,9 @@ gen$date = DATE
         write flat$28$simp$92 = flat$27$simp$82$simp$86$simp$89;
         write flat$28$simp$93 = Map []@{Map DateTime Int};
       }
-      read@{Mutable Bool} flat$28$simp$94 = flat$28$simp$91;
-      read@{Mutable Error} flat$28$simp$95 = flat$28$simp$92;
-      read@{Mutable Map DateTime Int} flat$28$simp$96 = flat$28$simp$93;
+      read@{Bool} flat$28$simp$94 = flat$28$simp$91;
+      read@{Error} flat$28$simp$95 = flat$28$simp$92;
+      read@{Map DateTime Int} flat$28$simp$96 = flat$28$simp$93;
       write flat$23$simp$46 = flat$28$simp$94;
       write flat$23$simp$47 = flat$28$simp$95;
       write flat$23$simp$48 = flat$28$simp$96;
@@ -432,16 +432,16 @@ gen$date = DATE
       write flat$23$simp$47 = flat$20$simp$44;
       write flat$23$simp$48 = Map []@{Map DateTime Int};
     }
-    read@{Mutable Bool} flat$23$simp$97 = flat$23$simp$46;
-    read@{Mutable Error} flat$23$simp$98 = flat$23$simp$47;
-    read@{Mutable Map DateTime Int} flat$23$simp$99 = flat$23$simp$48;
+    read@{Bool} flat$23$simp$97 = flat$23$simp$46;
+    read@{Error} flat$23$simp$98 = flat$23$simp$47;
+    read@{Map DateTime Int} flat$23$simp$99 = flat$23$simp$48;
     write flat$20$simp$40 = flat$23$simp$97;
     write flat$20$simp$41 = flat$23$simp$98;
     write flat$20$simp$42 = flat$23$simp$99;
   }
-  read@{Mutable Bool} flat$20$simp$100 = flat$20$simp$40;
-  read@{Mutable Error} flat$20$simp$101 = flat$20$simp$41;
-  read@{Mutable Map DateTime Int} flat$20$simp$102 = flat$20$simp$42;
+  read@{Bool} flat$20$simp$100 = flat$20$simp$40;
+  read@{Error} flat$20$simp$101 = flat$20$simp$41;
+  read@{Map DateTime Int} flat$20$simp$102 = flat$20$simp$42;
   output@{(Sum Error (Map DateTime Int))} repl (flat$20$simp$100@{Bool},
                flat$20$simp$101@{Error},
                flat$20$simp$102@{Map DateTime Int});

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -26,17 +26,17 @@ ok, c is now on
 > - Flattened:
 gen$date = DATE
 {
-  init acc$s$conv$13$simp$44@{Mutable Bool} = True@{Bool};
-  init acc$s$conv$13$simp$45@{Mutable Error} = ExceptTombstone@{Error};
-  init acc$s$conv$13$simp$46@{Mutable Double} = 0.0@{Double};
-  init acc$c$conv$26$simp$47@{Mutable Bool} = True@{Bool};
-  init acc$c$conv$26$simp$48@{Mutable Error} = ExceptTombstone@{Error};
-  init acc$c$conv$26$simp$49@{Mutable Double} = 0.0@{Double};
-  init acc$a$conv$66$simp$50@{Mutable Bool} = True@{Bool};
-  init acc$a$conv$66$simp$51@{Mutable Error} = ExceptTombstone@{Error};
-  init acc$a$conv$66$simp$52$simp$53$simp$55@{Mutable Double} = 0.0@{Double};
-  init acc$a$conv$66$simp$52$simp$53$simp$56@{Mutable Double} = 0.0@{Double};
-  init acc$a$conv$66$simp$52$simp$54@{Mutable Double} = 0.0@{Double};
+  init acc$s$conv$13$simp$44@{Bool} = True@{Bool};
+  init acc$s$conv$13$simp$45@{Error} = ExceptTombstone@{Error};
+  init acc$s$conv$13$simp$46@{Double} = 0.0@{Double};
+  init acc$c$conv$26$simp$47@{Bool} = True@{Bool};
+  init acc$c$conv$26$simp$48@{Error} = ExceptTombstone@{Error};
+  init acc$c$conv$26$simp$49@{Double} = 0.0@{Double};
+  init acc$a$conv$66$simp$50@{Bool} = True@{Bool};
+  init acc$a$conv$66$simp$51@{Error} = ExceptTombstone@{Error};
+  init acc$a$conv$66$simp$52$simp$53$simp$55@{Double} = 0.0@{Double};
+  init acc$a$conv$66$simp$52$simp$53$simp$56@{Double} = 0.0@{Double};
+  init acc$a$conv$66$simp$52$simp$54@{Double} = 0.0@{Double};
   load_resumable@{Bool} acc$s$conv$13$simp$44;
   load_resumable@{Error} acc$s$conv$13$simp$45;
   load_resumable@{Double} acc$s$conv$13$simp$46;
@@ -53,9 +53,9 @@ gen$date = DATE
              gen$fact$simp$297$simp$301$simp$302@{String},
              gen$fact$simp$297$simp$301$simp$303@{Int},
              gen$fact$simp$298@{DateTime}) in new {
-    init flat$0$simp$57@{Mutable Bool} = False@{Bool};
-    init flat$0$simp$58@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$0$simp$59@{Mutable Int} = 0@{Int};
+    init flat$0$simp$57@{Bool} = False@{Bool};
+    init flat$0$simp$58@{Error} = ExceptTombstone@{Error};
+    init flat$0$simp$59@{Int} = 0@{Int};
     if (gen$fact$simp$297$simp$299) {
       write flat$0$simp$57 = True@{Bool};
       write flat$0$simp$58 = ExceptTombstone@{Error};
@@ -65,12 +65,12 @@ gen$date = DATE
       write flat$0$simp$58 = gen$fact$simp$297$simp$300;
       write flat$0$simp$59 = 0@{Int};
     }
-    read@{Mutable Bool} flat$0$simp$60 = flat$0$simp$57;
-    read@{Mutable Error} flat$0$simp$61 = flat$0$simp$58;
-    read@{Mutable Int} flat$0$simp$62 = flat$0$simp$59;
-    init flat$1$simp$63@{Mutable Bool} = False@{Bool};
-    init flat$1$simp$64@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$1$simp$65@{Mutable Double} = 0.0@{Double};
+    read@{Bool} flat$0$simp$60 = flat$0$simp$57;
+    read@{Error} flat$0$simp$61 = flat$0$simp$58;
+    read@{Int} flat$0$simp$62 = flat$0$simp$59;
+    init flat$1$simp$63@{Bool} = False@{Bool};
+    init flat$1$simp$64@{Error} = ExceptTombstone@{Error};
+    init flat$1$simp$65@{Double} = 0.0@{Double};
     if (flat$0$simp$60) {
       let simp$358 = doubleOfInt#
                      flat$0$simp$62;
@@ -82,12 +82,12 @@ gen$date = DATE
       write flat$1$simp$64 = flat$0$simp$61;
       write flat$1$simp$65 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$1$simp$66 = flat$1$simp$63;
-    read@{Mutable Error} flat$1$simp$67 = flat$1$simp$64;
-    read@{Mutable Double} flat$1$simp$68 = flat$1$simp$65;
-    init flat$2$simp$69@{Mutable Bool} = False@{Bool};
-    init flat$2$simp$70@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$2$simp$71@{Mutable Double} = 0.0@{Double};
+    read@{Bool} flat$1$simp$66 = flat$1$simp$63;
+    read@{Error} flat$1$simp$67 = flat$1$simp$64;
+    read@{Double} flat$1$simp$68 = flat$1$simp$65;
+    init flat$2$simp$69@{Bool} = False@{Bool};
+    init flat$2$simp$70@{Error} = ExceptTombstone@{Error};
+    init flat$2$simp$71@{Double} = 0.0@{Double};
     if (flat$1$simp$66) {
       write flat$2$simp$69 = True@{Bool};
       write flat$2$simp$70 = ExceptTombstone@{Error};
@@ -97,19 +97,19 @@ gen$date = DATE
       write flat$2$simp$70 = flat$1$simp$67;
       write flat$2$simp$71 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$2$simp$72 = flat$2$simp$69;
-    read@{Mutable Error} flat$2$simp$73 = flat$2$simp$70;
-    read@{Mutable Double} flat$2$simp$74 = flat$2$simp$71;
-    read@{Mutable Bool} acc$s$conv$13$simp$75 = acc$s$conv$13$simp$44;
-    read@{Mutable Error} acc$s$conv$13$simp$76 = acc$s$conv$13$simp$45;
-    read@{Mutable Double} acc$s$conv$13$simp$77 = acc$s$conv$13$simp$46;
-    init flat$3$simp$78@{Mutable Bool} = False@{Bool};
-    init flat$3$simp$79@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$3$simp$80@{Mutable Double} = 0.0@{Double};
+    read@{Bool} flat$2$simp$72 = flat$2$simp$69;
+    read@{Error} flat$2$simp$73 = flat$2$simp$70;
+    read@{Double} flat$2$simp$74 = flat$2$simp$71;
+    read@{Bool} acc$s$conv$13$simp$75 = acc$s$conv$13$simp$44;
+    read@{Error} acc$s$conv$13$simp$76 = acc$s$conv$13$simp$45;
+    read@{Double} acc$s$conv$13$simp$77 = acc$s$conv$13$simp$46;
+    init flat$3$simp$78@{Bool} = False@{Bool};
+    init flat$3$simp$79@{Error} = ExceptTombstone@{Error};
+    init flat$3$simp$80@{Double} = 0.0@{Double};
     if (flat$2$simp$72) {
-      init flat$6$simp$81@{Mutable Bool} = False@{Bool};
-      init flat$6$simp$82@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$6$simp$83@{Mutable Double} = 0.0@{Double};
+      init flat$6$simp$81@{Bool} = False@{Bool};
+      init flat$6$simp$82@{Error} = ExceptTombstone@{Error};
+      init flat$6$simp$83@{Double} = 0.0@{Double};
       if (acc$s$conv$13$simp$75) {
         write flat$6$simp$81 = True@{Bool};
         let simp$398 = add#@{Double}
@@ -122,9 +122,9 @@ gen$date = DATE
         write flat$6$simp$82 = acc$s$conv$13$simp$76;
         write flat$6$simp$83 = 0.0@{Double};
       }
-      read@{Mutable Bool} flat$6$simp$84 = flat$6$simp$81;
-      read@{Mutable Error} flat$6$simp$85 = flat$6$simp$82;
-      read@{Mutable Double} flat$6$simp$86 = flat$6$simp$83;
+      read@{Bool} flat$6$simp$84 = flat$6$simp$81;
+      read@{Error} flat$6$simp$85 = flat$6$simp$82;
+      read@{Double} flat$6$simp$86 = flat$6$simp$83;
       write flat$3$simp$78 = flat$6$simp$84;
       write flat$3$simp$79 = flat$6$simp$85;
       write flat$3$simp$80 = flat$6$simp$86;
@@ -133,22 +133,22 @@ gen$date = DATE
       write flat$3$simp$79 = flat$2$simp$73;
       write flat$3$simp$80 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$3$simp$87 = flat$3$simp$78;
-    read@{Mutable Error} flat$3$simp$88 = flat$3$simp$79;
-    read@{Mutable Double} flat$3$simp$89 = flat$3$simp$80;
+    read@{Bool} flat$3$simp$87 = flat$3$simp$78;
+    read@{Error} flat$3$simp$88 = flat$3$simp$79;
+    read@{Double} flat$3$simp$89 = flat$3$simp$80;
     write acc$s$conv$13$simp$44 = flat$3$simp$87;
     write acc$s$conv$13$simp$45 = flat$3$simp$88;
     write acc$s$conv$13$simp$46 = flat$3$simp$89;
-    read@{Mutable Bool} acc$c$conv$26$simp$90 = acc$c$conv$26$simp$47;
-    read@{Mutable Error} acc$c$conv$26$simp$91 = acc$c$conv$26$simp$48;
-    read@{Mutable Double} acc$c$conv$26$simp$92 = acc$c$conv$26$simp$49;
-    init flat$9$simp$93@{Mutable Bool} = False@{Bool};
-    init flat$9$simp$94@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$9$simp$95@{Mutable Double} = 0.0@{Double};
+    read@{Bool} acc$c$conv$26$simp$90 = acc$c$conv$26$simp$47;
+    read@{Error} acc$c$conv$26$simp$91 = acc$c$conv$26$simp$48;
+    read@{Double} acc$c$conv$26$simp$92 = acc$c$conv$26$simp$49;
+    init flat$9$simp$93@{Bool} = False@{Bool};
+    init flat$9$simp$94@{Error} = ExceptTombstone@{Error};
+    init flat$9$simp$95@{Double} = 0.0@{Double};
     if (flat$1$simp$66) {
-      init flat$12$simp$96@{Mutable Bool} = False@{Bool};
-      init flat$12$simp$97@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$12$simp$98@{Mutable Double} = 0.0@{Double};
+      init flat$12$simp$96@{Bool} = False@{Bool};
+      init flat$12$simp$97@{Error} = ExceptTombstone@{Error};
+      init flat$12$simp$98@{Double} = 0.0@{Double};
       if (acc$c$conv$26$simp$90) {
         write flat$12$simp$96 = True@{Bool};
         let simp$437 = add#@{Double}
@@ -160,12 +160,12 @@ gen$date = DATE
         write flat$12$simp$97 = acc$c$conv$26$simp$91;
         write flat$12$simp$98 = 0.0@{Double};
       }
-      read@{Mutable Bool} flat$12$simp$99 = flat$12$simp$96;
-      read@{Mutable Error} flat$12$simp$100 = flat$12$simp$97;
-      read@{Mutable Double} flat$12$simp$101 = flat$12$simp$98;
-      init flat$13$simp$102@{Mutable Bool} = False@{Bool};
-      init flat$13$simp$103@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$13$simp$104@{Mutable Double} = 0.0@{Double};
+      read@{Bool} flat$12$simp$99 = flat$12$simp$96;
+      read@{Error} flat$12$simp$100 = flat$12$simp$97;
+      read@{Double} flat$12$simp$101 = flat$12$simp$98;
+      init flat$13$simp$102@{Bool} = False@{Bool};
+      init flat$13$simp$103@{Error} = ExceptTombstone@{Error};
+      init flat$13$simp$104@{Double} = 0.0@{Double};
       if (flat$12$simp$99) {
         write flat$13$simp$102 = True@{Bool};
         write flat$13$simp$103 = ExceptTombstone@{Error};
@@ -175,9 +175,9 @@ gen$date = DATE
         write flat$13$simp$103 = flat$12$simp$100;
         write flat$13$simp$104 = 0.0@{Double};
       }
-      read@{Mutable Bool} flat$13$simp$105 = flat$13$simp$102;
-      read@{Mutable Error} flat$13$simp$106 = flat$13$simp$103;
-      read@{Mutable Double} flat$13$simp$107 = flat$13$simp$104;
+      read@{Bool} flat$13$simp$105 = flat$13$simp$102;
+      read@{Error} flat$13$simp$106 = flat$13$simp$103;
+      read@{Double} flat$13$simp$107 = flat$13$simp$104;
       write flat$9$simp$93 = flat$13$simp$105;
       write flat$9$simp$94 = flat$13$simp$106;
       write flat$9$simp$95 = flat$13$simp$107;
@@ -186,14 +186,14 @@ gen$date = DATE
       write flat$9$simp$94 = flat$1$simp$67;
       write flat$9$simp$95 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$9$simp$108 = flat$9$simp$93;
-    read@{Mutable Error} flat$9$simp$109 = flat$9$simp$94;
-    read@{Mutable Double} flat$9$simp$110 = flat$9$simp$95;
+    read@{Bool} flat$9$simp$108 = flat$9$simp$93;
+    read@{Error} flat$9$simp$109 = flat$9$simp$94;
+    read@{Double} flat$9$simp$110 = flat$9$simp$95;
     write acc$c$conv$26$simp$47 = flat$9$simp$108;
     write acc$c$conv$26$simp$48 = flat$9$simp$109;
     write acc$c$conv$26$simp$49 = flat$9$simp$110;
-    init flat$18$simp$111@{Mutable Bool} = False@{Bool};
-    init flat$18$simp$113@{Mutable String} = ""@{String};
+    init flat$18$simp$111@{Bool} = False@{Bool};
+    init flat$18$simp$113@{String} = ""@{String};
     if (gen$fact$simp$297$simp$299) {
       write flat$18$simp$111 = True@{Bool};
       write flat$18$simp$113 = gen$fact$simp$297$simp$301$simp$302;
@@ -201,10 +201,10 @@ gen$date = DATE
       write flat$18$simp$111 = False@{Bool};
       write flat$18$simp$113 = ""@{String};
     }
-    read@{Mutable Bool} flat$18$simp$114 = flat$18$simp$111;
-    read@{Mutable String} flat$18$simp$116 = flat$18$simp$113;
-    init flat$19$simp$117@{Mutable Bool} = False@{Bool};
-    init flat$19$simp$119@{Mutable Bool} = False@{Bool};
+    read@{Bool} flat$18$simp$114 = flat$18$simp$111;
+    read@{String} flat$18$simp$116 = flat$18$simp$113;
+    init flat$19$simp$117@{Bool} = False@{Bool};
+    init flat$19$simp$119@{Bool} = False@{Bool};
     if (flat$18$simp$114) {
       let simp$502 = eq#@{String}
                      flat$18$simp$116 ("torso"@{String});
@@ -214,9 +214,9 @@ gen$date = DATE
       write flat$19$simp$117 = False@{Bool};
       write flat$19$simp$119 = False@{Bool};
     }
-    read@{Mutable Bool} flat$19$simp$120 = flat$19$simp$117;
-    read@{Mutable Bool} flat$19$simp$122 = flat$19$simp$119;
-    init flat$20@{Mutable Bool} = False@{Bool};
+    read@{Bool} flat$19$simp$120 = flat$19$simp$117;
+    read@{Bool} flat$19$simp$122 = flat$19$simp$119;
+    init flat$20@{Bool} = False@{Bool};
     if (flat$19$simp$120) {
       write flat$20 = flat$19$simp$122;
     } 
@@ -224,11 +224,11 @@ gen$date = DATE
       write flat$20 = True@{Bool};
     } 
     
-    read@{Mutable Bool} flat$20 = flat$20;
+    read@{Bool} flat$20 = flat$20;
     if (flat$20) {
-      init flat$21$simp$123@{Mutable Bool} = False@{Bool};
-      init flat$21$simp$124@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$21$simp$125@{Mutable Int} = 0@{Int};
+      init flat$21$simp$123@{Bool} = False@{Bool};
+      init flat$21$simp$124@{Error} = ExceptTombstone@{Error};
+      init flat$21$simp$125@{Int} = 0@{Int};
       if (gen$fact$simp$297$simp$299) {
         write flat$21$simp$123 = True@{Bool};
         write flat$21$simp$124 = ExceptTombstone@{Error};
@@ -238,12 +238,12 @@ gen$date = DATE
         write flat$21$simp$124 = gen$fact$simp$297$simp$300;
         write flat$21$simp$125 = 0@{Int};
       }
-      read@{Mutable Bool} flat$21$simp$126 = flat$21$simp$123;
-      read@{Mutable Error} flat$21$simp$127 = flat$21$simp$124;
-      read@{Mutable Int} flat$21$simp$128 = flat$21$simp$125;
-      init flat$22$simp$129@{Mutable Bool} = False@{Bool};
-      init flat$22$simp$130@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$22$simp$131@{Mutable Double} = 0.0@{Double};
+      read@{Bool} flat$21$simp$126 = flat$21$simp$123;
+      read@{Error} flat$21$simp$127 = flat$21$simp$124;
+      read@{Int} flat$21$simp$128 = flat$21$simp$125;
+      init flat$22$simp$129@{Bool} = False@{Bool};
+      init flat$22$simp$130@{Error} = ExceptTombstone@{Error};
+      init flat$22$simp$131@{Double} = 0.0@{Double};
       if (flat$21$simp$126) {
         let simp$538 = doubleOfInt#
                        flat$21$simp$128;
@@ -255,26 +255,26 @@ gen$date = DATE
         write flat$22$simp$130 = flat$21$simp$127;
         write flat$22$simp$131 = 0.0@{Double};
       }
-      read@{Mutable Bool} flat$22$simp$132 = flat$22$simp$129;
-      read@{Mutable Error} flat$22$simp$133 = flat$22$simp$130;
-      read@{Mutable Double} flat$22$simp$134 = flat$22$simp$131;
-      read@{Mutable Bool} acc$a$conv$66$simp$135 = acc$a$conv$66$simp$50;
-      read@{Mutable Error} acc$a$conv$66$simp$136 = acc$a$conv$66$simp$51;
-      read@{Mutable Double} acc$a$conv$66$simp$137$simp$138$simp$140 = acc$a$conv$66$simp$52$simp$53$simp$55;
-      read@{Mutable Double} acc$a$conv$66$simp$137$simp$138$simp$141 = acc$a$conv$66$simp$52$simp$53$simp$56;
-      read@{Mutable Double} acc$a$conv$66$simp$137$simp$139 = acc$a$conv$66$simp$52$simp$54;
-      init flat$23$simp$142@{Mutable Bool} = False@{Bool};
-      init flat$23$simp$143@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$23$simp$144$simp$145$simp$147@{Mutable Double} = 0.0@{Double};
-      init flat$23$simp$144$simp$145$simp$148@{Mutable Double} = 0.0@{Double};
-      init flat$23$simp$144$simp$146@{Mutable Double} = 0.0@{Double};
+      read@{Bool} flat$22$simp$132 = flat$22$simp$129;
+      read@{Error} flat$22$simp$133 = flat$22$simp$130;
+      read@{Double} flat$22$simp$134 = flat$22$simp$131;
+      read@{Bool} acc$a$conv$66$simp$135 = acc$a$conv$66$simp$50;
+      read@{Error} acc$a$conv$66$simp$136 = acc$a$conv$66$simp$51;
+      read@{Double} acc$a$conv$66$simp$137$simp$138$simp$140 = acc$a$conv$66$simp$52$simp$53$simp$55;
+      read@{Double} acc$a$conv$66$simp$137$simp$138$simp$141 = acc$a$conv$66$simp$52$simp$53$simp$56;
+      read@{Double} acc$a$conv$66$simp$137$simp$139 = acc$a$conv$66$simp$52$simp$54;
+      init flat$23$simp$142@{Bool} = False@{Bool};
+      init flat$23$simp$143@{Error} = ExceptTombstone@{Error};
+      init flat$23$simp$144$simp$145$simp$147@{Double} = 0.0@{Double};
+      init flat$23$simp$144$simp$145$simp$148@{Double} = 0.0@{Double};
+      init flat$23$simp$144$simp$146@{Double} = 0.0@{Double};
       if (acc$a$conv$66$simp$135) {
         let nn$conv$73 = add#@{Double}
                          acc$a$conv$66$simp$137$simp$138$simp$140
                          (1.0@{Double});
-        init flat$26$simp$149@{Mutable Bool} = False@{Bool};
-        init flat$26$simp$150@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$26$simp$151@{Mutable Double} = 0.0@{Double};
+        init flat$26$simp$149@{Bool} = False@{Bool};
+        init flat$26$simp$150@{Error} = ExceptTombstone@{Error};
+        init flat$26$simp$151@{Double} = 0.0@{Double};
         if (flat$22$simp$132) {
           let simp$575 = sub#@{Double}
                          flat$22$simp$134
@@ -287,12 +287,12 @@ gen$date = DATE
           write flat$26$simp$150 = flat$22$simp$133;
           write flat$26$simp$151 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$26$simp$152 = flat$26$simp$149;
-        read@{Mutable Error} flat$26$simp$153 = flat$26$simp$150;
-        read@{Mutable Double} flat$26$simp$154 = flat$26$simp$151;
-        init flat$27$simp$155@{Mutable Bool} = False@{Bool};
-        init flat$27$simp$156@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$27$simp$157@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$26$simp$152 = flat$26$simp$149;
+        read@{Error} flat$26$simp$153 = flat$26$simp$150;
+        read@{Double} flat$26$simp$154 = flat$26$simp$151;
+        init flat$27$simp$155@{Bool} = False@{Bool};
+        init flat$27$simp$156@{Error} = ExceptTombstone@{Error};
+        init flat$27$simp$157@{Double} = 0.0@{Double};
         if (flat$26$simp$152) {
           let simp$590 = div#
                          flat$26$simp$154 nn$conv$73;
@@ -304,12 +304,12 @@ gen$date = DATE
           write flat$27$simp$156 = flat$26$simp$153;
           write flat$27$simp$157 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$27$simp$158 = flat$27$simp$155;
-        read@{Mutable Error} flat$27$simp$159 = flat$27$simp$156;
-        read@{Mutable Double} flat$27$simp$160 = flat$27$simp$157;
-        init flat$28$simp$161@{Mutable Bool} = False@{Bool};
-        init flat$28$simp$162@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$28$simp$163@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$27$simp$158 = flat$27$simp$155;
+        read@{Error} flat$27$simp$159 = flat$27$simp$156;
+        read@{Double} flat$27$simp$160 = flat$27$simp$157;
+        init flat$28$simp$161@{Bool} = False@{Bool};
+        init flat$28$simp$162@{Error} = ExceptTombstone@{Error};
+        init flat$28$simp$163@{Double} = 0.0@{Double};
         if (flat$27$simp$158) {
           write flat$28$simp$161 = True@{Bool};
           let simp$612 = add#@{Double}
@@ -322,20 +322,20 @@ gen$date = DATE
           write flat$28$simp$162 = flat$27$simp$159;
           write flat$28$simp$163 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$28$simp$164 = flat$28$simp$161;
-        read@{Mutable Error} flat$28$simp$165 = flat$28$simp$162;
-        read@{Mutable Double} flat$28$simp$166 = flat$28$simp$163;
-        init flat$29$simp$167@{Mutable Bool} = False@{Bool};
-        init flat$29$simp$168@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$29$simp$169@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$28$simp$164 = flat$28$simp$161;
+        read@{Error} flat$28$simp$165 = flat$28$simp$162;
+        read@{Double} flat$28$simp$166 = flat$28$simp$163;
+        init flat$29$simp$167@{Bool} = False@{Bool};
+        init flat$29$simp$168@{Error} = ExceptTombstone@{Error};
+        init flat$29$simp$169@{Double} = 0.0@{Double};
         if (flat$26$simp$152) {
-          init flat$44$simp$170@{Mutable Bool} = False@{Bool};
-          init flat$44$simp$171@{Mutable Error} = ExceptTombstone@{Error};
-          init flat$44$simp$172@{Mutable Double} = 0.0@{Double};
+          init flat$44$simp$170@{Bool} = False@{Bool};
+          init flat$44$simp$171@{Error} = ExceptTombstone@{Error};
+          init flat$44$simp$172@{Double} = 0.0@{Double};
           if (flat$22$simp$132) {
-            init flat$50$simp$173@{Mutable Bool} = False@{Bool};
-            init flat$50$simp$174@{Mutable Error} = ExceptTombstone@{Error};
-            init flat$50$simp$175@{Mutable Double} = 0.0@{Double};
+            init flat$50$simp$173@{Bool} = False@{Bool};
+            init flat$50$simp$174@{Error} = ExceptTombstone@{Error};
+            init flat$50$simp$175@{Double} = 0.0@{Double};
             if (flat$28$simp$164) {
               let simp$626 = sub#@{Double}
                              flat$22$simp$134
@@ -348,9 +348,9 @@ gen$date = DATE
               write flat$50$simp$174 = flat$28$simp$165;
               write flat$50$simp$175 = 0.0@{Double};
             }
-            read@{Mutable Bool} flat$50$simp$176 = flat$50$simp$173;
-            read@{Mutable Error} flat$50$simp$177 = flat$50$simp$174;
-            read@{Mutable Double} flat$50$simp$178 = flat$50$simp$175;
+            read@{Bool} flat$50$simp$176 = flat$50$simp$173;
+            read@{Error} flat$50$simp$177 = flat$50$simp$174;
+            read@{Double} flat$50$simp$178 = flat$50$simp$175;
             write flat$44$simp$170 = flat$50$simp$176;
             write flat$44$simp$171 = flat$50$simp$177;
             write flat$44$simp$172 = flat$50$simp$178;
@@ -359,12 +359,12 @@ gen$date = DATE
             write flat$44$simp$171 = flat$22$simp$133;
             write flat$44$simp$172 = 0.0@{Double};
           }
-          read@{Mutable Bool} flat$44$simp$179 = flat$44$simp$170;
-          read@{Mutable Error} flat$44$simp$180 = flat$44$simp$171;
-          read@{Mutable Double} flat$44$simp$181 = flat$44$simp$172;
-          init flat$45$simp$182@{Mutable Bool} = False@{Bool};
-          init flat$45$simp$183@{Mutable Error} = ExceptTombstone@{Error};
-          init flat$45$simp$184@{Mutable Double} = 0.0@{Double};
+          read@{Bool} flat$44$simp$179 = flat$44$simp$170;
+          read@{Error} flat$44$simp$180 = flat$44$simp$171;
+          read@{Double} flat$44$simp$181 = flat$44$simp$172;
+          init flat$45$simp$182@{Bool} = False@{Bool};
+          init flat$45$simp$183@{Error} = ExceptTombstone@{Error};
+          init flat$45$simp$184@{Double} = 0.0@{Double};
           if (flat$44$simp$179) {
             write flat$45$simp$182 = True@{Bool};
             let simp$660 = mul#@{Double}
@@ -377,9 +377,9 @@ gen$date = DATE
             write flat$45$simp$183 = flat$44$simp$180;
             write flat$45$simp$184 = 0.0@{Double};
           }
-          read@{Mutable Bool} flat$45$simp$185 = flat$45$simp$182;
-          read@{Mutable Error} flat$45$simp$186 = flat$45$simp$183;
-          read@{Mutable Double} flat$45$simp$187 = flat$45$simp$184;
+          read@{Bool} flat$45$simp$185 = flat$45$simp$182;
+          read@{Error} flat$45$simp$186 = flat$45$simp$183;
+          read@{Double} flat$45$simp$187 = flat$45$simp$184;
           write flat$29$simp$167 = flat$45$simp$185;
           write flat$29$simp$168 = flat$45$simp$186;
           write flat$29$simp$169 = flat$45$simp$187;
@@ -388,12 +388,12 @@ gen$date = DATE
           write flat$29$simp$168 = flat$26$simp$153;
           write flat$29$simp$169 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$29$simp$188 = flat$29$simp$167;
-        read@{Mutable Error} flat$29$simp$189 = flat$29$simp$168;
-        read@{Mutable Double} flat$29$simp$190 = flat$29$simp$169;
-        init flat$30$simp$191@{Mutable Bool} = False@{Bool};
-        init flat$30$simp$192@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$30$simp$193@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$29$simp$188 = flat$29$simp$167;
+        read@{Error} flat$29$simp$189 = flat$29$simp$168;
+        read@{Double} flat$29$simp$190 = flat$29$simp$169;
+        init flat$30$simp$191@{Bool} = False@{Bool};
+        init flat$30$simp$192@{Error} = ExceptTombstone@{Error};
+        init flat$30$simp$193@{Double} = 0.0@{Double};
         if (flat$29$simp$188) {
           write flat$30$simp$191 = True@{Bool};
           let simp$693 = add#@{Double}
@@ -406,13 +406,13 @@ gen$date = DATE
           write flat$30$simp$192 = flat$29$simp$189;
           write flat$30$simp$193 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$30$simp$194 = flat$30$simp$191;
-        read@{Mutable Error} flat$30$simp$195 = flat$30$simp$192;
-        read@{Mutable Double} flat$30$simp$196 = flat$30$simp$193;
-        init flat$31$simp$197@{Mutable Bool} = False@{Bool};
-        init flat$31$simp$198@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$31$simp$199$simp$200@{Mutable Double} = 0.0@{Double};
-        init flat$31$simp$199$simp$201@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$30$simp$194 = flat$30$simp$191;
+        read@{Error} flat$30$simp$195 = flat$30$simp$192;
+        read@{Double} flat$30$simp$196 = flat$30$simp$193;
+        init flat$31$simp$197@{Bool} = False@{Bool};
+        init flat$31$simp$198@{Error} = ExceptTombstone@{Error};
+        init flat$31$simp$199$simp$200@{Double} = 0.0@{Double};
+        init flat$31$simp$199$simp$201@{Double} = 0.0@{Double};
         if (flat$28$simp$164) {
           write flat$31$simp$197 = True@{Bool};
           write flat$31$simp$198 = ExceptTombstone@{Error};
@@ -424,21 +424,21 @@ gen$date = DATE
           write flat$31$simp$199$simp$200 = 0.0@{Double};
           write flat$31$simp$199$simp$201 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$31$simp$202 = flat$31$simp$197;
-        read@{Mutable Error} flat$31$simp$203 = flat$31$simp$198;
-        read@{Mutable Double} flat$31$simp$204$simp$205 = flat$31$simp$199$simp$200;
-        read@{Mutable Double} flat$31$simp$204$simp$206 = flat$31$simp$199$simp$201;
-        init flat$32$simp$207@{Mutable Bool} = False@{Bool};
-        init flat$32$simp$208@{Mutable Error} = ExceptTombstone@{Error};
-        init flat$32$simp$209$simp$210$simp$212@{Mutable Double} = 0.0@{Double};
-        init flat$32$simp$209$simp$210$simp$213@{Mutable Double} = 0.0@{Double};
-        init flat$32$simp$209$simp$211@{Mutable Double} = 0.0@{Double};
+        read@{Bool} flat$31$simp$202 = flat$31$simp$197;
+        read@{Error} flat$31$simp$203 = flat$31$simp$198;
+        read@{Double} flat$31$simp$204$simp$205 = flat$31$simp$199$simp$200;
+        read@{Double} flat$31$simp$204$simp$206 = flat$31$simp$199$simp$201;
+        init flat$32$simp$207@{Bool} = False@{Bool};
+        init flat$32$simp$208@{Error} = ExceptTombstone@{Error};
+        init flat$32$simp$209$simp$210$simp$212@{Double} = 0.0@{Double};
+        init flat$32$simp$209$simp$210$simp$213@{Double} = 0.0@{Double};
+        init flat$32$simp$209$simp$211@{Double} = 0.0@{Double};
         if (flat$31$simp$202) {
-          init flat$35$simp$214@{Mutable Bool} = False@{Bool};
-          init flat$35$simp$215@{Mutable Error} = ExceptTombstone@{Error};
-          init flat$35$simp$216$simp$217$simp$219@{Mutable Double} = 0.0@{Double};
-          init flat$35$simp$216$simp$217$simp$220@{Mutable Double} = 0.0@{Double};
-          init flat$35$simp$216$simp$218@{Mutable Double} = 0.0@{Double};
+          init flat$35$simp$214@{Bool} = False@{Bool};
+          init flat$35$simp$215@{Error} = ExceptTombstone@{Error};
+          init flat$35$simp$216$simp$217$simp$219@{Double} = 0.0@{Double};
+          init flat$35$simp$216$simp$217$simp$220@{Double} = 0.0@{Double};
+          init flat$35$simp$216$simp$218@{Double} = 0.0@{Double};
           if (flat$30$simp$194) {
             write flat$35$simp$214 = True@{Bool};
             write flat$35$simp$215 = ExceptTombstone@{Error};
@@ -452,11 +452,11 @@ gen$date = DATE
             write flat$35$simp$216$simp$217$simp$220 = 0.0@{Double};
             write flat$35$simp$216$simp$218 = 0.0@{Double};
           }
-          read@{Mutable Bool} flat$35$simp$221 = flat$35$simp$214;
-          read@{Mutable Error} flat$35$simp$222 = flat$35$simp$215;
-          read@{Mutable Double} flat$35$simp$223$simp$224$simp$226 = flat$35$simp$216$simp$217$simp$219;
-          read@{Mutable Double} flat$35$simp$223$simp$224$simp$227 = flat$35$simp$216$simp$217$simp$220;
-          read@{Mutable Double} flat$35$simp$223$simp$225 = flat$35$simp$216$simp$218;
+          read@{Bool} flat$35$simp$221 = flat$35$simp$214;
+          read@{Error} flat$35$simp$222 = flat$35$simp$215;
+          read@{Double} flat$35$simp$223$simp$224$simp$226 = flat$35$simp$216$simp$217$simp$219;
+          read@{Double} flat$35$simp$223$simp$224$simp$227 = flat$35$simp$216$simp$217$simp$220;
+          read@{Double} flat$35$simp$223$simp$225 = flat$35$simp$216$simp$218;
           write flat$32$simp$207 = flat$35$simp$221;
           write flat$32$simp$208 = flat$35$simp$222;
           write flat$32$simp$209$simp$210$simp$212 = flat$35$simp$223$simp$224$simp$226;
@@ -469,11 +469,11 @@ gen$date = DATE
           write flat$32$simp$209$simp$210$simp$213 = 0.0@{Double};
           write flat$32$simp$209$simp$211 = 0.0@{Double};
         }
-        read@{Mutable Bool} flat$32$simp$228 = flat$32$simp$207;
-        read@{Mutable Error} flat$32$simp$229 = flat$32$simp$208;
-        read@{Mutable Double} flat$32$simp$230$simp$231$simp$233 = flat$32$simp$209$simp$210$simp$212;
-        read@{Mutable Double} flat$32$simp$230$simp$231$simp$234 = flat$32$simp$209$simp$210$simp$213;
-        read@{Mutable Double} flat$32$simp$230$simp$232 = flat$32$simp$209$simp$211;
+        read@{Bool} flat$32$simp$228 = flat$32$simp$207;
+        read@{Error} flat$32$simp$229 = flat$32$simp$208;
+        read@{Double} flat$32$simp$230$simp$231$simp$233 = flat$32$simp$209$simp$210$simp$212;
+        read@{Double} flat$32$simp$230$simp$231$simp$234 = flat$32$simp$209$simp$210$simp$213;
+        read@{Double} flat$32$simp$230$simp$232 = flat$32$simp$209$simp$211;
         write flat$23$simp$142 = flat$32$simp$228;
         write flat$23$simp$143 = flat$32$simp$229;
         write flat$23$simp$144$simp$145$simp$147 = flat$32$simp$230$simp$231$simp$233;
@@ -486,11 +486,11 @@ gen$date = DATE
         write flat$23$simp$144$simp$145$simp$148 = 0.0@{Double};
         write flat$23$simp$144$simp$146 = 0.0@{Double};
       }
-      read@{Mutable Bool} flat$23$simp$235 = flat$23$simp$142;
-      read@{Mutable Error} flat$23$simp$236 = flat$23$simp$143;
-      read@{Mutable Double} flat$23$simp$237$simp$238$simp$240 = flat$23$simp$144$simp$145$simp$147;
-      read@{Mutable Double} flat$23$simp$237$simp$238$simp$241 = flat$23$simp$144$simp$145$simp$148;
-      read@{Mutable Double} flat$23$simp$237$simp$239 = flat$23$simp$144$simp$146;
+      read@{Bool} flat$23$simp$235 = flat$23$simp$142;
+      read@{Error} flat$23$simp$236 = flat$23$simp$143;
+      read@{Double} flat$23$simp$237$simp$238$simp$240 = flat$23$simp$144$simp$145$simp$147;
+      read@{Double} flat$23$simp$237$simp$238$simp$241 = flat$23$simp$144$simp$145$simp$148;
+      read@{Double} flat$23$simp$237$simp$239 = flat$23$simp$144$simp$146;
       write acc$a$conv$66$simp$50 = flat$23$simp$235;
       write acc$a$conv$66$simp$51 = flat$23$simp$236;
       write acc$a$conv$66$simp$52$simp$53$simp$55 = flat$23$simp$237$simp$238$simp$240;
@@ -509,23 +509,23 @@ gen$date = DATE
   save_resumable@{Double} acc$a$conv$66$simp$52$simp$53$simp$55;
   save_resumable@{Double} acc$a$conv$66$simp$52$simp$53$simp$56;
   save_resumable@{Double} acc$a$conv$66$simp$52$simp$54;
-  read@{Mutable Bool} s$conv$13$simp$242 = acc$s$conv$13$simp$44;
-  read@{Mutable Error} s$conv$13$simp$243 = acc$s$conv$13$simp$45;
-  read@{Mutable Double} s$conv$13$simp$244 = acc$s$conv$13$simp$46;
-  read@{Mutable Bool} c$conv$26$simp$245 = acc$c$conv$26$simp$47;
-  read@{Mutable Error} c$conv$26$simp$246 = acc$c$conv$26$simp$48;
-  read@{Mutable Double} c$conv$26$simp$247 = acc$c$conv$26$simp$49;
-  read@{Mutable Bool} a$conv$66$simp$248 = acc$a$conv$66$simp$50;
-  read@{Mutable Error} a$conv$66$simp$249 = acc$a$conv$66$simp$51;
-  read@{Mutable Double} a$conv$66$simp$250$simp$251$simp$253 = acc$a$conv$66$simp$52$simp$53$simp$55;
-  read@{Mutable Double} a$conv$66$simp$250$simp$252 = acc$a$conv$66$simp$52$simp$54;
-  init flat$75$simp$255@{Mutable Bool} = False@{Bool};
-  init flat$75$simp$256@{Mutable Error} = ExceptTombstone@{Error};
-  init flat$75$simp$257@{Mutable Double} = 0.0@{Double};
+  read@{Bool} s$conv$13$simp$242 = acc$s$conv$13$simp$44;
+  read@{Error} s$conv$13$simp$243 = acc$s$conv$13$simp$45;
+  read@{Double} s$conv$13$simp$244 = acc$s$conv$13$simp$46;
+  read@{Bool} c$conv$26$simp$245 = acc$c$conv$26$simp$47;
+  read@{Error} c$conv$26$simp$246 = acc$c$conv$26$simp$48;
+  read@{Double} c$conv$26$simp$247 = acc$c$conv$26$simp$49;
+  read@{Bool} a$conv$66$simp$248 = acc$a$conv$66$simp$50;
+  read@{Error} a$conv$66$simp$249 = acc$a$conv$66$simp$51;
+  read@{Double} a$conv$66$simp$250$simp$251$simp$253 = acc$a$conv$66$simp$52$simp$53$simp$55;
+  read@{Double} a$conv$66$simp$250$simp$252 = acc$a$conv$66$simp$52$simp$54;
+  init flat$75$simp$255@{Bool} = False@{Bool};
+  init flat$75$simp$256@{Error} = ExceptTombstone@{Error};
+  init flat$75$simp$257@{Double} = 0.0@{Double};
   if (s$conv$13$simp$242) {
-    init flat$90$simp$258@{Mutable Bool} = False@{Bool};
-    init flat$90$simp$259@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$90$simp$260@{Mutable Double} = 0.0@{Double};
+    init flat$90$simp$258@{Bool} = False@{Bool};
+    init flat$90$simp$259@{Error} = ExceptTombstone@{Error};
+    init flat$90$simp$260@{Double} = 0.0@{Double};
     if (c$conv$26$simp$245) {
       let conv$39 = div#
                     s$conv$13$simp$244
@@ -538,9 +538,9 @@ gen$date = DATE
       write flat$90$simp$259 = c$conv$26$simp$246;
       write flat$90$simp$260 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$90$simp$261 = flat$90$simp$258;
-    read@{Mutable Error} flat$90$simp$262 = flat$90$simp$259;
-    read@{Mutable Double} flat$90$simp$263 = flat$90$simp$260;
+    read@{Bool} flat$90$simp$261 = flat$90$simp$258;
+    read@{Error} flat$90$simp$262 = flat$90$simp$259;
+    read@{Double} flat$90$simp$263 = flat$90$simp$260;
     write flat$75$simp$255 = flat$90$simp$261;
     write flat$75$simp$256 = flat$90$simp$262;
     write flat$75$simp$257 = flat$90$simp$263;
@@ -549,16 +549,16 @@ gen$date = DATE
     write flat$75$simp$256 = s$conv$13$simp$243;
     write flat$75$simp$257 = 0.0@{Double};
   }
-  read@{Mutable Bool} flat$75$simp$264 = flat$75$simp$255;
-  read@{Mutable Error} flat$75$simp$265 = flat$75$simp$256;
-  read@{Mutable Double} flat$75$simp$266 = flat$75$simp$257;
-  init flat$76$simp$267@{Mutable Bool} = False@{Bool};
-  init flat$76$simp$268@{Mutable Error} = ExceptTombstone@{Error};
-  init flat$76$simp$269@{Mutable Double} = 0.0@{Double};
+  read@{Bool} flat$75$simp$264 = flat$75$simp$255;
+  read@{Error} flat$75$simp$265 = flat$75$simp$256;
+  read@{Double} flat$75$simp$266 = flat$75$simp$257;
+  init flat$76$simp$267@{Bool} = False@{Bool};
+  init flat$76$simp$268@{Error} = ExceptTombstone@{Error};
+  init flat$76$simp$269@{Double} = 0.0@{Double};
   if (flat$75$simp$264) {
-    init flat$79$simp$270@{Mutable Bool} = False@{Bool};
-    init flat$79$simp$271@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$79$simp$272@{Mutable Double} = 0.0@{Double};
+    init flat$79$simp$270@{Bool} = False@{Bool};
+    init flat$79$simp$271@{Error} = ExceptTombstone@{Error};
+    init flat$79$simp$272@{Double} = 0.0@{Double};
     if (a$conv$66$simp$248) {
       let conv$121 = sub#@{Double}
                      a$conv$66$simp$250$simp$251$simp$253
@@ -574,12 +574,12 @@ gen$date = DATE
       write flat$79$simp$271 = a$conv$66$simp$249;
       write flat$79$simp$272 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$79$simp$273 = flat$79$simp$270;
-    read@{Mutable Error} flat$79$simp$274 = flat$79$simp$271;
-    read@{Mutable Double} flat$79$simp$275 = flat$79$simp$272;
-    init flat$80$simp$276@{Mutable Bool} = False@{Bool};
-    init flat$80$simp$277@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$80$simp$278@{Mutable Double} = 0.0@{Double};
+    read@{Bool} flat$79$simp$273 = flat$79$simp$270;
+    read@{Error} flat$79$simp$274 = flat$79$simp$271;
+    read@{Double} flat$79$simp$275 = flat$79$simp$272;
+    init flat$80$simp$276@{Bool} = False@{Bool};
+    init flat$80$simp$277@{Error} = ExceptTombstone@{Error};
+    init flat$80$simp$278@{Double} = 0.0@{Double};
     if (flat$79$simp$273) {
       let conv$134 = pow#@{Double}
                      flat$79$simp$275 (0.5@{Double});
@@ -591,12 +591,12 @@ gen$date = DATE
       write flat$80$simp$277 = flat$79$simp$274;
       write flat$80$simp$278 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$80$simp$279 = flat$80$simp$276;
-    read@{Mutable Error} flat$80$simp$280 = flat$80$simp$277;
-    read@{Mutable Double} flat$80$simp$281 = flat$80$simp$278;
-    init flat$81$simp$282@{Mutable Bool} = False@{Bool};
-    init flat$81$simp$283@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$81$simp$284@{Mutable Double} = 0.0@{Double};
+    read@{Bool} flat$80$simp$279 = flat$80$simp$276;
+    read@{Error} flat$80$simp$280 = flat$80$simp$277;
+    read@{Double} flat$80$simp$281 = flat$80$simp$278;
+    init flat$81$simp$282@{Bool} = False@{Bool};
+    init flat$81$simp$283@{Error} = ExceptTombstone@{Error};
+    init flat$81$simp$284@{Double} = 0.0@{Double};
     if (flat$80$simp$279) {
       let conv$141 = mul#@{Double}
                      flat$75$simp$266
@@ -609,9 +609,9 @@ gen$date = DATE
       write flat$81$simp$283 = flat$80$simp$280;
       write flat$81$simp$284 = 0.0@{Double};
     }
-    read@{Mutable Bool} flat$81$simp$285 = flat$81$simp$282;
-    read@{Mutable Error} flat$81$simp$286 = flat$81$simp$283;
-    read@{Mutable Double} flat$81$simp$287 = flat$81$simp$284;
+    read@{Bool} flat$81$simp$285 = flat$81$simp$282;
+    read@{Error} flat$81$simp$286 = flat$81$simp$283;
+    read@{Double} flat$81$simp$287 = flat$81$simp$284;
     write flat$76$simp$267 = flat$81$simp$285;
     write flat$76$simp$268 = flat$81$simp$286;
     write flat$76$simp$269 = flat$81$simp$287;
@@ -620,9 +620,9 @@ gen$date = DATE
     write flat$76$simp$268 = flat$75$simp$265;
     write flat$76$simp$269 = 0.0@{Double};
   }
-  read@{Mutable Bool} flat$76$simp$288 = flat$76$simp$267;
-  read@{Mutable Error} flat$76$simp$289 = flat$76$simp$268;
-  read@{Mutable Double} flat$76$simp$290 = flat$76$simp$269;
+  read@{Bool} flat$76$simp$288 = flat$76$simp$267;
+  read@{Error} flat$76$simp$289 = flat$76$simp$268;
+  read@{Double} flat$76$simp$290 = flat$76$simp$269;
   output@{(Sum Error Double)} repl (flat$76$simp$288@{Bool},
                flat$76$simp$289@{Error},
                flat$76$simp$290@{Double});
@@ -1611,9 +1611,9 @@ void compute(icicle_state_t *s)
 > - Flattened:
 gen$date = DATE
 {
-  init acc$s$reify$2$conv$5$simp$4@{Mutable Bool} = False@{Bool};
-  init acc$s$reify$2$conv$5$simp$5@{Mutable Error} = ExceptFold1NoValue@{Error};
-  init acc$s$reify$2$conv$5$simp$6@{Mutable DateTime} = 1858-11-17@{DateTime};
+  init acc$s$reify$2$conv$5$simp$4@{Bool} = False@{Bool};
+  init acc$s$reify$2$conv$5$simp$5@{Error} = ExceptFold1NoValue@{Error};
+  init acc$s$reify$2$conv$5$simp$6@{DateTime} = 1858-11-17@{DateTime};
   load_resumable@{Bool} acc$s$reify$2$conv$5$simp$4;
   load_resumable@{Error} acc$s$reify$2$conv$5$simp$5;
   load_resumable@{DateTime} acc$s$reify$2$conv$5$simp$6;
@@ -1626,14 +1626,14 @@ gen$date = DATE
     let anf$14 = negate#@{Int} anf$13;
     let anf$15 = DateTime_minusDays#
                  (2000-01-01@{DateTime}) anf$14;
-    read@{Mutable Bool} acc$s$reify$2$conv$5$simp$7 = acc$s$reify$2$conv$5$simp$4;
-    read@{Mutable Error} acc$s$reify$2$conv$5$simp$8 = acc$s$reify$2$conv$5$simp$5;
-    read@{Mutable DateTime} acc$s$reify$2$conv$5$simp$9 = acc$s$reify$2$conv$5$simp$6;
-    init flat$0$simp$10@{Mutable Bool} = False@{Bool};
-    init flat$0$simp$11@{Mutable Error} = ExceptTombstone@{Error};
-    init flat$0$simp$12@{Mutable DateTime} = 1858-11-17@{DateTime};
+    read@{Bool} acc$s$reify$2$conv$5$simp$7 = acc$s$reify$2$conv$5$simp$4;
+    read@{Error} acc$s$reify$2$conv$5$simp$8 = acc$s$reify$2$conv$5$simp$5;
+    read@{DateTime} acc$s$reify$2$conv$5$simp$9 = acc$s$reify$2$conv$5$simp$6;
+    init flat$0$simp$10@{Bool} = False@{Bool};
+    init flat$0$simp$11@{Error} = ExceptTombstone@{Error};
+    init flat$0$simp$12@{DateTime} = 1858-11-17@{DateTime};
     if (acc$s$reify$2$conv$5$simp$7) {
-      init flat$4@{Mutable DateTime} = 1858-11-17@{DateTime};
+      init flat$4@{DateTime} = 1858-11-17@{DateTime};
       if (gt#@{DateTime} anf$15
           acc$s$reify$2$conv$5$simp$9) {
         write flat$4 = anf$15;
@@ -1642,14 +1642,14 @@ gen$date = DATE
         write flat$4 = acc$s$reify$2$conv$5$simp$9;
       } 
       
-      read@{Mutable DateTime} flat$4 = flat$4;
+      read@{DateTime} flat$4 = flat$4;
       write flat$0$simp$10 = True@{Bool};
       write flat$0$simp$11 = ExceptTombstone@{Error};
       write flat$0$simp$12 = flat$4;
     } else {
-      init flat$3$simp$13@{Mutable Bool} = False@{Bool};
-      init flat$3$simp$14@{Mutable Error} = ExceptTombstone@{Error};
-      init flat$3$simp$15@{Mutable DateTime} = 1858-11-17@{DateTime};
+      init flat$3$simp$13@{Bool} = False@{Bool};
+      init flat$3$simp$14@{Error} = ExceptTombstone@{Error};
+      init flat$3$simp$15@{DateTime} = 1858-11-17@{DateTime};
       if (eq#@{Error} (ExceptFold1NoValue@{Error})
           acc$s$reify$2$conv$5$simp$8) {
         write flat$3$simp$13 = True@{Bool};
@@ -1660,16 +1660,16 @@ gen$date = DATE
         write flat$3$simp$14 = acc$s$reify$2$conv$5$simp$8;
         write flat$3$simp$15 = 1858-11-17@{DateTime};
       }
-      read@{Mutable Bool} flat$3$simp$16 = flat$3$simp$13;
-      read@{Mutable Error} flat$3$simp$17 = flat$3$simp$14;
-      read@{Mutable DateTime} flat$3$simp$18 = flat$3$simp$15;
+      read@{Bool} flat$3$simp$16 = flat$3$simp$13;
+      read@{Error} flat$3$simp$17 = flat$3$simp$14;
+      read@{DateTime} flat$3$simp$18 = flat$3$simp$15;
       write flat$0$simp$10 = flat$3$simp$16;
       write flat$0$simp$11 = flat$3$simp$17;
       write flat$0$simp$12 = flat$3$simp$18;
     }
-    read@{Mutable Bool} flat$0$simp$19 = flat$0$simp$10;
-    read@{Mutable Error} flat$0$simp$20 = flat$0$simp$11;
-    read@{Mutable DateTime} flat$0$simp$21 = flat$0$simp$12;
+    read@{Bool} flat$0$simp$19 = flat$0$simp$10;
+    read@{Error} flat$0$simp$20 = flat$0$simp$11;
+    read@{DateTime} flat$0$simp$21 = flat$0$simp$12;
     write acc$s$reify$2$conv$5$simp$4 = flat$0$simp$19;
     write acc$s$reify$2$conv$5$simp$5 = flat$0$simp$20;
     write acc$s$reify$2$conv$5$simp$6 = flat$0$simp$21;
@@ -1677,9 +1677,9 @@ gen$date = DATE
   save_resumable@{Bool} acc$s$reify$2$conv$5$simp$4;
   save_resumable@{Error} acc$s$reify$2$conv$5$simp$5;
   save_resumable@{DateTime} acc$s$reify$2$conv$5$simp$6;
-  read@{Mutable Bool} s$reify$2$conv$5$simp$22 = acc$s$reify$2$conv$5$simp$4;
-  read@{Mutable Error} s$reify$2$conv$5$simp$23 = acc$s$reify$2$conv$5$simp$5;
-  read@{Mutable DateTime} s$reify$2$conv$5$simp$24 = acc$s$reify$2$conv$5$simp$6;
+  read@{Bool} s$reify$2$conv$5$simp$22 = acc$s$reify$2$conv$5$simp$4;
+  read@{Error} s$reify$2$conv$5$simp$23 = acc$s$reify$2$conv$5$simp$5;
+  read@{DateTime} s$reify$2$conv$5$simp$24 = acc$s$reify$2$conv$5$simp$6;
   output@{(Sum Error DateTime)} repl (s$reify$2$conv$5$simp$22@{Bool},
                s$reify$2$conv$5$simp$23@{Error},
                s$reify$2$conv$5$simp$24@{DateTime});


### PR DESCRIPTION
Now that RLatest is gone from Core, AccumulatorType and Push statements are basically dead code in Avalanche, so let's just remove them.

I'm not too sure about the bubblegum semantics of circular buffers as accumulators here, presumably it needs to fill the role of what Latest accumulator was doing...

/cc @amosr 