### PR TITLE
Throwing it all away: remove array melting and map implementation

### DIFF
--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -12,8 +12,6 @@ typedef  int64_t iint_t;
 typedef   double idouble_t;
 typedef  int64_t idate_t;
 
-typedef const char *istring_t;
-
 static const ierror_t ierror_tombstone              = 0;
 static const ierror_t ierror_fold1_no_value         = 1;
 static const ierror_t ierror_variable_not_available = 2;

--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -37,3 +37,6 @@ STATIC_ASSERT(sizeof (void *) == sizeof (uint64_t), icicle_only_supports_systems
 #else
 #   define ICICLE_WHEN_DEBUG(code)
 #endif
+
+#define ICICLE_FUNCTION extern "C"
+

--- a/data/sea/10-mempool.h
+++ b/data/sea/10-mempool.h
@@ -81,6 +81,7 @@ static void * NOINLINE imempool_alloc_block (imempool_t *pool, size_t num_bytes)
     exit (1);
 }
 
+ICICLE_FUNCTION
 void * INLINE imempool_alloc (imempool_t *pool, size_t num_bytes)
 {
     TRY_ALLOC (imempool_alloc);
@@ -95,6 +96,7 @@ T * INLINE imempool_alloc_of (imempool_t *pool, size_t num_elts)
 }
 
 
+ICICLE_FUNCTION
 void imempool_create (imempool_t *pool)
 {
     pool->last        = 0;
@@ -104,6 +106,7 @@ void imempool_create (imempool_t *pool)
     imempool_add_block (pool);
 }
 
+ICICLE_FUNCTION
 void imempool_free (imempool_t *pool)
 {
     iblock_free (pool->last);

--- a/data/sea/10-mempool.h
+++ b/data/sea/10-mempool.h
@@ -13,7 +13,7 @@ typedef struct {
     void     *maximum_ptr;
 } imempool_t;
 
-// Advance a null pointer. C++ is pedantic about pointer arithmetic on a void*
+// Advance a void pointer. C++ is pedantic about pointer arithmetic on a void*
 #define ADVANCE_PTR(ptr,by) (void*)((char*)ptr + by)
 
 // If the size of imempool_t changes, be sure to update the `seaEval` and
@@ -87,6 +87,13 @@ void * INLINE imempool_alloc (imempool_t *pool, size_t num_bytes)
 
     return imempool_alloc_block (pool, num_bytes);
 }
+
+template<typename T>
+T * INLINE imempool_alloc_of (imempool_t *pool, size_t num_elts)
+{
+    return (T*)imempool_alloc(pool, num_elts * sizeof(T));
+}
+
 
 void imempool_create (imempool_t *pool)
 {

--- a/data/sea/10-mempool.h
+++ b/data/sea/10-mempool.h
@@ -13,6 +13,9 @@ typedef struct {
     void     *maximum_ptr;
 } imempool_t;
 
+// Advance a null pointer. C++ is pedantic about pointer arithmetic on a void*
+#define ADVANCE_PTR(ptr,by) (void*)((char*)ptr + by)
+
 // If the size of imempool_t changes, be sure to update the `seaEval` and
 // `stateWordsOfProgram` functions.
 ASSERT_SIZE (imempool_t, 3)
@@ -22,7 +25,7 @@ static iblock_t * iblock_create (iblock_t *prev)
     void     *ptr = malloc (iblock_size);
     iblock_t  src = { ptr, prev };
 
-    iblock_t *dst = malloc (sizeof (iblock_t));
+    iblock_t *dst = (iblock_t*)malloc (sizeof (iblock_t));
     memcpy (dst, &src, sizeof (iblock_t));
 
 #if ICICLE_DEBUG
@@ -50,7 +53,7 @@ static void imempool_add_block (imempool_t *pool)
 
     pool->last        = next;
     pool->current_ptr = next->ptr;
-    pool->maximum_ptr = next->ptr + iblock_size;
+    pool->maximum_ptr = ADVANCE_PTR(next->ptr, iblock_size);
 }
 
 /* This has to be a macro as when it's a function we end up with an extra
@@ -58,7 +61,7 @@ static void imempool_add_block (imempool_t *pool)
  * succeeded or not. */
 #define TRY_ALLOC(fn_name)                                                                             \
     void *ptr  = pool->current_ptr;                                                                    \
-    void *next = ptr + num_bytes;                                                                      \
+    void *next = ADVANCE_PTR(ptr, num_bytes);                                                                      \
                                                                                                        \
     if (next <= pool->maximum_ptr) {                                                                   \
         ICICLE_WHEN_DEBUG (fprintf (stderr, #fn_name ": %p (allocated %zu bytes)\n", ptr, num_bytes)); \

--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -15,3 +15,29 @@ static idouble_t INLINE idouble_pow   (idouble_t x, idouble_t y) { return pow(x,
 static idouble_t INLINE idouble_div   (idouble_t x, idouble_t y) { return x / y; }
 static idouble_t INLINE idouble_log   (idouble_t x)              { return log(x); }
 static idouble_t INLINE idouble_exp   (idouble_t x)              { return exp(x); }
+
+
+template<typename T>
+ibool_t ieq(const T& t, const T& u)
+{ return t == u; }
+
+template<typename T>
+ibool_t ine(const T& t, const T& u)
+{ return t != u; }
+
+template<typename T>
+ibool_t ilt(const T& t, const T& u)
+{ return t <  u; }
+
+template<typename T>
+ibool_t ile(const T& t, const T& u)
+{ return t <= u; }
+
+template<typename T>
+ibool_t igt(const T& t, const T& u)
+{ return t >  u; }
+
+template<typename T>
+ibool_t ige(const T& t, const T& u)
+{ return t >= u; }
+

--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -1,25 +1,10 @@
 #include "10-mempool.h"
 
-#define MK_SIMPLE_CMPS(t,pre)                                                   \
-    static ibool_t   INLINE pre##eq   (t x, t y) { return x == y; }             \
-    static ibool_t   INLINE pre##ne   (t x, t y) { return x != y; }             \
-    static ibool_t   INLINE pre##gt   (t x, t y) { return x >  y; }             \
-    static ibool_t   INLINE pre##ge   (t x, t y) { return x >= y; }             \
-    static ibool_t   INLINE pre##lt   (t x, t y) { return x <  y; }             \
-    static ibool_t   INLINE pre##le   (t x, t y) { return x <= y; }             \
-
-MK_SIMPLE_CMPS(ierror_t, ierror_)
-MK_SIMPLE_CMPS(ibool_t,  ibool_)
-MK_SIMPLE_CMPS(idate_t,  idate_)
-MK_SIMPLE_CMPS(iunit_t,  iunit_)
-
 static idouble_t INLINE iint_extend   (iint_t    x)              { return x; }
 static iint_t    INLINE iint_neg      (iint_t    x)              { return -x; }
 static iint_t    INLINE iint_add      (iint_t    x, iint_t    y) { return x + y; }
 static iint_t    INLINE iint_sub      (iint_t    x, iint_t    y) { return x - y; }
 static iint_t    INLINE iint_mul      (iint_t    x, iint_t    y) { return x * y; }
-
-MK_SIMPLE_CMPS(iint_t, iint_)
 
 static iint_t    INLINE idouble_trunc (idouble_t x)              { return (iint_t)x; }
 static idouble_t INLINE idouble_neg   (idouble_t x)              { return -x; }
@@ -30,12 +15,3 @@ static idouble_t INLINE idouble_pow   (idouble_t x, idouble_t y) { return pow(x,
 static idouble_t INLINE idouble_div   (idouble_t x, idouble_t y) { return x / y; }
 static idouble_t INLINE idouble_log   (idouble_t x)              { return log(x); }
 static idouble_t INLINE idouble_exp   (idouble_t x)              { return exp(x); }
-
-MK_SIMPLE_CMPS(idouble_t, idouble_)
-
-static ibool_t   INLINE istring_gt    (istring_t x, istring_t y) { return strcmp(x, y) >  0; }
-static ibool_t   INLINE istring_ge    (istring_t x, istring_t y) { return strcmp(x, y) >= 0; }
-static ibool_t   INLINE istring_lt    (istring_t x, istring_t y) { return strcmp(x, y) <  0; }
-static ibool_t   INLINE istring_le    (istring_t x, istring_t y) { return strcmp(x, y) <= 0; }
-static ibool_t   INLINE istring_eq    (istring_t x, istring_t y) { return strcmp(x, y) == 0; }
-static ibool_t   INLINE istring_ne    (istring_t x, istring_t y) { return strcmp(x, y) != 0; }

--- a/data/sea/22-string.h
+++ b/data/sea/22-string.h
@@ -21,7 +21,11 @@ struct istring_t
         return strcmp(this->payload, y.payload);
     }
 
-    const char* const payload;
+    const char* payload;
+
+    istring_t()
+        : payload(0)
+    { }
 
     istring_t(const char* const payload)
         : payload(payload)

--- a/data/sea/22-string.h
+++ b/data/sea/22-string.h
@@ -1,0 +1,34 @@
+#include "21-date.h"
+
+class istring_t
+{
+
+    bool operator==(const istring_t& y) const
+    { return cmp(y) == 0; }
+    bool operator!=(const istring_t& y) const
+    { return cmp(y) != 0; }
+    bool operator>(const istring_t& y) const
+    { return cmp(y) > 0; }
+    bool operator>=(const istring_t& y) const
+    { return cmp(y) >= 0; }
+    bool operator<(const istring_t& y) const
+    { return cmp(y) < 0; }
+    bool operator<=(const istring_t& y) const
+    { return cmp(y) <= 0; }
+
+    iint_t cmp(const istring_t& y) const
+    {
+        return strcmp(this->payload, y.payload);
+    }
+
+    const char* const payload;
+
+    istring_t(const char* const payload)
+        : payload(payload)
+    { }
+
+    istring_t(const istring_t& other)
+        : payload(other.payload)
+    { }
+};
+

--- a/data/sea/22-string.h
+++ b/data/sea/22-string.h
@@ -1,6 +1,6 @@
 #include "21-date.h"
 
-class istring_t
+struct istring_t
 {
 
     bool operator==(const istring_t& y) const

--- a/data/sea/23-compounds.h
+++ b/data/sea/23-compounds.h
@@ -1,0 +1,110 @@
+#include "22-string.h"
+
+// TODO equality etc
+
+template <typename T>
+class ioption_t
+{
+    const ibool_t is_some;
+    const T       value;
+
+    ibool_t isSome() const
+    {
+        return this->is_some;
+    }
+
+    const T& unsafeGet() const
+    {
+        return this->value;
+    }
+
+    ioption_t(ibool_t s, const T& t)
+     : is_some(s), value(t)
+     {};
+
+    ioption_t(const ioption_t<T>& other)
+     : is_some(other.is_some), value(other.value)
+     {};
+
+    ioption_t()
+     : is_some(ifalse), value()
+     {};
+};
+
+template <typename T>
+ioption_t<T> ioption_none()
+{ return ioption_t<T>(); }
+
+template <typename T>
+ioption_t<T> ioption_some(const T& t)
+{ return ioption_t<T>(itrue, t); }
+
+
+template <typename T, typename U>
+class ipair_t
+{
+    const T t;
+    const U u;
+
+    T& fst() const
+    {
+        return this->t;
+    }
+
+    U& snd() const
+    {
+        return this->snd;
+    }
+
+    ipair_t(const T& t, const U& u)
+     : t(t), u(u)
+     {};
+
+    ipair_t(const ipair_t<T,U>& other)
+     : t(other.t), u(other.u)
+     {};
+};
+
+template <typename T, typename U>
+ipair_t<T,U> ipair_pair(const T& t, const U& u)
+{ return ipair_t<T,U>(t, u); }
+
+
+template <typename L, typename R>
+class isum_t
+{
+    const ibool_t   is_right;
+    const L         l;
+    const R         r;
+
+    ibool_t isRight() const
+    {
+        return this->is_right;
+    }
+
+    const L& unsafeLeft() const
+    {
+        return this->l;
+    }
+
+    const R& unsafeRight() const
+    {
+        return this->r;
+    }
+
+    isum_t(ibool_t is_right, const L& l, const R& r)
+     : is_right(is_right), l(l), r(r)
+     {};
+
+    isum_t(const isum_t<L,R>& other)
+     : is_right(other.is_right), l(other.l), r(other.r)
+     {};
+};
+
+template <typename L, typename R>
+isum_t<L,R> isum_left(const L& l)
+{ return isum_t<L,R>(l, R()); }
+template <typename L, typename R>
+isum_t<L,R> isum_right(const R& r)
+{ return isum_t<L,R>(L(), r); }
+

--- a/data/sea/23-compounds.h
+++ b/data/sea/23-compounds.h
@@ -3,7 +3,7 @@
 // TODO equality etc
 
 template <typename T>
-class ioption_t
+struct ioption_t
 {
     const ibool_t is_some;
     const T       value;
@@ -41,20 +41,23 @@ ioption_t<T> ioption_some(const T& t)
 
 
 template <typename T, typename U>
-class ipair_t
+struct ipair_t
 {
-    const T t;
-    const U u;
+    T t;
+    U u;
 
-    T& fst() const
+    const T& fst() const
     {
         return this->t;
     }
 
-    U& snd() const
+    const U& snd() const
     {
-        return this->snd;
+        return this->u;
     }
+
+    ipair_t()
+     {};
 
     ipair_t(const T& t, const U& u)
      : t(t), u(u)
@@ -71,11 +74,11 @@ ipair_t<T,U> ipair_pair(const T& t, const U& u)
 
 
 template <typename L, typename R>
-class isum_t
+struct isum_t
 {
-    const ibool_t   is_right;
-    const L         l;
-    const R         r;
+    ibool_t   is_right;
+    L         l;
+    R         r;
 
     ibool_t isRight() const
     {
@@ -91,6 +94,9 @@ class isum_t
     {
         return this->r;
     }
+
+    isum_t()
+     {};
 
     isum_t(ibool_t is_right, const L& l, const R& r)
      : is_right(is_right), l(l), r(r)

--- a/data/sea/30-array.h
+++ b/data/sea/30-array.h
@@ -1,7 +1,7 @@
 #include "23-compounds.h"
 
 template<typename T>
-class iarray_t
+struct iarray_t
 {
     iint_t count;
     T* payload;
@@ -52,10 +52,16 @@ class iarray_t
         return *this;
     }
 
+    iarray_t()
+    {
+        this->count   = 0;
+        this->payload = 0;
+    }
+
     iarray_t(imempool_t* pool, iint_t count)
     {
-        this->count = count;
-        payload = imempool_alloc_of<T>(pool, count);
+        this->count   = count;
+        this->payload = imempool_alloc_of<T>(pool, count);
     }
 };
 

--- a/data/sea/30-array.h
+++ b/data/sea/30-array.h
@@ -1,103 +1,62 @@
-#include "21-date.h"
+#include "22-string.h"
 
-typedef struct
+template<typename T>
+class iarray_t
 {
     iint_t count;
-} iarray_struct;
-// payload goes straight after
+    T* payload;
 
-#define ARRAY(t)         iarray_t__##t
-#define ARRAY_FUN(f,pre) iarray__##pre##f
-
-// I'm not certain there's a point having a different one for each type.
-// It makes it look a little better, but I don't think it's any safer.
-#define MK_ARRAY_STRUCT(t) typedef iarray_struct* ARRAY(t);
-
-// get payload by advancing pointer by size of struct
-// (which should be equivalent to straight after struct fields)
-// then casting to t*
-#define ARRAY_PAYLOAD(x,t) ((t*)(x+1))
-
-
-#define MK_ARRAY_LENGTH(t,pre)                                                  \
-    static iint_t INLINE ARRAY_FUN(length,pre) (ARRAY(t) arr)                   \
-    { return arr->count; }
-
-#define MK_ARRAY_EQ(t,pre)                                                      \
-    static ibool_t INLINE ARRAY_FUN(eq,pre) (ARRAY(t) x, ARRAY(t) y)            \
-    {                                                                           \
-        if (x->count != y->count) return ifalse;                                \
-        for (iint_t ix = 0; ix != x->count; ++ix) {                             \
-            if (!pre##eq(ARRAY_PAYLOAD(x,t)[ix], ARRAY_PAYLOAD(y,t)[ix]))       \
-                return ifalse;                                                  \
-        }                                                                       \
-        return itrue;                                                           \
+    iint_t length() const
+    {
+        return this->count;
     }
 
-#define MK_ARRAY_LT(t,pre)                                                      \
-    static ibool_t INLINE ARRAY_FUN(lt,pre) (ARRAY(t) x, ARRAY(t) y)            \
-    {                                                                           \
-        iint_t min = (x->count < y->count) ? x->count : y->count;               \
-        for (iint_t ix = 0; ix != min; ++ix) {                                  \
-            if (!pre##lt(ARRAY_PAYLOAD(x,t)[ix], ARRAY_PAYLOAD(y,t)[ix]))       \
-                return ifalse;                                                  \
-        }                                                                       \
-        if (x->count < y->count)                                                \
-            return itrue;                                                       \
-        else                                                                    \
-            return ifalse;                                                      \
+    ibool_t operator==(const iarray_t<T>& other) const
+    {
+        if (other.count != count) return ifalse;
+        for (iint_t ix = 0; ix != other.count; ++ix) {
+            if (payload[ix] != other.payload[ix]) {
+                return ifalse;
+            }
+        }
+        return itrue;
     }
 
-#define MK_ARRAY_CMP(t,pre,op,ret)                                              \
-    static ibool_t INLINE ARRAY_FUN(op,pre) (ARRAY(t) x, ARRAY(t) y)            \
-    { return ret ; }
-
-#define MK_ARRAY_CMPS(t,pre)                                                    \
-    MK_ARRAY_EQ(t,pre)                                                          \
-    MK_ARRAY_LT(t,pre)                                                          \
-    MK_ARRAY_CMP(t,pre,ne, !ARRAY_FUN(eq,pre) (x,y))                            \
-    MK_ARRAY_CMP(t,pre,le,  ARRAY_FUN(lt,pre) (x,y) || ARRAY_FUN(eq,pre) (x,y)) \
-    MK_ARRAY_CMP(t,pre,ge, !ARRAY_FUN(lt,pre) (x,y))                            \
-    MK_ARRAY_CMP(t,pre,gt, !ARRAY_FUN(le,pre) (x,y))
-
-
-
-#define MK_ARRAY_INDEX(t,pre)                                                   \
-    static t       INLINE ARRAY_FUN(index,pre) (ARRAY(t) x, iint_t ix)          \
-    { return ARRAY_PAYLOAD(x,t)[ix]; }
-
-
-#define MK_ARRAY_CREATE(t,pre)                                                  \
-    static ARRAY(t)  INLINE ARRAY_FUN(create,pre)                               \
-                                     (imempool_t *pool, iint_t sz)              \
-    {                                                                           \
-        size_t bytes = sizeof(t) * sz + sizeof(iarray_struct);                  \
-        ARRAY(t) ret = (ARRAY(t))imempool_alloc(pool, bytes);                   \
-        ret->count   = sz;                                                      \
-        return ret;                                                             \
+    ibool_t operator<(const iarray_t<T>& other) const
+    {
+        iint_t min = (count < other.count) ? count : other.count;
+        for (iint_t ix = 0; ix != min; ++ix) {
+            if (!(payload[ix] < other.payload[ix])) {
+                return ifalse;
+            }
+        }
+        if (count < other.count) return itrue;
+        else return ifalse;
     }
 
-#define MK_ARRAY_PUT(t,pre)                                                     \
-    static ARRAY(t) INLINE ARRAY_FUN(put,pre)   (ARRAY(t) x, iint_t ix, t v)    \
-    {                                                                           \
-        ARRAY_PAYLOAD(x,t)[ix] = v;                                             \
-        return x;                                                               \
+    ibool_t operator!=(const iarray_t<T>& other) const
+    { return !(*this == other); }
+    ibool_t operator<=(const iarray_t<T>& other) const
+    { return (*this == other) || (*this < other); }
+    ibool_t operator>=(const iarray_t<T>& other) const
+    { return !(*this < other); }
+    ibool_t operator>(const iarray_t<T>& other) const
+    { return !(*this <= other); }
+
+    const T& index(iint_t ix) const
+    { return this->payload[ix]; }
+
+    iarray_t<T>& put(iint_t ix, const T& v)
+    {
+        this->payload[ix] = v;
+        return *this;
     }
 
+    iarray_t(imempool_t* pool, iint_t count)
+    {
+        this->count = count;
+        size_t bytes = sizeof(T) * count;
+        payload = (T*)imempool_alloc(pool, bytes);
+    }
+};
 
-
-#define MAKE_ARRAY(t,pre)                                                       \
-    MK_ARRAY_STRUCT (t)                                                         \
-    MK_ARRAY_LENGTH (t,pre)                                                     \
-    MK_ARRAY_CMPS   (t,pre)                                                     \
-    MK_ARRAY_INDEX  (t,pre)                                                     \
-    MK_ARRAY_CREATE (t,pre)                                                     \
-    MK_ARRAY_PUT    (t,pre)                                                     \
-    // MK_ARRAY_ZIP    (t,pre)                                                     \
-
-MAKE_ARRAY(idouble_t,   idouble_)
-MAKE_ARRAY(iint_t,      iint_)
-MAKE_ARRAY(ierror_t,    ierror_)
-MAKE_ARRAY(ibool_t,     ibool_)
-MAKE_ARRAY(idate_t,     idate_)
-MAKE_ARRAY(iunit_t,     iunit_)

--- a/data/sea/30-array.h
+++ b/data/sea/30-array.h
@@ -1,4 +1,4 @@
-#include "22-string.h"
+#include "23-compounds.h"
 
 template<typename T>
 class iarray_t
@@ -55,8 +55,7 @@ class iarray_t
     iarray_t(imempool_t* pool, iint_t count)
     {
         this->count = count;
-        size_t bytes = sizeof(T) * count;
-        payload = (T*)imempool_alloc(pool, bytes);
+        payload = imempool_alloc_of<T>(pool, count);
     }
 };
 

--- a/data/sea/31-buffer.h
+++ b/data/sea/31-buffer.h
@@ -1,146 +1,53 @@
 #include "30-array.h"
 
-typedef struct
+template <typename T>
+class ibuf_t
 {
     iint_t max_size;
     iint_t cur_size;
     iint_t head;
-} ibuf_struct;
-/*
- Invariants
-  0 <= cur_size <= max_size
-  0 <= head     <  max_size
 
-  read = ARRAY[ head..(head+cur_size) % max_size )
+    T* payload;
 
-*/
+    ibuf_t(imempool_t* pool, iint_t sz)
+    {
+        size_t bytes = sizeof(T) * sz;
+        payload      = (T*)imempool_alloc(pool, bytes);
 
-#define BUF(t)         ibuf_t__##t
-#define BUF_FUN(f,pre) ibuf__##pre##f
-
-#define MK_BUF_STRUCT(t) typedef ibuf_struct* BUF(t);
-
-#define BUF_PAYLOAD(x,t) ((t*)(x+1))
-
-/*
-Make
- Pre
-  0 <= sz
-
- Post
-  cur_size' = 0
-  head'     = 0
-  max_size' = sz
-  ARRAY'    = [??...]
-
-  read'     = ARRAY'[head'..head'+cur_size')
-            = ARRAY'[0..0)
-            = []
-
-  (invariants hold)
-
-*/
-#define MK_BUF_MAKE(t,pre)                                                      \
-    static BUF(t) INLINE BUF_FUN(make,pre)                                      \
-                     (imempool_t *pool, iint_t sz)                              \
-    {                                                                           \
-        size_t bytes  = sizeof(t) * sz + sizeof(ibuf_struct);                   \
-        BUF(t) ret    = (BUF(t))imempool_alloc(pool, bytes);                    \
-        ret->max_size = sz;                                                     \
-        ret->cur_size = 0;                                                      \
-        ret->head     = 0;                                                      \
-        return ret;                                                             \
+        max_size     = sz;
+        cur_size     = 0;
+        head         = 0;
     }
 
-/*
-Push(buf, val)
- Pre
-  (buf invariants hold)
- Post
-  cur_size' = min max_size (cur_size+1)
-  read'     = (take (max_size - 1) read) ++ [val]
+    ibuf_t& push(const T& val)
+    {
+        iint_t head_new = (cur_size < max_size)
+                        ? head
+                        : (head + 1) % max_size;
+        iint_t size_new = cur_size < max_size
+                        ? cur_size + 1
+                        : max_size;
 
-*/
+        iint_t update   = (head + cur_size) % max_size;
 
-/*
-Push(buf, val)
-  {buf invariants hold}
-  ...
-  {
-  head'     = if cur_size < max_size
-              then head
-              else (head+1) % max_size
+        payload[update] = val;
 
-  cur_size' = min max_size (cur_size+1)
+        head            = head_new;
+        cur_size        = size_new;
 
-  ARRAY'    = ARRAY[update]:=val
-  read'     = ARRAY[head'..(head'+cur_size') % max_size)
-  update    = (head + cur_size) % max_size
-  }
-  ==>
-  {
-  cur_size' = min max_size (cur_size+1)
-  read'     = (take (max_size - 1) read) ++ [val]
-  }
+        return *this;
 
-*/
-
-#define MK_BUF_PUSH(t,pre)                                                      \
-    static BUF(t) INLINE BUF_FUN(push,pre) (BUF(t) buf, t val)                  \
-    {                                                                           \
-        iint_t head_new = (buf->cur_size < buf->max_size)                       \
-                        ?  buf->head                                            \
-                        : (buf->head+1) % buf->max_size;                        \
-                                                                                \
-        iint_t size_new = (buf->cur_size < buf->max_size)                       \
-                        ?  buf->cur_size + 1                                    \
-                        :  buf->max_size;                                       \
-                                                                                \
-        iint_t update   = (buf->head + buf->cur_size) % buf->max_size;          \
-                                                                                \
-        BUF_PAYLOAD(buf,t)[update] = val;                                       \
-                                                                                \
-        buf->head     = head_new;                                               \
-        buf->cur_size = size_new;                                               \
-        return buf;                                                             \
     }
 
-
-/*
-Read(buf)
- Pre
-  (buf invariants hold)
- Post
-  out       = read
-*/
-
-#define MK_BUF_READ(t,pre)                                                      \
-    static ARRAY(t) INLINE BUF_FUN(read,pre)                                    \
-                    (imempool_t *pool, BUF(t) buf)                              \
-    {                                                                           \
-        ARRAY(t) out = ARRAY_FUN(create,pre)(pool, buf->cur_size);              \
-                                                                                \
-        for (iint_t ix = 0; ix != buf->cur_size; ++ix)                          \
-        {                                                                       \
-            iint_t in = (buf->head + ix) % buf->max_size;                       \
-            ARRAY_PAYLOAD(out,t)[ix] = BUF_PAYLOAD(buf,t)[in];                  \
-        }                                                                       \
-                                                                                \
-        return out;                                                             \
+    iarray_t<T>& read(imempool_t* pool) const
+    {
+        iarray_t<T> out(pool, cur_size);
+        for (iint_t ix = 0; ix != cur_size; ++ix) {
+            iint_t in = (head + ix) % max_size;
+            out.put(ix, payload[in]);
+        }
+        return out;
     }
+};
 
-
-
-#define MAKE_BUF(t,pre)                                                         \
-    MK_BUF_STRUCT (t)                                                           \
-    MK_BUF_MAKE   (t,pre)                                                       \
-    MK_BUF_PUSH   (t,pre)                                                       \
-    MK_BUF_READ   (t,pre)
-
-MAKE_BUF(idouble_t,   idouble_)
-MAKE_BUF(iint_t,      iint_)
-MAKE_BUF(ierror_t,    ierror_)
-MAKE_BUF(ibool_t,     ibool_)
-MAKE_BUF(idate_t,     idate_)
-MAKE_BUF(iunit_t,     iunit_)
 

--- a/data/sea/31-buffer.h
+++ b/data/sea/31-buffer.h
@@ -1,13 +1,19 @@
 #include "30-array.h"
 
 template <typename T>
-class ibuf_t
+struct ibuf_t
 {
     iint_t max_size;
     iint_t cur_size;
     iint_t head;
 
     T* payload;
+
+    ibuf_t()
+    {
+        max_size = cur_size = head = 0;
+        payload  = 0;
+    }
 
     ibuf_t(imempool_t* pool, iint_t sz)
     {
@@ -39,7 +45,7 @@ class ibuf_t
 
     }
 
-    iarray_t<T>& read(imempool_t* pool) const
+    iarray_t<T> read(imempool_t* pool) const
     {
         iarray_t<T> out(pool, cur_size);
         for (iint_t ix = 0; ix != cur_size; ++ix) {

--- a/data/sea/32-map.h
+++ b/data/sea/32-map.h
@@ -1,0 +1,71 @@
+#include "31-buffer.h"
+
+template <typename K, typename V>
+class imap_t
+{
+    iint_t count;
+    K* keys;
+    V* vals;
+
+    imap_t()
+    {
+        this->count = 0;
+        this->keys  = 0;
+        this->vals  = 0;
+    }
+
+
+    iint_t length() const
+    {
+        return this->count;
+    }
+
+    imap_t<K,V>& put(imempool_t* pool, const K& key, const V& val)
+    {
+        for (iint_t ix = 0; ix != count; ++ix)
+        {
+            if (keys[ix] == key) {
+                vals[ix] = val;
+                return *this;
+            }
+        }
+
+        count = count + 1;
+        K* keys_ = imempool_alloc_of<K>(count);
+        V* vals_ = imempool_alloc_of<V>(count);
+
+        for (iint_t ix = 0; ix != count; ++ix)
+        {
+            keys_[ix] = keys[ix];
+            vals_[ix] = vals[ix];
+        }
+        keys_[count-1] = key;
+        vals_[count-1] = val;
+
+        keys = keys_;
+        vals = vals_;
+
+        return *this;
+    }
+
+    ioption_t<V> lookup(const K& key) const
+    {
+        for (iint_t ix = 0; ix != count; ++ix)
+        {
+            if (keys[ix] == key) {
+                return ioption_some(vals[ix]);
+            }
+        }
+        return ioption_none<V>();
+    }
+
+    ipair_t<K,V> index(iint_t ix) const
+    {
+        return ipair_pair(keys[ix], vals[ix]);
+    }
+
+
+    // TODO equality etc.
+    // equality would be much easier with an ordered map
+};
+

--- a/data/sea/32-map.h
+++ b/data/sea/32-map.h
@@ -1,7 +1,7 @@
 #include "31-buffer.h"
 
 template <typename K, typename V>
-class imap_t
+struct imap_t
 {
     iint_t count;
     K* keys;
@@ -30,18 +30,18 @@ class imap_t
             }
         }
 
-        count = count + 1;
-        K* keys_ = imempool_alloc_of<K>(count);
-        V* vals_ = imempool_alloc_of<V>(count);
+        K* keys_ = imempool_alloc_of<K>(pool, count+1);
+        V* vals_ = imempool_alloc_of<V>(pool, count+1);
 
         for (iint_t ix = 0; ix != count; ++ix)
         {
             keys_[ix] = keys[ix];
             vals_[ix] = vals[ix];
         }
-        keys_[count-1] = key;
-        vals_[count-1] = val;
+        keys_[count] = key;
+        vals_[count] = val;
 
+        count = count + 1;
         keys = keys_;
         vals = vals_;
 

--- a/doc/design/ice-v1.md
+++ b/doc/design/ice-v1.md
@@ -21,16 +21,16 @@ Todo
 
 ## High
 
-1. Melt maps into pair of arrays
-    - (should be simple after melt arrays because majority is done in flatten)
-    - Converting maps to/from C values
-2. Array of strings
-    - Converting to/from C values
-3. Melt bufs (tran)
-
-## Medium
-
-1. C implementation of parsing
+1. Read output from C evaluator.
+    - Currently does not handle Maps, Arrays etc
+2. Equality and comparison for ``ipair_t``, ``isum_t`` and so on
+    - Implement operator ``==, !=, <=`` etc as in ``istring_t``.
+3. Implement structs
+    - Each struct should become its own C++ class
+    - Find all unique struct types mentioned and generate class for each
+    - Class should have constructor, field accessors, equality and comparison
+4. C implementation of parsing
+    - So it goes fast
 
 ## Low
 

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -145,6 +145,7 @@ library
                        Icicle.Sea.FromAvalanche.Base
                        Icicle.Sea.FromAvalanche.Prim
                        Icicle.Sea.FromAvalanche.Program
+                       Icicle.Sea.FromAvalanche.Struct
                        Icicle.Sea.FromAvalanche.Type
                        Icicle.Sea.Preamble
 

--- a/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -26,8 +26,6 @@ constructor :: (Eq a, Ord n) => a -> Statement a n Prim -> Fresh n (Statement a 
 constructor a_fresh statements
  = transformUDStmt goS emptyExpEnv statements
  where
-  xApp       = XApp   a_fresh
-  xPrim      = XPrim  a_fresh
   xValue     = XValue a_fresh
   xTrue      = xValue BoolT (VBool True)
   xFalse     = xValue BoolT (VBool False)
@@ -79,18 +77,6 @@ constructor a_fresh statements
    = v
 
    -- safe projections
-   | Just (PrimProject (PrimProjectArrayLength _), [XVar _ n]) <- takePrimApps x
-   , Just x' <- get env n
-   , Just (ta, _, a, _) <- fromZippedArray x'
-   = xPrim (PrimProject $ PrimProjectArrayLength ta)
-    `xApp` a
-
-   | Just (PrimProject (PrimProjectArrayLength _), [XVar _ n]) <- takePrimApps x
-   , Just x' <- get env n
-   , Just (_, _, i, _, _) <- fromSummedArray x'
-   = xPrim (PrimProject $ PrimProjectArrayLength BoolT)
-    `xApp` i
-
    | Just (PrimProject (PrimProjectOptionIsSome _), [n]) <- takePrimApps x
    , Just x' <- resolve env n
    , Just (_,b,_) <- fromOption x'
@@ -102,21 +88,6 @@ constructor a_fresh statements
    = i
 
    -- unsafe projections
-   | Just (PrimUnsafe (PrimUnsafeArrayIndex _), [XVar _ n, ix]) <- takePrimApps x
-   , Just x' <- get env n
-   , Just (ta, tb, a, b) <- fromZippedArray x'
-   = xPrim (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair ta tb)
-    `xApp` (xPrim (PrimUnsafe (PrimUnsafeArrayIndex ta)) `xApp` a `xApp` ix)
-    `xApp` (xPrim (PrimUnsafe (PrimUnsafeArrayIndex tb)) `xApp` b `xApp` ix)
-
-   | Just (PrimUnsafe (PrimUnsafeArrayIndex _), [XVar _ n, ix]) <- takePrimApps x
-   , Just x' <- get env n
-   , Just (ta, tb, i, a, b) <- fromSummedArray x'
-   = xPrim (PrimPack $ PrimSumPack ta tb)
-    `xApp` (xPrim (PrimUnsafe (PrimUnsafeArrayIndex BoolT)) `xApp` i `xApp` ix)
-    `xApp` (xPrim (PrimUnsafe (PrimUnsafeArrayIndex ta))    `xApp` a `xApp` ix)
-    `xApp` (xPrim (PrimUnsafe (PrimUnsafeArrayIndex tb))    `xApp` b `xApp` ix)
-
    | Just (PrimUnsafe (PrimUnsafeOptionGet _), [n]) <- takePrimApps x
    , Just x' <- resolve env n
    , Just (_,_,v) <- fromOption x'
@@ -132,82 +103,9 @@ constructor a_fresh statements
    , Just (_,_,_,_,b) <- fromSum x'
    = b
 
-   -- * Update
-   --   put (sum i a b) ~> sum (put i) (put a) (put b)
-   | Just (PrimUpdate (PrimUpdateArrayPut _), [arr,ix,v]) <- takePrimApps x
-   , Just arrx              <- resolve env arr
-   , Just (ta, tb, i, a, b) <- fromSummedArray arrx
-   , boool                  <- xPrim (PrimProject (PrimProjectSumIsRight ta tb)) `xApp` v
-   , l                      <- xPrim (PrimUnsafe  (PrimUnsafeSumGetLeft  ta tb)) `xApp` v
-   , r                      <- xPrim (PrimUnsafe  (PrimUnsafeSumGetRight ta tb)) `xApp` v
-   , l'                     <- goX env l
-   , r'                     <- goX env r
-   = xPrim (PrimArray $ PrimArraySum ta tb)
-   `xApp` (xPrim (PrimUpdate (PrimUpdateArrayPut BoolT)) `xApp` i `xApp` ix `xApp` boool)
-   `xApp` (xPrim (PrimUpdate (PrimUpdateArrayPut ta))    `xApp` a `xApp` ix `xApp` l')
-   `xApp` (xPrim (PrimUpdate (PrimUpdateArrayPut tb))    `xApp` b `xApp` ix `xApp` r')
-
-   -- put (zip a b) ~> zip (put a) (put b)
-   | Just (PrimUpdate (PrimUpdateArrayPut _), [arr,ix,v]) <- takePrimApps x
-   , Just arrx           <- resolve env arr
-   , Just (ta, tb, a, b) <- fromZippedArray arrx
-   , f                   <- xPrim (PrimMinimal $ Min.PrimPair $ Min.PrimPairFst ta tb) `xApp` v
-   , s                   <- xPrim (PrimMinimal $ Min.PrimPair $ Min.PrimPairSnd ta tb) `xApp` v
-   , f'                  <- goX env f
-   , s'                  <- goX env s
-   = xPrim (PrimArray $ PrimArrayZip ta tb)
-   `xApp` (xPrim (PrimUpdate (PrimUpdateArrayPut ta)) `xApp` a `xApp` ix `xApp` f')
-   `xApp` (xPrim (PrimUpdate (PrimUpdateArrayPut ta)) `xApp` b `xApp` ix `xApp` s')
-
-   -- * Arrays
-   --   unzip [e1,e2,...en] ~> ([fst e1, fst e2, ..., fst en ], [snd e1, snd e2, ..., snd en])
-   | Just (PrimArray (PrimArrayUnzip _ _), [arr])       <- takePrimApps x
-   , Just (XValue _ (ArrayT (PairT ta tb)) (VArray xs)) <- resolve env arr
-   , Just (as, bs)                                      <- unzip' xs
-   = xValue
-      (PairT (ArrayT ta) (ArrayT tb))
-      (VPair (VArray as) (VArray bs))
-
-   -- unsum [e1..en] ~> ([isRight e1..isRight en], ([getLeft e1..getLeft en], [getRight e1..getRight en]))
-   | Just (PrimArray (PrimArrayUnsum _ _), [arr])      <- takePrimApps x
-   , Just (XValue _ (ArrayT (SumT ta tb)) (VArray xs)) <- resolve env arr
-   , Just (is, as, bs)                                 <- unsum' ta tb xs
-   = xValue
-      (PairT (ArrayT BoolT) (PairT (ArrayT ta) (ArrayT tb)))
-      (VPair (VArray is) (VPair (VArray as) (VArray bs)))
-
-   -- * "Rewrite rules"
-   --   unsum (sum i a b) ~> (i, (a, b))
-   | Just (PrimArray (PrimArrayUnsum ta tb), [n])       <- takePrimApps x
-   , Just arr                                           <- resolve env n
-   , Just (PrimArray (PrimArraySum   _  _),  [i, a, b]) <- takePrimApps arr
-   = xPrim (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair (ArrayT BoolT) (PairT (ArrayT ta) (ArrayT tb)))
-   `xApp` i
-   `xApp` (xPrim (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair (ArrayT ta) (ArrayT tb))
-           `xApp` a `xApp` b)
-
-   --   unzip (zip a b) ~> (a, b)
-   | Just (PrimArray (PrimArrayUnzip ta tb), [n])    <- takePrimApps x
-   , Just arr                                        <- resolve env n
-   , Just (PrimArray (PrimArrayZip   _  _),  [a, b]) <- takePrimApps arr
-   = xPrim (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair (ArrayT ta) (ArrayT tb))
-   `xApp` a `xApp` b
-
    | otherwise
    = x
 
-
-  fromZippedArray x
-   | Just (PrimArray (PrimArrayZip ta tb), [a, b]) <- takePrimApps x
-   = Just (ta, tb, a, b)
-   | otherwise
-   = Nothing
-
-  fromSummedArray x
-   | Just (PrimArray (PrimArraySum ta tb), [i, a, b]) <- takePrimApps x
-   = Just (ta, tb, i, a, b)
-   | otherwise
-   = Nothing
 
   fromPair x
    | XValue _ (PairT ta tb) (VPair a b) <- x
@@ -263,25 +161,6 @@ constructor a_fresh statements
    = Just (ta, tb, xTrue, xDefault ta, b)
 
    | otherwise
-   = Nothing
-
-  unzip' []
-    = return ([], [])
-  unzip' (VPair a b : xs)
-    = do (as, bs) <- unzip' xs
-         return (a:as, b:bs)
-  unzip' _
-    = Nothing
-
-  unsum' _ _ []
-   = return ([], [], [])
-  unsum' ta tb (VLeft a : xs)
-   = do (is', as', bs') <- unsum' ta tb xs
-        return (VBool False : is', a : as', defaultOfType tb : bs')
-  unsum' ta tb (VRight b : xs)
-   = do (is', as', bs') <- unsum' ta tb xs
-        return (VBool True : is', defaultOfType ta : as', b : bs')
-  unsum' _ _ _
    = Nothing
 
   -- Either lookup a name, or just return the value if it's already a constant.

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -220,26 +220,12 @@ primTypeOfPrim p
      -> unsa pu
     PrimUpdate pu
      -> upda pu
-    PrimArray (PrimArrayZip _ _)
-     -> Function "Array.zip"
-    PrimArray (PrimArrayUnzip _ _)
-     -> Function "Array.unzip"
-    PrimArray (PrimArraySum _ _)
-     -> Function "Array.sum"
-    PrimArray (PrimArrayUnsum _ _)
-     -> Function "Array.unsum"
     PrimPack (PrimOptionPack _)
      -> Function "Option.pack"
     PrimPack (PrimSumPack _ _)
      -> Function "Sum.pack"
     PrimPack (PrimStructPack _)
      -> Function "Struct.pack"
-    PrimMap (PrimMapPack _ _)
-     -> Function "Map.pack"
-    PrimMap (PrimMapUnpackKeys _ _)
-     -> Function "Map.unpackKeys"
-    PrimMap (PrimMapUnpackValues _ _)
-     -> Function "Map.unpackValues"
     PrimBuf pb
      -> buf pb
 
@@ -306,14 +292,18 @@ primTypeOfPrim p
   proj (PrimProjectArrayLength _) = Method "size"
   proj (PrimProjectOptionIsSome _)= Special1 $ \a -> a <> " != null"
   proj (PrimProjectSumIsRight _ _) = Method "isRight"
+  proj (PrimProjectMapLength _ _) = Method "size"
+  proj (PrimProjectMapLookup _ _) = Method "lookup"
 
   unsa (PrimUnsafeArrayIndex _)    = Method "get"
   unsa (PrimUnsafeArrayCreate t)   = Function ("new ArrayList" <> angled (boxedType t))
   unsa (PrimUnsafeOptionGet _)     = Special1 $ \a -> a
   unsa (PrimUnsafeSumGetLeft  _ _) = Method "left"
   unsa (PrimUnsafeSumGetRight _ _) = Method "right"
+  unsa (PrimUnsafeMapIndex _ _)    = Method "get"
 
   upda (PrimUpdateArrayPut _)      = Function "Array.put"
+  upda (PrimUpdateMapPut _ _)      = Function "Map.put"
 
   buf (PrimBufMake t) = Function $ "new IcicleBuf" <> angled (boxedType t)
   buf (PrimBufPush _) = Method "push"

--- a/src/Icicle/Sea/Eval.hs
+++ b/src/Icicle/Sea/Eval.hs
@@ -215,7 +215,7 @@ compilerOptions :: [CompilerOption]
 compilerOptions =
   [ "-O3"           -- 🔨
   , "-march=native" -- 🚀  all optimisations valid for the current CPU (AVX512, etc)
-  , "-std=c99"      -- 👹  variable declarations anywhere!
+  -- , "-std=c99"      -- 👹  variable declarations anywhere!
   , "-fPIC"         -- 🌏  position independent code, required on Linux
   ]
 

--- a/src/Icicle/Sea/FromAvalanche/Analysis.hs
+++ b/src/Icicle/Sea/FromAvalanche/Analysis.hs
@@ -8,6 +8,7 @@ module Icicle.Sea.FromAvalanche.Analysis (
   , accumsOfProgram
   , outputsOfProgram
   , readsOfProgram
+  , typesOfProgram
   ) where
 
 import           Icicle.Avalanche.Prim.Flat
@@ -16,12 +17,16 @@ import           Icicle.Avalanche.Statement.Statement
 
 import           Icicle.Common.Annot
 import           Icicle.Common.Base
+import           Icicle.Common.Exp
 import           Icicle.Common.Type
 
 import           P
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
 
 
 ------------------------------------------------------------------------
@@ -168,3 +173,63 @@ outputsOfStatement stmt
 
      Output n t xts
       -> Map.singleton n (t, fmap snd xts)
+
+------------------------------------------------------------------------
+
+typesOfProgram :: Program (Annot a) n Prim -> Set ValType
+typesOfProgram = typesOfStatement . statements
+
+typesOfStatement :: Statement (Annot a) n Prim -> Set ValType
+typesOfStatement stmt
+ = case stmt of
+     Block []              -> Set.empty
+     Block (s:ss)          -> typesOfStatement s  `Set.union`
+                              typesOfStatement (Block ss)
+     Let _ x ss            -> typesOfExp       x  `Set.union`
+                              typesOfStatement ss
+     If x tt ee            -> typesOfExp       x  `Set.union`
+                              typesOfStatement tt `Set.union`
+                              typesOfStatement ee
+     ForeachInts  _ f t ss -> typesOfExp       f `Set.union`
+                              typesOfExp       t `Set.union`
+                              typesOfStatement ss
+     ForeachFacts _ _ _ ss -> typesOfStatement ss
+     InitAccumulator (Accumulator _ at x) ss
+                           -> Set.singleton    at `Set.union`
+                              typesOfExp       x  `Set.union`
+                              typesOfStatement ss
+
+     Write _ x             -> typesOfExp x
+     LoadResumable _ vt    -> Set.singleton vt
+     SaveResumable _ vt    -> Set.singleton vt
+     Output _ vt xs        -> Set.singleton vt `Set.union`
+                              Set.unions (fmap goOut xs)
+     KeepFactInHistory     -> Set.empty
+
+     Read _ _ vt ss
+      -> Set.singleton vt `Set.union`
+         typesOfStatement ss
+
+ where
+  goOut (x,t)
+   = typesOfExp x `Set.union` Set.singleton t
+
+typesOfExp :: Exp (Annot a) n Prim -> Set ValType
+typesOfExp xx
+ = case xx of
+    XVar a _
+     -> ann a
+    XPrim a _
+     -> ann a
+    XValue _ vt _
+     -> Set.singleton vt
+    XApp a b c
+     -> ann a `Set.union` typesOfExp b `Set.union` typesOfExp c
+    XLam a _ vt b
+     -> ann a `Set.union` Set.singleton vt `Set.union` typesOfExp b
+    XLet a _ b c
+     -> ann a `Set.union` typesOfExp b `Set.union` typesOfExp c
+ where
+  ann a = Set.singleton $ functionReturns $ annType a
+
+

--- a/src/Icicle/Sea/FromAvalanche/Prim.hs
+++ b/src/Icicle/Sea/FromAvalanche/Prim.hs
@@ -65,9 +65,6 @@ seaOfXPrim p
      PrimUpdate op
       -> PDFun $ seaOfPrimUpdate op
 
-     PrimArray op
-      -> PDFun $ seaOfPrimArray op
-
      PrimBuf   op
       -> seaOfPrimBuf op
 
@@ -142,12 +139,8 @@ seaOfPrimUpdate p
  = case p of
      PrimUpdateArrayPut t
       -> prefixOfValType (ArrayT t) <> "put"
-
-seaOfPrimArray :: PrimArray -> Doc
-seaOfPrimArray p
- = case p of
-     _
-      -> seaError "seaOfPrimArray" p
+     PrimUpdateMapPut k v
+      -> prefixOfValType (MapT k v) <> "put"
 
 seaOfPrimBuf :: PrimBuf -> PrimDoc
 seaOfPrimBuf p

--- a/src/Icicle/Sea/FromAvalanche/Prim.hs
+++ b/src/Icicle/Sea/FromAvalanche/Prim.hs
@@ -170,7 +170,7 @@ seaOfPrimStruct :: M.PrimStruct -> PrimDoc
 seaOfPrimStruct p
  = case p of
      M.PrimStructGet f _ _
-      -> PDMeth (pretty f)
+      -> PDMeth ("getField__" <> pretty f)
 
 
 seaOfPrimRelation :: M.PrimRelation -> Doc

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -24,6 +24,7 @@ import qualified Icicle.Internal.Pretty as Pretty
 import           Icicle.Sea.FromAvalanche.Analysis
 import           Icicle.Sea.FromAvalanche.Base
 import           Icicle.Sea.FromAvalanche.Prim
+import           Icicle.Sea.FromAvalanche.Struct
 import           Icicle.Sea.FromAvalanche.Type
 
 import           P
@@ -40,10 +41,12 @@ seaOfProgram :: (Show a, Show n, Pretty n, Ord n)
              => Program (Annot a) n Prim -> Doc
 seaOfProgram program
  =  vsep
--- [ "#line 1 \"state definition\""
- [ stateOfProgram program
+ [ "#line 1 \"struct types\""
+ , makeStructDeclarations $ typesOfProgram program
+ , "#line 1 \"state definition\""
+ , stateOfProgram program
  , ""
--- , "#line 1 \"compute function\""
+ , "#line 1 \"compute function\""
  , "ICICLE_FUNCTION"
  , "void compute(icicle_state_t *s)"
  , "{"

--- a/src/Icicle/Sea/FromAvalanche/Struct.hs
+++ b/src/Icicle/Sea/FromAvalanche/Struct.hs
@@ -1,0 +1,70 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+
+module Icicle.Sea.FromAvalanche.Struct (
+    makeStructDeclaration
+  , makeStructDeclarations
+  ) where
+
+import           Icicle.Common.Type
+
+import           Icicle.Internal.Pretty
+
+import           Icicle.Sea.FromAvalanche.Base
+import           Icicle.Sea.FromAvalanche.Type
+
+import           P
+
+import qualified Data.Map as Map
+
+import           Data.Set (Set)
+import qualified Data.Set as Set
+
+makeStructDeclarations :: Set ValType -> Doc
+makeStructDeclarations tys
+ = mconcat
+ $ fmap go
+ $ Set.toList tys
+ where
+  go (StructT st)
+   = makeStructDeclaration st <> line
+  go _
+   = ""
+
+makeStructDeclaration :: StructType -> Doc
+makeStructDeclaration st@(StructType fs)
+ = vsep
+ [ "struct " <> typename
+ , "{"
+ , indent 4
+ $ vsep 
+ ( (fmap goField $ Map.toList fs)
+   <> [ctorNil, ctorPack])
+ , "};" ]
+ where
+  typename = noPadSeaOfValType (StructT st)
+
+  goField (nm,ty)
+   = seaOfValType ty <+> seaOfName nm <> ";"
+   <> line
+   <> seaOfValType ty <+> "getField__" <> seaOfName nm <> "() const"
+   <> line
+   <> "{ return this->" <> seaOfName nm <> "; }"
+
+  ctorNil
+   = typename <> "() {}"
+
+  ctorPack
+   = typename <> tupled (fmap arg $ Map.toList fs)
+   <> line
+   <> "{"
+   <> indent 4 (vsep $ fmap set $ Map.toList fs)
+   <> "}"
+
+  arg (nm,ty)
+   = noPadSeaOfValType ty <+> seaOfName nm
+
+  set (nm,_)
+   = "this->" <> seaOfName nm <> " = " <> seaOfName nm <> ";"
+

--- a/src/Icicle/Sea/FromAvalanche/Type.hs
+++ b/src/Icicle/Sea/FromAvalanche/Type.hs
@@ -24,6 +24,8 @@ import           Icicle.Sea.FromAvalanche.Base
 
 import           P
 
+import qualified Data.Map as Map
+
 
 prefixOfArithType :: ArithType -> Doc
 prefixOfArithType t
@@ -41,16 +43,8 @@ prefixOfValType t
      DoubleT   -> "idouble_"
      DateTimeT -> "idate_"
      ErrorT    -> "ierror_"
-
      StringT   -> "istring_"
-     BufT   t' -> "ibuf__"   <> prefixOfValType t'
-     ArrayT t' -> "iarray__" <> prefixOfValType t'
-     MapT{}    -> nope "maps not implemented"
-
-     StructT{} -> nope "structs should have been melted"
-     OptionT{} -> nope "options should have been melted"
-     PairT{}   -> nope "pairs should have been melted"
-     SumT{}    -> nope "sums should have been melted"
+     _         -> nope ("no prefix operations for " <> show t)
 
 ------------------------------------------------------------------------
 
@@ -77,7 +71,11 @@ stringOfValType t
      ArrayT t' -> "iarray_t" <> templateOfValType [t']
 
      MapT k v  -> "imap_t" <> templateOfValType [k,v]
-     StructT{} -> "structs should have been melted"
+     StructT (StructType ts)
+      -> "istruct_t_"
+      <> ( intercalate "__"
+         $ fmap (\(ff,tt) -> show (pretty ff) <> "_" <> stringOfValType tt)
+         $ Map.toList ts)
      OptionT t'-> "ioption_t" <> templateOfValType [t']
      PairT a b -> "ipair_t" <> templateOfValType [a,b]
      SumT a b  -> "isum_t" <> templateOfValType [a,b]

--- a/test/Icicle/Test/Data/DateTime.hs
+++ b/test/Icicle/Test/Data/DateTime.hs
@@ -110,11 +110,11 @@ code = textOfDoc $ seaPreamble PP.</> seaTestables
 
 seaTestables :: PP.Doc
 seaTestables = PP.vsep
-  [ "iint_t testable_idate_to_epoch     (idate_t x)            { return idate_to_epoch     (x);    }"
-  , "iint_t testable_idate_from_epoch   (iint_t g)             { return idate_from_epoch   (g);    }"
-  , "iint_t testable_idate_days_diff    (idate_t x, idate_t y) { return idate_days_diff    (x, y); }"
-  , "iint_t testable_idate_minus_days   (idate_t x, iint_t y)  { return idate_minus_days   (x, y); }"
-  , "iint_t testable_idate_minus_months (idate_t x, iint_t y)  { return idate_minus_months (x, y); }"
+  [ "extern \"C\" iint_t testable_idate_to_epoch     (idate_t x)            { return idate_to_epoch     (x);    }"
+  , "extern \"C\" iint_t testable_idate_from_epoch   (iint_t g)             { return idate_from_epoch   (g);    }"
+  , "extern \"C\" iint_t testable_idate_days_diff    (idate_t x, idate_t y) { return idate_days_diff    (x, y); }"
+  , "extern \"C\" iint_t testable_idate_minus_days   (idate_t x, iint_t y)  { return idate_minus_days   (x, y); }"
+  , "extern \"C\" iint_t testable_idate_minus_months (idate_t x, iint_t y)  { return idate_minus_months (x, y); }"
   ]
 
 -- These C testing utils should perhaps be generalised and placed in their own module.

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -16,25 +16,25 @@ gen$date = DATE
   load_resumable@{Error} acc$c$conv$13$simp$5;
   load_resumable@{Int} acc$c$conv$13$simp$6;
   load_resumable@{Buf (Sum Error Int)} acc$conv$30;
-  for_facts (gen$fact$simp$62$simp$64@{Bool},
-             gen$fact$simp$62$simp$65@{Error},
-             gen$fact$simp$62$simp$66@{Int},
-             gen$fact$simp$63@{DateTime}) in new {
+  for_facts (gen$fact$simp$50$simp$52@{Bool},
+             gen$fact$simp$50$simp$53@{Error},
+             gen$fact$simp$50$simp$54@{Int},
+             gen$fact$simp$51@{DateTime}) in new {
     read@{Buf (Sum Error Int)} acc$conv$30 = acc$conv$30;
-    let simp$69 = Sum_pack#@{Error, Int}
-                  gen$fact$simp$62$simp$64
-                  gen$fact$simp$62$simp$65
-                  gen$fact$simp$62$simp$66;
+    let simp$57 = Sum_pack#@{Error, Int}
+                  gen$fact$simp$50$simp$52
+                  gen$fact$simp$50$simp$53
+                  gen$fact$simp$50$simp$54;
     let flat$0 = Buf_push#@{(Sum Error Int)}
-                 acc$conv$30 simp$69;
+                 acc$conv$30 simp$57;
     write acc$conv$30 = flat$0;
     init flat$1$simp$7@{Bool} = False@{Bool};
     init flat$1$simp$9@{Bool} = False@{Bool};
-    if (gen$fact$simp$62$simp$64) {
+    if (gen$fact$simp$50$simp$52) {
       write flat$1$simp$7 = True@{Bool};
-      let simp$79 = gt#@{Int}
-                    gen$fact$simp$62$simp$66 (10@{Int});
-      write flat$1$simp$9 = simp$79;
+      let simp$67 = gt#@{Int}
+                    gen$fact$simp$50$simp$54 (10@{Int});
+      write flat$1$simp$9 = simp$67;
     } else {
       write flat$1$simp$7 = False@{Bool};
       write flat$1$simp$9 = False@{Bool};
@@ -57,16 +57,16 @@ gen$date = DATE
       init flat$3$simp$16@{Bool} = False@{Bool};
       init flat$3$simp$17@{Error} = ExceptTombstone@{Error};
       init flat$3$simp$18@{Int} = 0@{Int};
-      if (gen$fact$simp$62$simp$64) {
+      if (gen$fact$simp$50$simp$52) {
         init flat$6$simp$19@{Bool} = False@{Bool};
         init flat$6$simp$20@{Error} = ExceptTombstone@{Error};
         init flat$6$simp$21@{Int} = 0@{Int};
         if (acc$c$conv$13$simp$13) {
           write flat$6$simp$19 = True@{Bool};
-          let simp$100 = add#@{Int}
-                         acc$c$conv$13$simp$15 (1@{Int});
+          let simp$88 = add#@{Int}
+                        acc$c$conv$13$simp$15 (1@{Int});
           write flat$6$simp$20 = ExceptTombstone@{Error};
-          write flat$6$simp$21 = simp$100;
+          write flat$6$simp$21 = simp$88;
         } else {
           write flat$6$simp$19 = False@{Bool};
           write flat$6$simp$20 = acc$c$conv$13$simp$14;
@@ -95,7 +95,7 @@ gen$date = DATE
         write flat$3$simp$18 = flat$7$simp$30;
       } else {
         write flat$3$simp$16 = False@{Bool};
-        write flat$3$simp$17 = gen$fact$simp$62$simp$65;
+        write flat$3$simp$17 = gen$fact$simp$50$simp$53;
         write flat$3$simp$18 = 0@{Int};
       }
       read@{Bool} flat$3$simp$31 = flat$3$simp$16;
@@ -117,49 +117,28 @@ gen$date = DATE
   init flat$16$simp$37@{Bool} = False@{Bool};
   init flat$16$simp$38@{Error} = ExceptTombstone@{Error};
   init flat$16$simp$39$simp$40@{Int} = 0@{Int};
-  init flat$16$simp$39$simp$41$simp$45@{Array Bool} = []@{Array Bool};
-  init flat$16$simp$39$simp$41$simp$46@{Array Error} = []@{Array Error};
-  init flat$16$simp$39$simp$41$simp$47@{Array Int} = []@{Array Int};
+  init flat$16$simp$39$simp$41@{Array (Sum Error Int)} = []@{Array (Sum Error Int)};
   if (c$conv$13$simp$34) {
     let flat$19 = Buf_read#@{(Sum Error Int)}
                   conv$30;
-    let simp$178 = Array_unsum#@{Error, Int}
-                   flat$19;
-    let conv$31$simp$59 = fst#@{Array Bool, (Array Error, Array Int)}
-                          simp$178;
-    let simp$182 = snd#@{Array Bool, (Array Error, Array Int)} simp$178;
-    let conv$31$simp$60 = fst#@{Array Error, Array Int}
-                          simp$182;
-    let conv$31$simp$61 = snd#@{Array Error, Array Int}
-                          simp$182;
     write flat$16$simp$37 = True@{Bool};
     write flat$16$simp$38 = ExceptTombstone@{Error};
     write flat$16$simp$39$simp$40 = c$conv$13$simp$36;
-    write flat$16$simp$39$simp$41$simp$45 = conv$31$simp$59;
-    write flat$16$simp$39$simp$41$simp$46 = conv$31$simp$60;
-    write flat$16$simp$39$simp$41$simp$47 = conv$31$simp$61;
+    write flat$16$simp$39$simp$41 = flat$19;
   } else {
     write flat$16$simp$37 = False@{Bool};
     write flat$16$simp$38 = c$conv$13$simp$35;
     write flat$16$simp$39$simp$40 = 0@{Int};
-    write flat$16$simp$39$simp$41$simp$45 = []@{Array Bool};
-    write flat$16$simp$39$simp$41$simp$46 = []@{Array Error};
-    write flat$16$simp$39$simp$41$simp$47 = []@{Array Int};
+    write flat$16$simp$39$simp$41 = []@{Array (Sum Error Int)};
   }
-  read@{Bool} flat$16$simp$48 = flat$16$simp$37;
-  read@{Error} flat$16$simp$49 = flat$16$simp$38;
-  read@{Int} flat$16$simp$50$simp$51 = flat$16$simp$39$simp$40;
-  read@{Array Bool} flat$16$simp$50$simp$52$simp$53 = flat$16$simp$39$simp$41$simp$45;
-  read@{Array Error} flat$16$simp$50$simp$52$simp$54 = flat$16$simp$39$simp$41$simp$46;
-  read@{Array Int} flat$16$simp$50$simp$52$simp$55 = flat$16$simp$39$simp$41$simp$47;
-  let simp$241 = Array_sum#@{Error, Int}
-                 flat$16$simp$50$simp$52$simp$53
-                 flat$16$simp$50$simp$52$simp$54
-                 flat$16$simp$50$simp$52$simp$55;
-  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$16$simp$48@{Bool},
-               flat$16$simp$49@{Error},
-               flat$16$simp$50$simp$51@{Int},
-               simp$241@{Array (Sum Error Int)});
+  read@{Bool} flat$16$simp$42 = flat$16$simp$37;
+  read@{Error} flat$16$simp$43 = flat$16$simp$38;
+  read@{Int} flat$16$simp$44$simp$45 = flat$16$simp$39$simp$40;
+  read@{Array (Sum Error Int)} flat$16$simp$44$simp$46 = flat$16$simp$39$simp$41;
+  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$16$simp$42@{Bool},
+               flat$16$simp$43@{Error},
+               flat$16$simp$44$simp$45@{Int},
+               flat$16$simp$44$simp$46@{Array (Sum Error Int)});
 }
 
 - Core evaluation:
@@ -172,279 +151,168 @@ gen$date = DATE
 {
   init acc$conv$2@{Map DateTime (Buf ((Sum Error Int), DateTime))} = Map []@{Map DateTime (Buf ((Sum Error Int), DateTime))};
   load_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
-  for_facts (gen$fact$simp$108$simp$110@{Bool},
-             gen$fact$simp$108$simp$111@{Error},
-             gen$fact$simp$108$simp$112@{Int},
-             gen$fact$simp$109@{DateTime}) in new {
+  for_facts (gen$fact$simp$70$simp$72@{Bool},
+             gen$fact$simp$70$simp$73@{Error},
+             gen$fact$simp$70$simp$74@{Int},
+             gen$fact$simp$71@{DateTime}) in new {
     read@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2 = acc$conv$2;
-    let simp$115 = Sum_pack#@{Error, Int}
-                   gen$fact$simp$108$simp$110
-                   gen$fact$simp$108$simp$111
-                   gen$fact$simp$108$simp$112;
-    let simp$116 = pair#@{(Sum Error Int) DateTime} simp$115
-                   gen$fact$simp$109;
+    let simp$77 = Sum_pack#@{Error, Int}
+                  gen$fact$simp$70$simp$72
+                  gen$fact$simp$70$simp$73
+                  gen$fact$simp$70$simp$74;
+    let simp$78 = pair#@{(Sum Error Int) DateTime} simp$77
+                  gen$fact$simp$71;
     let flat$0 = Buf_push#@{((Sum Error Int), DateTime)}
-                 (Buf 2 []@{Buf ((Sum Error Int), DateTime)}) simp$116;
-    init flat$1@{Bool} = False@{Bool};
-    init flat$2@{Array DateTime} = Map_unpack_keys#@{DateTime Buf ((Sum Error Int), DateTime)}
-                  acc$conv$2;
-    init flat$3@{Array (Buf ((Sum Error Int), DateTime))} = Map_unpack_values#@{DateTime Buf ((Sum Error Int), DateTime)}
-                  acc$conv$2;
-    read@{Array DateTime} flat$2 = flat$2;
-    let flat$4 = Array_length#@{DateTime}
-                 flat$2;
-    foreach (flat$5 in 0@{Int}..flat$4) {
-      read@{Array DateTime} flat$2 = flat$2;
-      read@{Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
-      let simp$1 = unsafe_Array_index#@{DateTime}
-                   flat$2 flat$5;
-      if (eq#@{DateTime} simp$1
-          gen$fact$simp$109) {
-        let flat$6 = unsafe_Array_index#@{Buf ((Sum Error Int), DateTime)}
-                     flat$3 flat$5;
-        let flat$7 = Buf_push#@{((Sum Error Int), DateTime)} flat$6
-                     simp$116;
-        write flat$3 = Array_put#@{Buf ((Sum Error Int), DateTime)} flat$3
-                       flat$5 flat$7;
-        write flat$1 = True@{Bool};
-      }
-    }
-    read@{Bool} flat$1 = flat$1;
-    if (flat$1) {
-      
+                 (Buf 2 []@{Buf ((Sum Error Int), DateTime)}) simp$78;
+    init flat$4@{Map DateTime (Buf ((Sum Error Int), DateTime))} = acc$conv$2;
+    let flat$1 = Map_lookup#@{DateTime, Buf ((Sum Error Int), DateTime)}
+                 acc$conv$2 gen$fact$simp$71;
+    if (Option_isSome# [Buf ((Sum Error Int), DateTime)]
+        flat$1) {
+      let flat$3 = unsafe_Option_get#@{Buf ((Sum Error Int), DateTime)}
+                   flat$1;
+      let flat$6 = Buf_push#@{((Sum Error Int), DateTime)} flat$3
+                   simp$78;
+      write flat$4 = Map_put#@{DateTime, Buf ((Sum Error Int), DateTime)}
+                     acc$conv$2 gen$fact$simp$71
+                     flat$6;
     } else {
-      read@{Array DateTime} flat$9 = flat$2;
-      let simp$4 = Array_length#@{DateTime}
-                   flat$9;
-      let simp$5 = add#@{Int} simp$4 (1@{Int});
-      init flat$8@{Array DateTime} = unsafe_Array_create#@{DateTime}
-                    simp$5;
-      foreach (flat$10 in 0@{Int}..Array_length#@{DateTime}
-                             flat$9) {
-        read@{Array DateTime} flat$8 = flat$8;
-        let simp$7 = unsafe_Array_index#@{DateTime}
-                     flat$9 flat$10;
-        write flat$8 = Array_put#@{DateTime} flat$8
-                       flat$10 simp$7;
-      }
-      read@{Array DateTime} flat$8 = flat$8;
-      write flat$8 = Array_put#@{DateTime} flat$8
-                     simp$4 gen$fact$simp$109;
-      read@{Array DateTime} flat$8 = flat$8;
-      write flat$2 = flat$8;
-      read@{Array (Buf ((Sum Error Int), DateTime))} flat$12 = flat$3;
-      let simp$12 = Array_length#@{Buf ((Sum Error Int), DateTime)}
-                    flat$12;
-      let simp$13 = add#@{Int} simp$12 (1@{Int});
-      init flat$11@{Array (Buf ((Sum Error Int), DateTime))} = unsafe_Array_create#@{Buf ((Sum Error Int), DateTime)}
-                     simp$13;
-      foreach (flat$13 in 0@{Int}..Array_length#@{Buf ((Sum Error Int), DateTime)}
-                             flat$12) {
-        read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
-        let simp$15 = unsafe_Array_index#@{Buf ((Sum Error Int), DateTime)}
-                      flat$12 flat$13;
-        write flat$11 = Array_put#@{Buf ((Sum Error Int), DateTime)}
-                        flat$11 flat$13 simp$15;
-      }
-      read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
-      write flat$11 = Array_put#@{Buf ((Sum Error Int), DateTime)}
-                      flat$11 simp$12 flat$0;
-      read@{Array (Buf ((Sum Error Int), DateTime))} flat$11 = flat$11;
-      write flat$3 = flat$11;
-    }
-    read@{Array DateTime} flat$2 = flat$2;
-    read@{Array (Buf ((Sum Error Int), DateTime))} flat$3 = flat$3;
-    let flat$14 = Map_pack#@{DateTime Buf ((Sum Error Int), DateTime)} flat$2
-                  flat$3;
-    write acc$conv$2 = flat$14;
+      write flat$4 = Map_put#@{DateTime, Buf ((Sum Error Int), DateTime)}
+                     acc$conv$2 gen$fact$simp$71
+                     flat$0;
+    } 
+    
+    read@{Map DateTime (Buf ((Sum Error Int), DateTime))} flat$5 = flat$4;
+    write acc$conv$2 = flat$5;
   }
   save_resumable@{Map DateTime (Buf ((Sum Error Int), DateTime))} acc$conv$2;
   read@{Map DateTime (Buf ((Sum Error Int), DateTime))} conv$2 = acc$conv$2;
-  let flat$15 = Map_unpack_keys#@{DateTime Buf ((Sum Error Int), DateTime)}
-                conv$2;
-  let flat$16 = Map_unpack_values#@{DateTime Buf ((Sum Error Int), DateTime)}
-                conv$2;
-  init flat$20$simp$40@{Bool} = True@{Bool};
-  init flat$20$simp$41@{Error} = ExceptTombstone@{Error};
-  init flat$20$simp$42@{Map DateTime Int} = Map []@{Map DateTime Int};
-  foreach (flat$21 in 0@{Int}..Array_length#@{DateTime}
-                         flat$15) {
-    read@{Bool} flat$20$simp$43 = flat$20$simp$40;
-    read@{Error} flat$20$simp$44 = flat$20$simp$41;
-    read@{Map DateTime Int} flat$20$simp$45 = flat$20$simp$42;
-    let conv$26 = unsafe_Array_index#@{DateTime}
-                  flat$15 flat$21;
-    let conv$5 = unsafe_Array_index#@{Buf ((Sum Error Int), DateTime)}
-                 flat$16 flat$21;
-    init flat$23$simp$46@{Bool} = False@{Bool};
-    init flat$23$simp$47@{Error} = ExceptTombstone@{Error};
-    init flat$23$simp$48@{Map DateTime Int} = Map []@{Map DateTime Int};
-    if (flat$20$simp$43) {
-      let flat$26 = Buf_read#@{((Sum Error Int), DateTime)}
-                    conv$5;
-      let simp$130 = Array_unzip#@{(Sum Error Int), DateTime}
-                     flat$26;
-      let conv$6$simp$103 = fst#@{Array (Sum Error Int), Array DateTime}
-                            simp$130;
-      init flat$27$simp$50$simp$54$simp$56@{Bool} = True@{Bool};
-      init flat$27$simp$50$simp$54$simp$57@{Error} = ExceptTombstone@{Error};
-      init flat$27$simp$50$simp$54$simp$58@{Int} = 0@{Int};
-      foreach (flat$44 in 0@{Int}..Array_length#@{(Sum Error Int)}
-                             conv$6$simp$103) {
-        read@{Bool} flat$27$simp$60$simp$64$simp$66 = flat$27$simp$50$simp$54$simp$56;
-        read@{Error} flat$27$simp$60$simp$64$simp$67 = flat$27$simp$50$simp$54$simp$57;
-        read@{Int} flat$27$simp$60$simp$64$simp$68 = flat$27$simp$50$simp$54$simp$58;
-        let v$inline$0$conv$13 = unsafe_Array_index#@{(Sum Error Int)}
-                                 conv$6$simp$103 flat$44;
-        init flat$46$simp$69@{Bool} = False@{Bool};
-        init flat$46$simp$70@{Error} = ExceptTombstone@{Error};
-        init flat$46$simp$71@{Int} = 0@{Int};
+  init flat$7$simp$4@{Bool} = True@{Bool};
+  init flat$7$simp$5@{Error} = ExceptTombstone@{Error};
+  init flat$7$simp$6@{Map DateTime Int} = Map []@{Map DateTime Int};
+  foreach (flat$8 in 0@{Int}..Map_length#@{DateTime, Buf ((Sum Error Int), DateTime)}
+                        conv$2) {
+    let flat$9 = unsafe_Map_index#@{DateTime, Buf ((Sum Error Int), DateTime)}
+                 conv$2 flat$8;
+    let flat$10 = fst#@{DateTime, Buf ((Sum Error Int), DateTime)} flat$9;
+    let flat$11 = snd#@{DateTime, Buf ((Sum Error Int), DateTime)} flat$9;
+    read@{Bool} flat$7$simp$7 = flat$7$simp$4;
+    read@{Error} flat$7$simp$8 = flat$7$simp$5;
+    read@{Map DateTime Int} flat$7$simp$9 = flat$7$simp$6;
+    init flat$12$simp$10@{Bool} = False@{Bool};
+    init flat$12$simp$11@{Error} = ExceptTombstone@{Error};
+    init flat$12$simp$12@{Map DateTime Int} = Map []@{Map DateTime Int};
+    if (flat$7$simp$7) {
+      let flat$15 = Buf_read#@{((Sum Error Int), DateTime)}
+                    flat$11;
+      init flat$16$simp$14$simp$18$simp$20@{Bool} = True@{Bool};
+      init flat$16$simp$14$simp$18$simp$21@{Error} = ExceptTombstone@{Error};
+      init flat$16$simp$14$simp$18$simp$22@{Int} = 0@{Int};
+      foreach (flat$25 in 0@{Int}..Array_length#@{((Sum Error Int), DateTime)}
+                             flat$15) {
+        read@{Bool} flat$16$simp$24$simp$28$simp$30 = flat$16$simp$14$simp$18$simp$20;
+        read@{Error} flat$16$simp$24$simp$28$simp$31 = flat$16$simp$14$simp$18$simp$21;
+        read@{Int} flat$16$simp$24$simp$28$simp$32 = flat$16$simp$14$simp$18$simp$22;
+        let flat$26 = unsafe_Array_index#@{((Sum Error Int), DateTime)}
+                      flat$15 flat$25;
+        let v$inline$0$conv$13 = fst#@{(Sum Error Int), DateTime}
+                                 flat$26;
+        init flat$27$simp$33@{Bool} = False@{Bool};
+        init flat$27$simp$34@{Error} = ExceptTombstone@{Error};
+        init flat$27$simp$35@{Int} = 0@{Int};
         if (Sum_isRight#@{Error, Int}
             v$inline$0$conv$13) {
-          let flat$48 = unsafe_Sum_right#@{Error, Int}
+          let flat$29 = unsafe_Sum_right#@{Error, Int}
                         v$inline$0$conv$13;
-          init flat$49$simp$72@{Bool} = False@{Bool};
-          init flat$49$simp$73@{Error} = ExceptTombstone@{Error};
-          init flat$49$simp$74@{Int} = 0@{Int};
-          if (flat$27$simp$60$simp$64$simp$66) {
-            let simp$164 = add#@{Int} flat$48
-                           flat$27$simp$60$simp$64$simp$68;
-            write flat$49$simp$72 = True@{Bool};
-            write flat$49$simp$73 = ExceptTombstone@{Error};
-            write flat$49$simp$74 = simp$164;
+          init flat$30$simp$36@{Bool} = False@{Bool};
+          init flat$30$simp$37@{Error} = ExceptTombstone@{Error};
+          init flat$30$simp$38@{Int} = 0@{Int};
+          if (flat$16$simp$24$simp$28$simp$30) {
+            let simp$118 = add#@{Int} flat$29
+                           flat$16$simp$24$simp$28$simp$32;
+            write flat$30$simp$36 = True@{Bool};
+            write flat$30$simp$37 = ExceptTombstone@{Error};
+            write flat$30$simp$38 = simp$118;
           } else {
-            write flat$49$simp$72 = False@{Bool};
-            write flat$49$simp$73 = flat$27$simp$60$simp$64$simp$67;
-            write flat$49$simp$74 = 0@{Int};
+            write flat$30$simp$36 = False@{Bool};
+            write flat$30$simp$37 = flat$16$simp$24$simp$28$simp$31;
+            write flat$30$simp$38 = 0@{Int};
           }
-          read@{Bool} flat$49$simp$75 = flat$49$simp$72;
-          read@{Error} flat$49$simp$76 = flat$49$simp$73;
-          read@{Int} flat$49$simp$77 = flat$49$simp$74;
-          write flat$46$simp$69 = flat$49$simp$75;
-          write flat$46$simp$70 = flat$49$simp$76;
-          write flat$46$simp$71 = flat$49$simp$77;
+          read@{Bool} flat$30$simp$39 = flat$30$simp$36;
+          read@{Error} flat$30$simp$40 = flat$30$simp$37;
+          read@{Int} flat$30$simp$41 = flat$30$simp$38;
+          write flat$27$simp$33 = flat$30$simp$39;
+          write flat$27$simp$34 = flat$30$simp$40;
+          write flat$27$simp$35 = flat$30$simp$41;
         } else {
-          let flat$47 = unsafe_Sum_left#@{Error, Int}
+          let flat$28 = unsafe_Sum_left#@{Error, Int}
                         v$inline$0$conv$13;
-          write flat$46$simp$69 = False@{Bool};
-          write flat$46$simp$70 = flat$47;
-          write flat$46$simp$71 = 0@{Int};
+          write flat$27$simp$33 = False@{Bool};
+          write flat$27$simp$34 = flat$28;
+          write flat$27$simp$35 = 0@{Int};
         }
-        read@{Bool} flat$46$simp$78 = flat$46$simp$69;
-        read@{Error} flat$46$simp$79 = flat$46$simp$70;
-        read@{Int} flat$46$simp$80 = flat$46$simp$71;
-        write flat$27$simp$50$simp$54$simp$56 = flat$46$simp$78;
-        write flat$27$simp$50$simp$54$simp$57 = flat$46$simp$79;
-        write flat$27$simp$50$simp$54$simp$58 = flat$46$simp$80;
+        read@{Bool} flat$27$simp$42 = flat$27$simp$33;
+        read@{Error} flat$27$simp$43 = flat$27$simp$34;
+        read@{Int} flat$27$simp$44 = flat$27$simp$35;
+        write flat$16$simp$14$simp$18$simp$20 = flat$27$simp$42;
+        write flat$16$simp$14$simp$18$simp$21 = flat$27$simp$43;
+        write flat$16$simp$14$simp$18$simp$22 = flat$27$simp$44;
       }
-      read@{Bool} flat$27$simp$82$simp$86$simp$88 = flat$27$simp$50$simp$54$simp$56;
-      read@{Error} flat$27$simp$82$simp$86$simp$89 = flat$27$simp$50$simp$54$simp$57;
-      read@{Int} flat$27$simp$82$simp$86$simp$90 = flat$27$simp$50$simp$54$simp$58;
-      init flat$28$simp$91@{Bool} = False@{Bool};
-      init flat$28$simp$92@{Error} = ExceptTombstone@{Error};
-      init flat$28$simp$93@{Map DateTime Int} = Map []@{Map DateTime Int};
-      if (flat$27$simp$82$simp$86$simp$88) {
-        init flat$31@{Bool} = False@{Bool};
-        init flat$32@{Array DateTime} = Map_unpack_keys#@{DateTime Int}
-                       flat$20$simp$45;
-        init flat$33@{Array Int} = Map_unpack_values#@{DateTime Int}
-                       flat$20$simp$45;
-        read@{Array DateTime} flat$32 = flat$32;
-        let flat$34 = Array_length#@{DateTime}
-                      flat$32;
-        foreach (flat$35 in 0@{Int}..flat$34) {
-          read@{Array DateTime} flat$32 = flat$32;
-          read@{Array Int} flat$33 = flat$33;
-          let simp$23 = unsafe_Array_index#@{DateTime}
-                        flat$32 flat$35;
-          if (eq#@{DateTime} simp$23 conv$26) {
-            let flat$36 = unsafe_Array_index#@{Int}
-                          flat$33 flat$35;
-            write flat$33 = Array_put#@{Int}
-                            flat$33 flat$35 flat$36;
-            write flat$31 = True@{Bool};
-          }
-        }
-        read@{Bool} flat$31 = flat$31;
-        if (flat$31) {
-          
+      read@{Bool} flat$16$simp$46$simp$50$simp$52 = flat$16$simp$14$simp$18$simp$20;
+      read@{Error} flat$16$simp$46$simp$50$simp$53 = flat$16$simp$14$simp$18$simp$21;
+      read@{Int} flat$16$simp$46$simp$50$simp$54 = flat$16$simp$14$simp$18$simp$22;
+      init flat$17$simp$55@{Bool} = False@{Bool};
+      init flat$17$simp$56@{Error} = ExceptTombstone@{Error};
+      init flat$17$simp$57@{Map DateTime Int} = Map []@{Map DateTime Int};
+      if (flat$16$simp$46$simp$50$simp$52) {
+        init flat$23@{Map DateTime Int} = flat$7$simp$9;
+        let flat$20 = Map_lookup#@{DateTime, Int}
+                      flat$7$simp$9 flat$10;
+        if (Option_isSome# [Int]
+            flat$20) {
+          let flat$22 = unsafe_Option_get#@{Int}
+                        flat$20;
+          write flat$23 = Map_put#@{DateTime, Int}
+                          flat$7$simp$9 flat$10 flat$22;
         } else {
-          read@{Array DateTime} flat$38 = flat$32;
-          let simp$26 = Array_length#@{DateTime}
-                        flat$38;
-          let simp$27 = add#@{Int} simp$26 (1@{Int});
-          init flat$37@{Array DateTime} = unsafe_Array_create#@{DateTime}
-                         simp$27;
-          foreach (flat$39 in 0@{Int}..Array_length#@{DateTime}
-                                 flat$38) {
-            read@{Array DateTime} flat$37 = flat$37;
-            let simp$29 = unsafe_Array_index#@{DateTime}
-                          flat$38 flat$39;
-            write flat$37 = Array_put#@{DateTime}
-                            flat$37 flat$39 simp$29;
-          }
-          read@{Array DateTime} flat$37 = flat$37;
-          write flat$37 = Array_put#@{DateTime}
-                          flat$37 simp$26 conv$26;
-          read@{Array DateTime} flat$37 = flat$37;
-          write flat$32 = flat$37;
-          read@{Array Int} flat$41 = flat$33;
-          let simp$34 = Array_length#@{Int}
-                        flat$41;
-          let simp$35 = add#@{Int} simp$34 (1@{Int});
-          init flat$40@{Array Int} = unsafe_Array_create#@{Int}
-                         simp$35;
-          foreach (flat$42 in 0@{Int}..Array_length#@{Int}
-                                 flat$41) {
-            read@{Array Int} flat$40 = flat$40;
-            let simp$37 = unsafe_Array_index#@{Int}
-                          flat$41 flat$42;
-            write flat$40 = Array_put#@{Int}
-                            flat$40 flat$42 simp$37;
-          }
-          read@{Array Int} flat$40 = flat$40;
-          write flat$40 = Array_put#@{Int}
-                          flat$40 simp$34
-                          flat$27$simp$82$simp$86$simp$90;
-          read@{Array Int} flat$40 = flat$40;
-          write flat$33 = flat$40;
-        }
-        read@{Array DateTime} flat$32 = flat$32;
-        read@{Array Int} flat$33 = flat$33;
-        let flat$43 = Map_pack#@{DateTime Int} flat$32
-                      flat$33;
-        write flat$28$simp$91 = True@{Bool};
-        write flat$28$simp$92 = ExceptTombstone@{Error};
-        write flat$28$simp$93 = flat$43;
+          write flat$23 = Map_put#@{DateTime, Int}
+                          flat$7$simp$9 flat$10
+                          flat$16$simp$46$simp$50$simp$54;
+        } 
+        
+        read@{Map DateTime Int} flat$24 = flat$23;
+        write flat$17$simp$55 = True@{Bool};
+        write flat$17$simp$56 = ExceptTombstone@{Error};
+        write flat$17$simp$57 = flat$24;
       } else {
-        write flat$28$simp$91 = False@{Bool};
-        write flat$28$simp$92 = flat$27$simp$82$simp$86$simp$89;
-        write flat$28$simp$93 = Map []@{Map DateTime Int};
+        write flat$17$simp$55 = False@{Bool};
+        write flat$17$simp$56 = flat$16$simp$46$simp$50$simp$53;
+        write flat$17$simp$57 = Map []@{Map DateTime Int};
       }
-      read@{Bool} flat$28$simp$94 = flat$28$simp$91;
-      read@{Error} flat$28$simp$95 = flat$28$simp$92;
-      read@{Map DateTime Int} flat$28$simp$96 = flat$28$simp$93;
-      write flat$23$simp$46 = flat$28$simp$94;
-      write flat$23$simp$47 = flat$28$simp$95;
-      write flat$23$simp$48 = flat$28$simp$96;
+      read@{Bool} flat$17$simp$58 = flat$17$simp$55;
+      read@{Error} flat$17$simp$59 = flat$17$simp$56;
+      read@{Map DateTime Int} flat$17$simp$60 = flat$17$simp$57;
+      write flat$12$simp$10 = flat$17$simp$58;
+      write flat$12$simp$11 = flat$17$simp$59;
+      write flat$12$simp$12 = flat$17$simp$60;
     } else {
-      write flat$23$simp$46 = False@{Bool};
-      write flat$23$simp$47 = flat$20$simp$44;
-      write flat$23$simp$48 = Map []@{Map DateTime Int};
+      write flat$12$simp$10 = False@{Bool};
+      write flat$12$simp$11 = flat$7$simp$8;
+      write flat$12$simp$12 = Map []@{Map DateTime Int};
     }
-    read@{Bool} flat$23$simp$97 = flat$23$simp$46;
-    read@{Error} flat$23$simp$98 = flat$23$simp$47;
-    read@{Map DateTime Int} flat$23$simp$99 = flat$23$simp$48;
-    write flat$20$simp$40 = flat$23$simp$97;
-    write flat$20$simp$41 = flat$23$simp$98;
-    write flat$20$simp$42 = flat$23$simp$99;
+    read@{Bool} flat$12$simp$61 = flat$12$simp$10;
+    read@{Error} flat$12$simp$62 = flat$12$simp$11;
+    read@{Map DateTime Int} flat$12$simp$63 = flat$12$simp$12;
+    write flat$7$simp$4 = flat$12$simp$61;
+    write flat$7$simp$5 = flat$12$simp$62;
+    write flat$7$simp$6 = flat$12$simp$63;
   }
-  read@{Bool} flat$20$simp$100 = flat$20$simp$40;
-  read@{Error} flat$20$simp$101 = flat$20$simp$41;
-  read@{Map DateTime Int} flat$20$simp$102 = flat$20$simp$42;
-  output@{(Sum Error (Map DateTime Int))} repl (flat$20$simp$100@{Bool},
-               flat$20$simp$101@{Error},
-               flat$20$simp$102@{Map DateTime Int});
+  read@{Bool} flat$7$simp$64 = flat$7$simp$4;
+  read@{Error} flat$7$simp$65 = flat$7$simp$5;
+  read@{Map DateTime Int} flat$7$simp$66 = flat$7$simp$6;
+  output@{(Sum Error (Map DateTime Int))} repl (flat$7$simp$64@{Bool},
+               flat$7$simp$65@{Error},
+               flat$7$simp$66@{Map DateTime Int});
 }
 
 - Core evaluation:

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -629,7 +629,6 @@ gen$date = DATE
 }
 
 - C:
-#line 1 "state definition"
 typedef struct {
     /* runtime */
     imempool_t       mempool;
@@ -673,7 +672,7 @@ typedef struct {
     idouble_t        res_acc_s_conv_13_simp_46;
 } icicle_state_t;
 
-#line 1 "compute function"
+ICICLE_FUNCTION
 void compute(icicle_state_t *s)
 {
     ibool_t          a_conv_66_simp_248;
@@ -1137,7 +1136,7 @@ void compute(icicle_state_t *s)
         flat_19_simp_119                      = ifalse;                               /* init */
         
         if (flat_18_simp_114) {
-            ibool_t          simp_502         = istring_eq (flat_18_simp_116, "torso"); /* let */
+            ibool_t          simp_502         = ieq<istring_t>  (flat_18_simp_116, "torso"); /* let */
             flat_19_simp_117                  = itrue;                                /* write */
             flat_19_simp_119                  = simp_502;                             /* write */
         } else {
@@ -1686,7 +1685,6 @@ gen$date = DATE
 }
 
 - C:
-#line 1 "state definition"
 typedef struct {
     /* runtime */
     imempool_t       mempool;
@@ -1713,7 +1711,7 @@ typedef struct {
     idate_t          res_acc_s_reify_2_conv_5_simp_6;
 } icicle_state_t;
 
-#line 1 "compute function"
+ICICLE_FUNCTION
 void compute(icicle_state_t *s)
 {
     ibool_t          acc_s_reify_2_conv_5_simp_4;
@@ -1779,7 +1777,7 @@ void compute(icicle_state_t *s)
         if (acc_s_reify_2_conv_5_simp_7) {
             flat_4                            = 0x7420b1100000000;                    /* init */
             
-            if (idate_gt (anf_15, acc_s_reify_2_conv_5_simp_9)) {
+            if (igt<idate_t>  (anf_15, acc_s_reify_2_conv_5_simp_9)) {
                 flat_4                        = anf_15;                               /* write */
             } else {
                 flat_4                        = acc_s_reify_2_conv_5_simp_9;          /* write */
@@ -1794,7 +1792,7 @@ void compute(icicle_state_t *s)
             flat_3_simp_14                    = ierror_tombstone;                     /* init */
             flat_3_simp_15                    = 0x7420b1100000000;                    /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, acc_s_reify_2_conv_5_simp_8)) {
+            if (ieq<ierror_t>  (ierror_fold1_no_value, acc_s_reify_2_conv_5_simp_8)) {
                 flat_3_simp_13                = itrue;                                /* write */
                 flat_3_simp_14                = ierror_tombstone;                     /* write */
                 flat_3_simp_15                = anf_15;                               /* write */


### PR DESCRIPTION
Before implementing C++ templates for arrays and buffers etc