### PR TITLE
try to make simps faster

### DIFF
--- a/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Statement.hs
@@ -24,14 +24,14 @@ data Statement a n p
  -- | An IF for filters
  = If           (Exp a n p) (Statement a n p) (Statement a n p)
  -- | Local binding, so the name better be unique
- | Let (Name n) (Exp a n p) (Statement a n p)
+ | Let !(Name n) (Exp a n p) (Statement a n p)
 
  -- | A loop over some ints
- | ForeachInts  (Name n) (Exp a n p) (Exp a n p) (Statement a n p)
+ | ForeachInts  !(Name n) (Exp a n p) (Exp a n p) (Statement a n p)
 
  -- | A loop over all the facts.
  -- This should only occur once in the program, and not inside a loop.
- | ForeachFacts [(Name n, ValType)] ValType FactLoopType (Statement a n p)
+ | ForeachFacts ![(Name n, ValType)] ValType FactLoopType (Statement a n p)
 
  -- | Execute several statements in a block.
  | Block [Statement a n p]
@@ -44,12 +44,12 @@ data Statement a n p
  -- As let:
  --      Let  local = accumulator,
  --      Read local = accumulator.
- | Read   (Name n) (Name n) ValType (Statement a n p)
+ | Read   !(Name n) !(Name n) ValType (Statement a n p)
 
  -- Leaf nodes
  -- | Update a resumable or windowed fold accumulator,
  -- with Exp : acc
- | Write  (Name n) (Exp a n p)
+ | Write  !(Name n) (Exp a n p)
 
  -- | Emit a value to output
  | Output OutputName ValType [(Exp a n p, ValType)]
@@ -58,10 +58,10 @@ data Statement a n p
  | KeepFactInHistory
 
  -- | Load an accumulator from history. Must be before any fact loops.
- | LoadResumable (Name n) ValType
+ | LoadResumable !(Name n) ValType
 
  -- | Save an accumulator to history. Must be after all fact loops.
- | SaveResumable (Name n) ValType
+ | SaveResumable !(Name n) ValType
  deriving (Eq, Ord, Show)
 
 instance Monoid (Statement a n p) where

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -23,10 +23,10 @@ import qualified    Data.Text   as T
 -- | User defined names.
 data Name n =
  -- | Raw name
-   Name     n
+   Name     !n
  -- | Prefix a name.
  -- Very useful for generating fresh(ish) readable names.
- | NameMod  n (Name n)
+ | NameMod  !n !(Name n)
  deriving (Eq,Ord,Show,Functor)
 
 data WindowUnit
@@ -41,22 +41,22 @@ data WindowUnit
 -- closures, which include expressions.
 -- This is in here to resolve circular dependency.
 data BaseValue
- = VInt   Int
- | VDouble Double
+ = VInt      {-# UNPACK #-}!Int
+ | VDouble   {-# UNPACK #-}!Double
  | VUnit
- | VBool  Bool
- | VDateTime        DateTime
- | VString T.Text
- | VArray [BaseValue]
- | VPair  BaseValue BaseValue
- | VLeft  BaseValue
- | VRight BaseValue
- | VSome  BaseValue
+ | VBool     !Bool
+ | VDateTime {-# UNPACK #-}!DateTime
+ | VString   {-# UNPACK #-}!T.Text
+ | VArray    ![BaseValue]
+ | VPair     !BaseValue !BaseValue
+ | VLeft     !BaseValue
+ | VRight    !BaseValue
+ | VSome     !BaseValue
  | VNone
- | VMap    (Map.Map BaseValue    BaseValue)
- | VStruct (Map.Map StructField  BaseValue)
- | VBuf   [BaseValue]
- | VError ExceptionInfo
+ | VMap      !(Map.Map BaseValue    BaseValue)
+ | VStruct   !(Map.Map StructField  BaseValue)
+ | VBuf      ![BaseValue]
+ | VError    !ExceptionInfo
  deriving (Show, Ord, Eq)
 
 -- | Called "exceptions"
@@ -69,7 +69,7 @@ data ExceptionInfo
  deriving (Show, Ord, Eq)
 
 
-data StructField
+newtype StructField
  = StructField
  { nameOfStructField :: T.Text
  }

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -17,7 +17,7 @@ import              P
 -- | Incredibly simple expressions;
 data Exp a n p
  -- | Read a variable from heap
- = XVar a (Name n)
+ = XVar a !(Name n)
 
  -- | A predefined primitive
  | XPrim a p
@@ -32,10 +32,10 @@ data Exp a n p
 
  -- | Lambda abstraction:
  -- This is only really used for arguments passed to primitives such as fold.
- | XLam a (Name n) ValType (Exp a n p)
+ | XLam a !(Name n) ValType (Exp a n p)
 
  -- | Let binding
- | XLet a (Name n) (Exp a n p) (Exp a n p)
+ | XLet a !(Name n) (Exp a n p) (Exp a n p)
  deriving (Eq,Ord,Show)
 
 

--- a/src/Icicle/Common/Type.hs
+++ b/src/Icicle/Common/Type.hs
@@ -57,13 +57,13 @@ data ValType
  | StringT
  | UnitT
  | ErrorT
- | ArrayT  ValType
- | MapT    ValType    ValType
- | OptionT ValType
- | PairT   ValType    ValType
- | SumT    ValType    ValType
- | StructT StructType
- | BufT    Int        ValType
+ | ArrayT  !ValType
+ | MapT    !ValType    !ValType
+ | OptionT !ValType
+ | PairT   !ValType    !ValType
+ | SumT    !ValType    !ValType
+ | StructT !StructType
+ | BufT    !Int        ValType
  deriving (Eq,Ord,Show)
 
 
@@ -102,7 +102,7 @@ defaultOfType typ
      BufT _ _  -> VBuf []
 
 
-data StructType
+newtype StructType
  = StructType
  { getStructType :: Map.Map StructField ValType }
  deriving (Eq, Ord)

--- a/src/Icicle/Source/Lexer/Token.hs
+++ b/src/Icicle/Source/Lexer/Token.hs
@@ -35,14 +35,14 @@ type TOK = (Token, SourcePos)
 
 data Token
  -- | Primitive keywords
- = TKeyword  Keyword
+ = TKeyword  !Keyword
  -- | Ints, strings, whatever
- | TLiteral  Literal
+ | TLiteral  !Literal
  -- | Function operators like (+) (>)
- | TOperator Operator
+ | TOperator    {-# UNPACK #-}!Operator
  -- | Names. I dunno
- | TVariable Variable
- | TConstructor Variable
+ | TVariable    {-# UNPACK #-}!Variable
+ | TConstructor {-# UNPACK #-}!Variable
 
  -- | '('
  | TParenL
@@ -64,7 +64,7 @@ data Token
  | TAlternative
 
  -- | An error
- | TUnexpected Text
+ | TUnexpected {-# UNPACK #-}!Text
  deriving (Eq, Ord, Show)
 
 data Keyword
@@ -97,17 +97,17 @@ data Keyword
 
 -- TODO: Strings, floats
 data Literal
- = LitInt Int
- | LitDouble Double
- | LitString Text
- | LitDate DateTime
+ = LitInt    {-# UNPACK #-}!Int
+ | LitDouble {-# UNPACK #-}!Double
+ | LitString {-# UNPACK #-}!Text
+ | LitDate   {-# UNPACK #-}!DateTime
  deriving (Eq, Ord, Show)
 
-data Operator
+newtype Operator
  = Operator Text
  deriving (Eq, Ord, Show)
 
-data Variable
+newtype Variable
  = Variable Text
  deriving (Eq, Ord, Show)
 


### PR DESCRIPTION
this: `time ./dist/build/icicle-repl/icicle-repl "feature injury ~> group severity ~> (count severity, max location)"` is super slow (~30s).

trying to make core-simp and simpFlattened a bit faster. Making names, valtypes and basevalues strict gives minimal speedup (~1-2s).