### PR TITLE
improve simps

### DIFF
--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -45,22 +45,22 @@ simpFlattened a_fresh p
       let Program i bd s = p'
 
       s' <-  melt a_fresh s
-         >>= forwardStmts a_fresh . pullLets
-         >>= thresher a_fresh
-         >>= forwardStmts a_fresh
-         >>= crunch i bd
-         >>= crunch i bd
+         >>= crunchy i bd . pullLets
          >>= return . simpStatementExps a_fresh
 
       return $ p { statements = s' }
-
  where
+  crunchy i bd s
+   = do s' <- crunch i bd s
+        if s == s'
+        then return s
+        else crunchy i bd s'
+
   crunch i bd ss
-   =   constructor  a_fresh  (pullLets ss)
+   =   constructor  a_fresh (pullLets ss)
    >>= thresher     a_fresh
    >>= forwardStmts a_fresh
    >>= nestBlocks   a_fresh
    >>= thresher     a_fresh
    >>= fmap statements . transformX return (simp a_fresh) . Program i bd
-
 

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -45,8 +45,7 @@ simpFlattened a_fresh p
       let Program i bd s = p'
 
       s' <-  melt a_fresh s
-         >>= crunchy i bd . pullLets
-         >>= return . simpStatementExps a_fresh
+         >>= crunchy i bd
 
       return $ p { statements = s' }
  where

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -46,16 +46,8 @@ simpFlattened a_fresh p
 
       s' <-  melt a_fresh s
          >>= forwardStmts a_fresh . pullLets
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
-         >>= crunch i bd
+         >>= thresher a_fresh
+         >>= forwardStmts a_fresh
          >>= crunch i bd
          >>= crunch i bd
          >>= return . simpStatementExps a_fresh
@@ -65,6 +57,7 @@ simpFlattened a_fresh p
  where
   crunch i bd ss
    =   constructor  a_fresh  (pullLets ss)
+   >>= thresher     a_fresh
    >>= forwardStmts a_fresh
    >>= nestBlocks   a_fresh
    >>= thresher     a_fresh

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -9,20 +9,15 @@ module Icicle.Avalanche.Statement.Simp (
   , substXinS
   , thresher
   , nestBlocks
-  , simpStatementExps
   ) where
 
 import              Icicle.Avalanche.Statement.Statement
 import              Icicle.Avalanche.Statement.Simp.ExpEnv
-import qualified    Icicle.Avalanche.Prim.Flat as F
-import qualified    Icicle.Avalanche.Prim.Eval as AE
 
 import              Icicle.Common.Base
 import              Icicle.Common.Exp
 import              Icicle.Common.Exp.Simp.Beta
 import              Icicle.Common.Fresh
-import              Icicle.Common.Type
-import              Icicle.Common.Value
 
 import              P
 
@@ -454,55 +449,3 @@ killAccumulator acc xx statements
 
    | otherwise
    = return ((), s)
-
--- | Simplify expressions with flattened primitives. Performs:
---    * constant folding for common expressions and flat prims.
---    * beta reduction
---
-simpStatementExps :: Ord n => a -> Statement a n F.Prim -> Statement a n F.Prim
-simpStatementExps a_fresh statements
- = runIdentity
- $ transformUDStmt trans () statements
- where
-  trans _ ss
-   = return . ((),)
-   $ case ss of
-      If x s1 s2            -> If (goX x) s1 s2
-      Let n x s             -> Let n (goX x) s
-      ForeachInts n x1 x2 s -> ForeachInts n (goX x1) (goX x2) s
-      Write n x             -> Write n (goX x)
-      InitAccumulator a s   -> InitAccumulator (goA a) s
-      Output n t xs         -> Output n t (fmap (first goX) xs)
-      _                     -> ss
-
-  goA aa
-   = aa { accInit = goX (accInit aa) }
-
-  goX xx
-   = case xx of
-      XApp a p q
-       | p' <- goX p
-       , q' <- goX q
-       , Just (prim, as) <- takePrimApps (XApp a p' q')
-       , Just args       <- mapM (takeValue . goX) as
-       -> fromMaybe (XApp a p' q') (goP prim args)
-
-      XApp a p q
-        -> XApp a (goX p) (goX q)
-
-      XLam a n t x1
-        -> XLam a n t (goX x1)
-
-      XLet a n x1 x2
-        -> XLet a n (goX x1) (goX x2)
-
-      b@(XVar{})   -> b
-      b@(XPrim{})  -> b
-      b@(XValue{}) -> b
-
-  goP p vs
-   = case AE.evalPrim p vs of
-      Right (VBase b)
-       -> Just
-        $ XValue a_fresh (functionReturns $ F.typeOfPrim p) b
-      _ -> Nothing

--- a/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -80,7 +80,7 @@ constructor a_fresh statements
 
   goS env s
    = let env' = updateExpEnv s env
-         go   = goX env
+         go   = goX env'
          ret s' = return (updateExpEnv s' env', s')
      in  case s of
           If x t e

--- a/src/Icicle/Avalanche/Statement/Simp/Melt.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Melt.hs
@@ -60,7 +60,7 @@ melt :: (Show n, Ord n)
      -> Statement (Annot a) n Prim
      -> Fresh n (Statement (Annot a) n Prim)
 melt a_fresh ss
- = meltAccumulators   a_fresh ss
+ =   meltAccumulators a_fresh ss
  >>= meltBindings     a_fresh
  >>= meltForeachFacts a_fresh
  >>= meltOutputs      a_fresh

--- a/src/Icicle/Pipeline.hs
+++ b/src/Icicle/Pipeline.hs
@@ -256,11 +256,10 @@ simpFlattened av
  = let name = Fresh.counterPrefixNameState (SP.Variable . T.pack . show) "simp"
    in  AA.eraseAnnotP
      $ snd
-     $ Fresh.runFresh go2 name
+     $ Fresh.runFresh go' name
  where
-  -- The magic recipe for nice, small, clean Avalanche
-  go2
-   = go av >>= go
+  go'
+   = go av
   -- Thread through a dummy annotation
   go
    = AS.simpFlattened (CA.Annot (CT.FunT [] CT.ErrorT) ())

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -283,31 +283,31 @@ gen$date = DATE
       init flat$11$simp$63@{Array (Buf 2 DateTime)} = unsafe_Array_create#@{Buf 2 DateTime}
                              simp$279;
       foreach (flat$13 in 0@{Int}..Array_length#@{Buf 2 Bool}
-                             flat$12$simp$58) {
-        read@{Array (Buf 2 Bool)} flat$11$simp$66 = flat$11$simp$62;
-        read@{Array (Buf 2 Error)} flat$11$simp$67 = flat$11$simp$63;
-        read@{Array (Buf 2 Int)} flat$11$simp$68 = flat$11$simp$64;
-        read@{Array (Buf 2 DateTime)} flat$11$simp$69 = flat$11$simp$65;
-        let simp$666 = unsafe_Array_index#@{Buf 2 Bool}
+                             flat$12$simp$56) {
+        read@{Array (Buf 2 Bool)} flat$11$simp$64 = flat$11$simp$60;
+        read@{Array (Buf 2 Error)} flat$11$simp$65 = flat$11$simp$61;
+        read@{Array (Buf 2 Int)} flat$11$simp$66 = flat$11$simp$62;
+        read@{Array (Buf 2 DateTime)} flat$11$simp$67 = flat$11$simp$63;
+        let simp$631 = unsafe_Array_index#@{Buf 2 Bool}
+                       flat$12$simp$56 flat$13;
+        let simp$633 = unsafe_Array_index#@{Buf 2 Error}
+                       flat$12$simp$57 flat$13;
+        let simp$635 = unsafe_Array_index#@{Buf 2 Int}
                        flat$12$simp$58 flat$13;
-        let simp$668 = unsafe_Array_index#@{Buf 2 Error}
+        let simp$637 = unsafe_Array_index#@{Buf 2 DateTime}
                        flat$12$simp$59 flat$13;
-        let simp$670 = unsafe_Array_index#@{Buf 2 Int}
-                       flat$12$simp$60 flat$13;
-        let simp$672 = unsafe_Array_index#@{Buf 2 DateTime}
-                       flat$12$simp$61 flat$13;
-        write flat$11$simp$62 = Array_put#@{Buf 2 Bool}
+        write flat$11$simp$60 = Array_put#@{Buf 2 Bool}
+                                flat$11$simp$64 flat$13
+                                simp$631;
+        write flat$11$simp$61 = Array_put#@{Buf 2 Error}
+                                flat$11$simp$65 flat$13
+                                simp$633;
+        write flat$11$simp$62 = Array_put#@{Buf 2 Int}
                                 flat$11$simp$66 flat$13
-                                simp$666;
-        write flat$11$simp$63 = Array_put#@{Buf 2 Error}
+                                simp$635;
+        write flat$11$simp$63 = Array_put#@{Buf 2 DateTime}
                                 flat$11$simp$67 flat$13
-                                simp$668;
-        write flat$11$simp$64 = Array_put#@{Buf 2 Int}
-                                flat$11$simp$68 flat$13
-                                simp$670;
-        write flat$11$simp$65 = Array_put#@{Buf 2 DateTime}
-                                flat$11$simp$69 flat$13
-                                simp$672;
+                                simp$637;
       }
       read@{Array (Buf 2 Bool)} flat$11$simp$68 = flat$11$simp$60;
       read@{Array (Buf 2 Error)} flat$11$simp$69 = flat$11$simp$61;
@@ -359,54 +359,54 @@ gen$date = DATE
   init flat$20$simp$87@{Array DateTime} = []@{Array DateTime};
   init flat$20$simp$88@{Array Int} = []@{Array Int};
   foreach (flat$21 in 0@{Int}..Array_length#@{DateTime}
-                         conv$2$simp$82) {
-    read@{Bool} flat$20$simp$91 = flat$20$simp$87;
-    read@{Error} flat$20$simp$92 = flat$20$simp$88;
-    read@{Array DateTime} flat$20$simp$93 = flat$20$simp$89;
-    read@{Array Int} flat$20$simp$94 = flat$20$simp$90;
-    let simp$416 = unsafe_Array_index#@{DateTime}
+                         conv$2$simp$80) {
+    read@{Bool} flat$20$simp$89 = flat$20$simp$85;
+    read@{Error} flat$20$simp$90 = flat$20$simp$86;
+    read@{Array DateTime} flat$20$simp$91 = flat$20$simp$87;
+    read@{Array Int} flat$20$simp$92 = flat$20$simp$88;
+    let simp$408 = unsafe_Array_index#@{DateTime}
+                   conv$2$simp$80 flat$21;
+    let simp$410 = unsafe_Array_index#@{Buf 2 Bool}
+                   conv$2$simp$81 flat$21;
+    let simp$412 = unsafe_Array_index#@{Buf 2 Error}
                    conv$2$simp$82 flat$21;
-    let simp$418 = unsafe_Array_index#@{Buf 2 Bool}
+    let simp$414 = unsafe_Array_index#@{Buf 2 Int}
                    conv$2$simp$83 flat$21;
-    let simp$420 = unsafe_Array_index#@{Buf 2 Error}
-                   conv$2$simp$84 flat$21;
-    let simp$422 = unsafe_Array_index#@{Buf 2 Int}
-                   conv$2$simp$85 flat$21;
-    init flat$23$simp$95@{Bool} = False@{Bool};
-    init flat$23$simp$96@{Error} = ExceptTombstone@{Error};
-    init flat$23$simp$97@{Array DateTime} = []@{Array DateTime};
-    init flat$23$simp$98@{Array Int} = []@{Array Int};
-    if (flat$20$simp$91) {
-      let conv$6$simp$152 = Buf_read#@{Array Bool}
-                            simp$418;
-      let conv$6$simp$153 = Buf_read#@{Array Error}
-                            simp$420;
-      let conv$6$simp$154 = Buf_read#@{Array Int}
-                            simp$422;
-      init flat$27$simp$102@{Bool} = True@{Bool};
-      init flat$27$simp$103@{Error} = ExceptTombstone@{Error};
-      init flat$27$simp$104@{Int} = 0@{Int};
+    init flat$23$simp$93@{Bool} = False@{Bool};
+    init flat$23$simp$94@{Error} = ExceptTombstone@{Error};
+    init flat$23$simp$95@{Array DateTime} = []@{Array DateTime};
+    init flat$23$simp$96@{Array Int} = []@{Array Int};
+    if (flat$20$simp$89) {
+      let conv$6$simp$147 = Buf_read#@{Array Bool}
+                            simp$410;
+      let conv$6$simp$148 = Buf_read#@{Array Error}
+                            simp$412;
+      let conv$6$simp$149 = Buf_read#@{Array Int}
+                            simp$414;
+      init flat$27$simp$100@{Bool} = True@{Bool};
+      init flat$27$simp$101@{Error} = ExceptTombstone@{Error};
+      init flat$27$simp$102@{Int} = 0@{Int};
       foreach (flat$44 in 0@{Int}..Array_length#@{Bool}
-                             conv$6$simp$152) {
-        read@{Bool} flat$27$simp$109 = flat$27$simp$102;
-        read@{Error} flat$27$simp$110 = flat$27$simp$103;
-        read@{Int} flat$27$simp$111 = flat$27$simp$104;
-        let simp$473 = unsafe_Array_index#@{Bool}
-                       conv$6$simp$152 flat$44;
-        let simp$479 = unsafe_Array_index#@{Int}
-                       conv$6$simp$154 flat$44;
-        init flat$46$simp$113@{Bool} = False@{Bool};
-        init flat$46$simp$114@{Error} = ExceptTombstone@{Error};
-        init flat$46$simp$115@{Int} = 0@{Int};
-        if (simp$473) {
-          init flat$49$simp$116@{Bool} = False@{Bool};
-          init flat$49$simp$117@{Error} = ExceptTombstone@{Error};
-          init flat$49$simp$118@{Int} = 0@{Int};
-          if (flat$27$simp$109) {
-            write flat$49$simp$116 = True@{Bool};
-            write flat$49$simp$117 = ExceptTombstone@{Error};
-            write flat$49$simp$118 = add#@{Int}
-                                     simp$479 flat$27$simp$111;
+                             conv$6$simp$147) {
+        read@{Bool} flat$27$simp$106 = flat$27$simp$100;
+        read@{Error} flat$27$simp$107 = flat$27$simp$101;
+        read@{Int} flat$27$simp$108 = flat$27$simp$102;
+        let simp$465 = unsafe_Array_index#@{Bool}
+                       conv$6$simp$147 flat$44;
+        let simp$471 = unsafe_Array_index#@{Int}
+                       conv$6$simp$149 flat$44;
+        init flat$46$simp$109@{Bool} = False@{Bool};
+        init flat$46$simp$110@{Error} = ExceptTombstone@{Error};
+        init flat$46$simp$111@{Int} = 0@{Int};
+        if (simp$465) {
+          init flat$49$simp$112@{Bool} = False@{Bool};
+          init flat$49$simp$113@{Error} = ExceptTombstone@{Error};
+          init flat$49$simp$114@{Int} = 0@{Int};
+          if (flat$27$simp$106) {
+            write flat$49$simp$112 = True@{Bool};
+            write flat$49$simp$113 = ExceptTombstone@{Error};
+            write flat$49$simp$114 = add#@{Int}
+                                     simp$471 flat$27$simp$108;
           } else {
             write flat$49$simp$112 = False@{Bool};
             write flat$49$simp$113 = flat$27$simp$107;
@@ -450,7 +450,7 @@ gen$date = DATE
           read@{Array Int} flat$33 = flat$33;
           let simp$21 = unsafe_Array_index#@{DateTime}
                         flat$32 flat$35;
-          if (eq#@{DateTime} simp$23 simp$416) {
+          if (eq#@{DateTime} simp$21 simp$408) {
             let flat$36 = unsafe_Array_index#@{Int}
                           flat$33 flat$35;
             write flat$33 = Array_put#@{Int}
@@ -478,7 +478,7 @@ gen$date = DATE
           }
           read@{Array DateTime} flat$37 = flat$37;
           write flat$37 = Array_put#@{DateTime}
-                          flat$37 simp$26 simp$416;
+                          flat$37 simp$24 simp$408;
           read@{Array DateTime} flat$37 = flat$37;
           write flat$32 = flat$37;
           read@{Array Int} flat$41 = flat$33;

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -283,31 +283,31 @@ gen$date = DATE
       init flat$11$simp$63@{Array (Buf 2 DateTime)} = unsafe_Array_create#@{Buf 2 DateTime}
                              simp$279;
       foreach (flat$13 in 0@{Int}..Array_length#@{Buf 2 Bool}
-                             flat$12$simp$56) {
-        read@{Array (Buf 2 Bool)} flat$11$simp$64 = flat$11$simp$60;
-        read@{Array (Buf 2 Error)} flat$11$simp$65 = flat$11$simp$61;
-        read@{Array (Buf 2 Int)} flat$11$simp$66 = flat$11$simp$62;
-        read@{Array (Buf 2 DateTime)} flat$11$simp$67 = flat$11$simp$63;
-        let simp$653 = unsafe_Array_index#@{Buf 2 Bool}
-                       flat$12$simp$56 flat$13;
-        write flat$11$simp$60 = Array_put#@{Buf 2 Bool}
-                                flat$11$simp$64 flat$13
-                                simp$653;
-        let simp$675 = unsafe_Array_index#@{Buf 2 Error}
-                       flat$12$simp$57 flat$13;
-        write flat$11$simp$61 = Array_put#@{Buf 2 Error}
-                                flat$11$simp$65 flat$13
-                                simp$675;
-        let simp$697 = unsafe_Array_index#@{Buf 2 Int}
+                             flat$12$simp$58) {
+        read@{Array (Buf 2 Bool)} flat$11$simp$66 = flat$11$simp$62;
+        read@{Array (Buf 2 Error)} flat$11$simp$67 = flat$11$simp$63;
+        read@{Array (Buf 2 Int)} flat$11$simp$68 = flat$11$simp$64;
+        read@{Array (Buf 2 DateTime)} flat$11$simp$69 = flat$11$simp$65;
+        let simp$715 = unsafe_Array_index#@{Buf 2 Bool}
                        flat$12$simp$58 flat$13;
-        write flat$11$simp$62 = Array_put#@{Buf 2 Int}
-                                flat$11$simp$66 flat$13
-                                simp$697;
-        let simp$719 = unsafe_Array_index#@{Buf 2 DateTime}
+        let simp$717 = unsafe_Array_index#@{Buf 2 Error}
                        flat$12$simp$59 flat$13;
-        write flat$11$simp$63 = Array_put#@{Buf 2 DateTime}
+        let simp$719 = unsafe_Array_index#@{Buf 2 Int}
+                       flat$12$simp$60 flat$13;
+        let simp$721 = unsafe_Array_index#@{Buf 2 DateTime}
+                       flat$12$simp$61 flat$13;
+        write flat$11$simp$62 = Array_put#@{Buf 2 Bool}
+                                flat$11$simp$66 flat$13
+                                simp$715;
+        write flat$11$simp$63 = Array_put#@{Buf 2 Error}
                                 flat$11$simp$67 flat$13
+                                simp$717;
+        write flat$11$simp$64 = Array_put#@{Buf 2 Int}
+                                flat$11$simp$68 flat$13
                                 simp$719;
+        write flat$11$simp$65 = Array_put#@{Buf 2 DateTime}
+                                flat$11$simp$69 flat$13
+                                simp$721;
       }
       read@{Array (Buf 2 Bool)} flat$11$simp$68 = flat$11$simp$60;
       read@{Array (Buf 2 Error)} flat$11$simp$69 = flat$11$simp$61;
@@ -359,54 +359,54 @@ gen$date = DATE
   init flat$20$simp$87@{Array DateTime} = []@{Array DateTime};
   init flat$20$simp$88@{Array Int} = []@{Array Int};
   foreach (flat$21 in 0@{Int}..Array_length#@{DateTime}
-                         conv$2$simp$80) {
-    read@{Bool} flat$20$simp$89 = flat$20$simp$85;
-    read@{Error} flat$20$simp$90 = flat$20$simp$86;
-    read@{Array DateTime} flat$20$simp$91 = flat$20$simp$87;
-    read@{Array Int} flat$20$simp$92 = flat$20$simp$88;
-    let simp$424 = unsafe_Array_index#@{DateTime}
-                   conv$2$simp$80 flat$21;
-    let simp$426 = unsafe_Array_index#@{Buf 2 Bool}
-                   conv$2$simp$81 flat$21;
-    let simp$428 = unsafe_Array_index#@{Buf 2 Error}
+                         conv$2$simp$82) {
+    read@{Bool} flat$20$simp$91 = flat$20$simp$87;
+    read@{Error} flat$20$simp$92 = flat$20$simp$88;
+    read@{Array DateTime} flat$20$simp$93 = flat$20$simp$89;
+    read@{Array Int} flat$20$simp$94 = flat$20$simp$90;
+    let simp$416 = unsafe_Array_index#@{DateTime}
                    conv$2$simp$82 flat$21;
-    let simp$430 = unsafe_Array_index#@{Buf 2 Int}
+    let simp$418 = unsafe_Array_index#@{Buf 2 Bool}
                    conv$2$simp$83 flat$21;
-    init flat$23$simp$93@{Bool} = False@{Bool};
-    init flat$23$simp$94@{Error} = ExceptTombstone@{Error};
-    init flat$23$simp$95@{Array DateTime} = []@{Array DateTime};
-    init flat$23$simp$96@{Array Int} = []@{Array Int};
-    if (flat$20$simp$89) {
-      let conv$6$simp$147 = Buf_read#@{Array Bool}
-                            simp$426;
-      let conv$6$simp$148 = Buf_read#@{Array Error}
-                            simp$428;
-      let conv$6$simp$149 = Buf_read#@{Array Int}
-                            simp$430;
-      init flat$27$simp$100@{Bool} = True@{Bool};
-      init flat$27$simp$101@{Error} = ExceptTombstone@{Error};
-      init flat$27$simp$102@{Int} = 0@{Int};
+    let simp$420 = unsafe_Array_index#@{Buf 2 Error}
+                   conv$2$simp$84 flat$21;
+    let simp$422 = unsafe_Array_index#@{Buf 2 Int}
+                   conv$2$simp$85 flat$21;
+    init flat$23$simp$95@{Bool} = False@{Bool};
+    init flat$23$simp$96@{Error} = ExceptTombstone@{Error};
+    init flat$23$simp$97@{Array DateTime} = []@{Array DateTime};
+    init flat$23$simp$98@{Array Int} = []@{Array Int};
+    if (flat$20$simp$91) {
+      let conv$6$simp$152 = Buf_read#@{Array Bool}
+                            simp$418;
+      let conv$6$simp$153 = Buf_read#@{Array Error}
+                            simp$420;
+      let conv$6$simp$154 = Buf_read#@{Array Int}
+                            simp$422;
+      init flat$27$simp$102@{Bool} = True@{Bool};
+      init flat$27$simp$103@{Error} = ExceptTombstone@{Error};
+      init flat$27$simp$104@{Int} = 0@{Int};
       foreach (flat$44 in 0@{Int}..Array_length#@{Bool}
-                             conv$6$simp$147) {
-        read@{Bool} flat$27$simp$106 = flat$27$simp$100;
-        read@{Error} flat$27$simp$107 = flat$27$simp$101;
-        read@{Int} flat$27$simp$108 = flat$27$simp$102;
-        let simp$481 = unsafe_Array_index#@{Bool}
-                       conv$6$simp$147 flat$44;
-        let simp$487 = unsafe_Array_index#@{Int}
-                       conv$6$simp$149 flat$44;
-        init flat$46$simp$109@{Bool} = False@{Bool};
-        init flat$46$simp$110@{Error} = ExceptTombstone@{Error};
-        init flat$46$simp$111@{Int} = 0@{Int};
-        if (simp$481) {
-          init flat$49$simp$112@{Bool} = False@{Bool};
-          init flat$49$simp$113@{Error} = ExceptTombstone@{Error};
-          init flat$49$simp$114@{Int} = 0@{Int};
-          if (flat$27$simp$106) {
-            write flat$49$simp$112 = True@{Bool};
-            write flat$49$simp$113 = ExceptTombstone@{Error};
-            write flat$49$simp$114 = add#@{Int}
-                                     simp$487 flat$27$simp$108;
+                             conv$6$simp$152) {
+        read@{Bool} flat$27$simp$109 = flat$27$simp$102;
+        read@{Error} flat$27$simp$110 = flat$27$simp$103;
+        read@{Int} flat$27$simp$111 = flat$27$simp$104;
+        let simp$473 = unsafe_Array_index#@{Bool}
+                       conv$6$simp$152 flat$44;
+        let simp$479 = unsafe_Array_index#@{Int}
+                       conv$6$simp$154 flat$44;
+        init flat$46$simp$113@{Bool} = False@{Bool};
+        init flat$46$simp$114@{Error} = ExceptTombstone@{Error};
+        init flat$46$simp$115@{Int} = 0@{Int};
+        if (simp$473) {
+          init flat$49$simp$116@{Bool} = False@{Bool};
+          init flat$49$simp$117@{Error} = ExceptTombstone@{Error};
+          init flat$49$simp$118@{Int} = 0@{Int};
+          if (flat$27$simp$109) {
+            write flat$49$simp$116 = True@{Bool};
+            write flat$49$simp$117 = ExceptTombstone@{Error};
+            write flat$49$simp$118 = add#@{Int}
+                                     simp$479 flat$27$simp$111;
           } else {
             write flat$49$simp$112 = False@{Bool};
             write flat$49$simp$113 = flat$27$simp$107;
@@ -450,7 +450,7 @@ gen$date = DATE
           read@{Array Int} flat$33 = flat$33;
           let simp$21 = unsafe_Array_index#@{DateTime}
                         flat$32 flat$35;
-          if (eq#@{DateTime} simp$21 simp$424) {
+          if (eq#@{DateTime} simp$23 simp$416) {
             let flat$36 = unsafe_Array_index#@{Int}
                           flat$33 flat$35;
             write flat$33 = Array_put#@{Int}
@@ -478,7 +478,7 @@ gen$date = DATE
           }
           read@{Array DateTime} flat$37 = flat$37;
           write flat$37 = Array_put#@{DateTime}
-                          flat$37 simp$24 simp$424;
+                          flat$37 simp$26 simp$416;
           read@{Array DateTime} flat$37 = flat$37;
           write flat$32 = flat$37;
           read@{Array Int} flat$41 = flat$33;

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -288,26 +288,26 @@ gen$date = DATE
         read@{Array (Buf 2 Error)} flat$11$simp$67 = flat$11$simp$63;
         read@{Array (Buf 2 Int)} flat$11$simp$68 = flat$11$simp$64;
         read@{Array (Buf 2 DateTime)} flat$11$simp$69 = flat$11$simp$65;
-        let simp$715 = unsafe_Array_index#@{Buf 2 Bool}
+        let simp$666 = unsafe_Array_index#@{Buf 2 Bool}
                        flat$12$simp$58 flat$13;
-        let simp$717 = unsafe_Array_index#@{Buf 2 Error}
+        let simp$668 = unsafe_Array_index#@{Buf 2 Error}
                        flat$12$simp$59 flat$13;
-        let simp$719 = unsafe_Array_index#@{Buf 2 Int}
+        let simp$670 = unsafe_Array_index#@{Buf 2 Int}
                        flat$12$simp$60 flat$13;
-        let simp$721 = unsafe_Array_index#@{Buf 2 DateTime}
+        let simp$672 = unsafe_Array_index#@{Buf 2 DateTime}
                        flat$12$simp$61 flat$13;
         write flat$11$simp$62 = Array_put#@{Buf 2 Bool}
                                 flat$11$simp$66 flat$13
-                                simp$715;
+                                simp$666;
         write flat$11$simp$63 = Array_put#@{Buf 2 Error}
                                 flat$11$simp$67 flat$13
-                                simp$717;
+                                simp$668;
         write flat$11$simp$64 = Array_put#@{Buf 2 Int}
                                 flat$11$simp$68 flat$13
-                                simp$719;
+                                simp$670;
         write flat$11$simp$65 = Array_put#@{Buf 2 DateTime}
                                 flat$11$simp$69 flat$13
-                                simp$721;
+                                simp$672;
       }
       read@{Array (Buf 2 Bool)} flat$11$simp$68 = flat$11$simp$60;
       read@{Array (Buf 2 Error)} flat$11$simp$69 = flat$11$simp$61;

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -550,11 +550,11 @@ gen$date = DATE
     if (a$conv$66$simp$230) {
       let conv$121 = sub#@{Double}
                      a$conv$66$simp$232 (1.0@{Double});
-      let conv$127$simp$276 = div#
-                              a$conv$66$simp$234 conv$121;
+      let conv$122 = div#
+                     a$conv$66$simp$234 conv$121;
       write flat$79$simp$250 = True@{Bool};
       write flat$79$simp$251 = ExceptTombstone@{Error};
-      write flat$79$simp$252 = conv$127$simp$276;
+      write flat$79$simp$252 = conv$122;
     } else {
       write flat$79$simp$250 = False@{Bool};
       write flat$79$simp$251 = a$conv$66$simp$231;
@@ -1507,10 +1507,10 @@ void iprogram_0(iprogram_0_t *s)
         
         if (a_conv_66_simp_230) {
             idouble_t        conv_121         = idouble_sub (a_conv_66_simp_232, 1.0); /* let */
-            idouble_t        conv_127_simp_276 = idouble_div (a_conv_66_simp_234, conv_121); /* let */
+            idouble_t        conv_122         = idouble_div (a_conv_66_simp_234, conv_121); /* let */
             flat_79_simp_250                  = itrue;                                /* write */
             flat_79_simp_251                  = ierror_tombstone;                     /* write */
-            flat_79_simp_252                  = conv_127_simp_276;                    /* write */
+            flat_79_simp_252                  = conv_122;                             /* write */
         } else {
             flat_79_simp_250                  = ifalse;                               /* write */
             flat_79_simp_251                  = a_conv_66_simp_231;                   /* write */


### PR DESCRIPTION
only need to crunch twice (crunching once yields avalanche type error from leftover melt stuff)

sadly the performance doesn't improve much for `feature injury ~> group 1 ~> correlation 0 severity`