### PR TITLE
Add segfault handler to PSV test

### DIFF
--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -2,8 +2,10 @@
 
 #include <assert.h>
 #include <ctype.h>
+#include <execinfo.h>
 #include <fcntl.h>
 #include <math.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -38,7 +40,7 @@ static const iunit_t iunit  = 0x13013;
 static const ibool_t ifalse = 0;
 static const ibool_t itrue  = 1;
 
-#if ICICLE_DEBUG
+#if ICICLE_NOINLINE || ICICLE_DEBUG
 #   define INLINE __attribute__((noinline))
 #else
 #   define INLINE __attribute__((always_inline))

--- a/data/sea/06-segv.h
+++ b/data/sea/06-segv.h
@@ -2,8 +2,8 @@
 
 /* this global is pretty nasty, don't know how else we can get
  * information in a signal handler though */
-static const size_t segv_user_data_size = 1024*1024;
-static char segv_user_data[segv_user_data_size];
+#define SEGV_USER_DATA_SIZE (1024*1024)
+static char segv_user_data[SEGV_USER_DATA_SIZE];
 
 static void segv_handler (int sig)
 {
@@ -19,7 +19,7 @@ static void segv_handler (int sig)
 
 void segv_install_handler (const char *user_data, size_t user_data_size)
 {
-    size_t size = MIN (user_data_size, segv_user_data_size-1);
+    size_t size = MIN (user_data_size, SEGV_USER_DATA_SIZE-1);
     memcpy (segv_user_data, user_data, size);
     segv_user_data[size] = '\0';
 

--- a/data/sea/06-segv.h
+++ b/data/sea/06-segv.h
@@ -1,0 +1,44 @@
+#include "05-error.h"
+
+/* this global is pretty nasty, don't know how else we can get
+ * information in a signal handler though */
+static const size_t segv_user_data_size = 1024*1024;
+static char segv_user_data[segv_user_data_size];
+
+static void segv_handler (int sig)
+{
+    void *frames[50];
+    size_t n_frames = backtrace (frames, sizeof(frames));
+
+    fprintf (stderr, "icicle: segmentation fault:\n");
+    backtrace_symbols_fd (frames, n_frames, STDERR_FILENO);
+    fprintf (stderr, "\n%s\n", segv_user_data);
+
+    exit (1);
+}
+
+void segv_install_handler (const char *user_data, size_t user_data_size)
+{
+    size_t size = MIN (user_data_size, segv_user_data_size-1);
+    memcpy (segv_user_data, user_data, size);
+    segv_user_data[size] = '\0';
+
+    struct sigaction act;
+
+    sigemptyset (&act.sa_mask);
+    act.sa_flags   = 0;
+    act.sa_handler = segv_handler;
+
+    sigaction (SIGSEGV, &act, NULL);
+}
+
+void segv_remove_handler ()
+{
+    struct sigaction act;
+
+    sigemptyset (&act.sa_mask);
+    act.sa_flags   = 0;
+    act.sa_handler = SIG_DFL;
+
+    sigaction (SIGSEGV, &act, NULL);
+}

--- a/data/sea/06-segv.h
+++ b/data/sea/06-segv.h
@@ -5,8 +5,21 @@
 #define SEGV_USER_DATA_SIZE (1024*1024)
 static char segv_user_data[SEGV_USER_DATA_SIZE];
 
+void segv_remove_handler ()
+{
+    struct sigaction act;
+
+    sigemptyset (&act.sa_mask);
+    act.sa_flags   = 0;
+    act.sa_handler = SIG_DFL;
+
+    sigaction (SIGSEGV, &act, NULL);
+}
+
 static void segv_handler (int sig)
 {
+    segv_remove_handler ();
+
     void *frames[50];
     size_t n_frames = backtrace (frames, sizeof(frames));
 
@@ -28,17 +41,6 @@ void segv_install_handler (const char *user_data, size_t user_data_size)
     sigemptyset (&act.sa_mask);
     act.sa_flags   = 0;
     act.sa_handler = segv_handler;
-
-    sigaction (SIGSEGV, &act, NULL);
-}
-
-void segv_remove_handler ()
-{
-    struct sigaction act;
-
-    sigemptyset (&act.sa_mask);
-    act.sa_flags   = 0;
-    act.sa_handler = SIG_DFL;
 
     sigaction (SIGSEGV, &act, NULL);
 }

--- a/data/sea/10-mempool.h
+++ b/data/sea/10-mempool.h
@@ -1,4 +1,4 @@
-#include "05-error.h"
+#include "06-segv.h"
 
 const size_t iblock_size = 1 * 1024 * 1024;
 


### PR DESCRIPTION
We can now trap segmentation faults and print a stack trace as well as some user data before exiting.

In the case of the PSV test, the user data is the test case which caused the segfault.