### PR TITLE
fix up issues with outputting pairs

### DIFF
--- a/data/example/DemographicsChapter.toml
+++ b/data/example/DemographicsChapter.toml
@@ -9,8 +9,3 @@ title = "Demonstration dictionary nested"
   expression="""
     feature salary ~> sd (double value)
   """
-
-[feature.salary_test]
-  expression="""
-    feature salary ~> mean (double value), sd (double value), sum value, max value, min value
-  """

--- a/data/example/DemographicsChapter.toml
+++ b/data/example/DemographicsChapter.toml
@@ -9,3 +9,8 @@ title = "Demonstration dictionary nested"
   expression="""
     feature salary ~> sd (double value)
   """
+
+[feature.salary_test]
+  expression="""
+    feature salary ~> mean (double value), sd (double value), sum value, max value, min value
+  """

--- a/src/Icicle/Sea/FromAvalanche/Psv.hs
+++ b/src/Icicle/Sea/FromAvalanche/Psv.hs
@@ -681,12 +681,7 @@ strOfOutput ps oname@(OutputName name) otype0 ts0 ixStart
    mismatch    = Left (SeaOutputTypeMismatch oname otype0 ts0)
    unsupported = Left (SeaUnsupportedOutputType otype0)
 
-   incAssign n i
-    = n <+> "+=" <+> i <> ";"
-   inc n
-    = n <> "++;"
-
-   -- output (nested) pairs as array
+   -- Output (nested) pairs as array
    goP ts ns
     = let ptr  = bufn $ mconcat ns
           len  = lenn $ mconcat ns
@@ -705,14 +700,11 @@ strOfOutput ps oname@(OutputName name) otype0 ts0 ixStart
            )
            | otherwise
            = mismatch
-          com (a:s:ss)
-           = a
-           : vsep [ ch ptr' ","
-                  , inc len
-                  , s
-                  ]
-           : com ss
-          com ss = ss
+          com  []       = []
+          com  (s:ss)   = com' s ss
+          com' a []     = [a]
+          com' a (s:ss) = vsep [a, ch ptr' ",", inc len]
+                        : com' s ss
       in  do (i, sz, stms, bs) <- foldM go (0, "2", mempty, mempty) ts
              let size           = sz <+> "+" <+> pretty i
                  stms'          = com stms
@@ -726,7 +718,7 @@ strOfOutput ps oname@(OutputName name) otype0 ts0 ixStart
                                      ]
              pure (stms'', (ptr, size, len) : bs)
 
-   -- output single types
+   -- Output single types
    go1 t mx
     = let buf = bufn mx
           len = lenn mx
@@ -771,6 +763,9 @@ strOfOutput ps oname@(OutputName name) otype0 ts0 ixStart
 
    -- snprintf (buf, psv_output_buf_size, "%fmt", n,);
    snprintf i buf fmt n = i <> " = snprintf (" <> buf <> ", psv_output_buf_size,\"" <> fmt <> "\", " <> n <> ");"
+
+   incAssign n i = n <+> "+=" <+> i <> ";"
+   inc n         = n <>  "++;"
 
 
 ------------------------------------------------------------------------


### PR DESCRIPTION
per @jystic's suggestions, will do:

- fix comma issues
- move top-level SumT ErrorT out as a special case, so we only allocate buffers and run `dprintf` if there isn't an error
- remove the `memcpy`s