### PR TITLE
Clang style error messages when input data is invalid

### DIFF
--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -21,6 +21,7 @@
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 #pragma GCC diagnostic ignored "-Wunused-variable"
 #pragma GCC diagnostic ignored "-Wundefined-internal"
+#pragma GCC diagnostic ignored "-Wself-assign"
 
 typedef uint64_t ierror_t;
 typedef uint64_t iunit_t;
@@ -30,7 +31,6 @@ typedef   double idouble_t;
 typedef  int64_t itime_t;
 
 typedef const char *istring_t;
-typedef const char *ierror_msg_t;
 
 static const ierror_t ierror_not_an_error           = 0;
 static const ierror_t ierror_tombstone              = 1;

--- a/data/sea/05-error.h
+++ b/data/sea/05-error.h
@@ -1,5 +1,11 @@
 #include "00-includes.h"
 
+/*
+Error messages
+*/
+
+typedef const char *ierror_msg_t;
+
 static ierror_msg_t NOINLINE ierror_msg_format (const char *fmt, ...)
 {
     va_list args;
@@ -42,6 +48,82 @@ static ierror_msg_t NOINLINE ierror_msg_add_line (iint_t line, ierror_msg_t orig
 
     return error_text;
 }
+
+/*
+Location-based errors
+*/
+
+typedef struct ierror_loc {
+    const char *line_start;
+    const char *line_end;
+    const char *span_start;
+    const char *span_end;
+    char        message[0];
+} *ierror_loc_t;
+
+static ierror_loc_t NOINLINE ierror_loc_format (const char *start, const char *end, const char *fmt, ...)
+{
+    const size_t message_size = 4 * 1024;
+
+    va_list args;
+    va_start (args, fmt);
+
+    struct ierror_loc *error = calloc (sizeof (struct ierror_loc) + message_size, 1);
+
+    vsnprintf (error->message, message_size, fmt, args);
+    va_end (args);
+
+    error->span_start = start;
+    error->span_end   = end;
+
+    return error;
+}
+
+static ierror_msg_t NOINLINE ierror_loc_pretty (ierror_loc_t loc, iint_t line)
+{
+    size_t  msg_size = 8 * 1024;
+    char   *msg_text = calloc (msg_size, 1);
+
+    char *p  = msg_text;
+    char *pe = msg_text + msg_size;
+
+    int prefix_size = snprintf (p, pe - p, "line %lld: ", line);
+    p += prefix_size;
+    p += snprintf (p, pe - p, "%.*s\n", (int)(loc->line_end - loc->line_start), loc->line_start);
+
+    if (loc->span_start == 0 || loc->span_end == 0)
+        goto done;
+
+    int ix_start = prefix_size + (loc->span_start - loc->line_start);
+    int ix_end   = prefix_size + (loc->span_end   - loc->line_start);
+
+    static const char *span_chars = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~";
+
+    if (ix_start <= ix_end) {
+        int span_size = ix_end - ix_start;
+        p += snprintf (p, pe - p, "%*s",    ix_start, "");
+        p += snprintf (p, pe - p, "%.*s^ ", MAX (0, span_size), span_chars);
+        goto done;
+    }
+
+    if (ix_start > ix_end) {
+        int span_size = ix_start - ix_end;
+        p += snprintf (p, pe - p, "%*s",    ix_end, "");
+        p += snprintf (p, pe - p, "^%.*s ", MAX (0, span_size), span_chars);
+        goto done;
+    }
+
+done:
+    snprintf (p, pe - p, "%s", loc->message);
+    free ((struct ierror_loc *) loc);
+
+    return msg_text;
+}
+
+
+/*
+Debugging
+*/
 
 static void NOINLINE idebug (const char *msg, const char *value_ptr, const size_t value_size)
 {

--- a/test/Icicle/Test/Sea/Text.hs
+++ b/test/Icicle/Test/Sea/Text.hs
@@ -15,8 +15,9 @@ import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Either
 
 import           Data.String (String)
+import           Data.Word (Word64)
 
-import           Disorder.Core.IO
+import           Disorder.Core.IO (testIO)
 
 import           Foreign.C
 import           Foreign.Marshal
@@ -26,10 +27,13 @@ import           Foreign.Storable
 import           Jetski
 
 import           P
+import           Prelude (minBound, maxBound)
 
-import           System.IO
+import           System.IO (IO)
+import           System.IO.Unsafe (unsafePerformIO)
 
-import           Test.QuickCheck (forAllProperties, quickCheckWithResult, stdArgs, maxSuccess)
+import           Test.QuickCheck (forAllProperties, quickCheckWithResult, stdArgs)
+import           Test.QuickCheck (maxSuccess, forAll, choose)
 import           Test.QuickCheck.Property (Property, (===), counterexample, failed, property)
 
 import           X.Control.Monad.Trans.Either (firstEitherT)
@@ -37,44 +41,63 @@ import           X.Control.Monad.Trans.Either (firstEitherT)
 
 prop_text_read_int :: Int64 -> Property
 prop_text_read_int expected
- = testRead "testable_text_read_iint" (show expected)
- $ \actual -> actual === expected
+ = testRead "testable_text_read_iint" (show expected) $ \actual ->
+     actual === expected
 
-prop_text_read_double :: Double -> Property
-prop_text_read_double expected
- = testRead "testable_text_read_idouble" (show expected)
- $ \actual -> let diff    = actual - expected
-                  epsilon = 0.000000001
-              in counterexample ("expected   = " <> show expected)
-               $ counterexample ("actual     = " <> show actual)
-               $ counterexample ("difference = " <> show diff)
-               $ property (diff < epsilon)
+prop_text_read_double :: Property
+prop_text_read_double
+ = forAll (choose (minBound, maxBound)) $ \(expected64 :: Word64) ->
+   let expected = fromWord64 expected64
+   in testRead "testable_text_read_idouble" (show expected) $ \actual ->
+     let epsilon = if expected /= 0
+                   then abs expected * 1.0e-14
+                   else 0
+
+         diff    = actual - expected
+
+         equal   = isNaN expected && isNaN actual
+                || expected == actual
+                || diff < epsilon
+
+     in counterexample ("expected   =  " <> show expected)
+      $ counterexample ("actual     =  " <> show actual)
+      $ counterexample ("difference =  " <> show diff)
+      $ counterexample ("epsilon    =  " <> show epsilon)
+      $ property equal
 
 seaTestables :: SourceCode
 seaTestables = codeOfDoc $ PP.vsep
-  [ "ierror_msg_t testable_text_read_iint (char *p, size_t n, iint_t *output_ptr) {"
-  , "    return text_read_iint (&p, p + n, output_ptr);"
+  [ "ierror_msg_t from_loc (char *ps, char *pe, ierror_loc_t loc) {"
+  , "    if (!loc) return 0;"
+  , "    loc->line_start = ps;"
+  , "    loc->line_end   = pe;"
+  , "    return ierror_loc_pretty (loc, 1);"
+  , "}"
+  , "ierror_msg_t testable_text_read_iint (char *p, size_t n, iint_t *output_ptr) {"
+  , "    return from_loc (p, p+n, text_read_iint (&p, p+n, output_ptr));"
   , "}"
   , "ierror_msg_t testable_text_read_idouble (char *p, size_t n, idouble_t *output_ptr) {"
-  , "    return text_read_idouble (&p, p + n, output_ptr);"
+  , "    segv_install_handler (0, 0);"
+  , "    return from_loc (p, p+n, text_read_idouble (&p, p+n, output_ptr));"
   , "}"
   ]
 
 ------------------------------------------------------------------------
 
 data TestError
- = SeaError   String
+ = SeaError    String
  | JetskiError JetskiError
 
 testRead :: Storable a => Symbol -> String -> (a -> Property) -> Property
-testRead symbol input onOutput = testIO . runRight $ do
+testRead symbol input onOutput = testIO . liftIO . runRight $ do
   lib <- firstEitherT JetskiError (readLibrary seaTestables)
   fn  <- firstEitherT JetskiError (function lib symbol (retPtr retCChar))
 
-  res <- liftIO $
-    withCStringLen input $ \(p, n) -> do
+  (hoistEither =<<) . liftIO $
+    withCString input $ \p -> do
     alloca $ \(outputPtr :: Ptr a) -> do
-      errorPtr <- liftIO $ fn [argPtr p, argCSize (fromIntegral n), argPtr outputPtr]
+      let n = fromIntegral (length input)
+      errorPtr <- liftIO $ fn [argPtr p, argCSize n, argPtr outputPtr]
 
       if errorPtr /= nullPtr
       then do
@@ -83,9 +106,8 @@ testRead symbol input onOutput = testIO . runRight $ do
         return (Left (SeaError msg))
       else do
         output <- peek outputPtr
-        return (Right (counterexample ("input = " <> show input) (onOutput output)))
-
-  hoistEither res
+        return (Right (counterexample ("input      = " <> show input)
+                                      (onOutput output)))
 
 runRight :: Monad m => EitherT TestError m Property -> m Property
 runRight a = do
@@ -95,10 +117,15 @@ runRight a = do
     Left (JetskiError x) -> return (counterexample (show x) failed)
     Right x              -> return x
 
+fromWord64 :: Word64 -> Double
+fromWord64 w64 =
+  unsafePerformIO . alloca $ \(ptr :: Ptr Double) ->
+    poke (castPtr ptr) w64 >> peek ptr
+
 ------------------------------------------------------------------------
 
 return []
 tests :: IO Bool
 tests = releaseLibraryAfterTests $ do
   -- $quickCheckAll
-  $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 1000 })
+  $forAllProperties $ quickCheckWithResult (stdArgs { maxSuccess = 10000 })


### PR DESCRIPTION
Here's a few examples of actual output:

```
line 1: ABC
        ~~~^ missing '|' after entity

line 1: ABC|stuffs
            ~~~~~~^ missing '|' after attribute

line 1: ABC|stuffs|[{"open":XX3500000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000}]|2012-05-08T00:00:00Z
                            ^ not an integer

line 1: ABC|stuffs|[{"open":350000000000000000000000000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000}]|2012-05-08T00:00:00Z
                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ integer too big, only 64-bits supported

line 1: ABC|stuffs|[{"foo":xx,"open":350000000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000}]|2012-05-08T00:00:00Z
                           ^ not a boolean

line 1: ABC|stuffs|[{"open":350000000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000,"foo":"abcde}]|2012-05-08T00:00:00Z
                                                                                                                ~~~~~~~^ string missing closing quote

line 1: ABC|stuffs|[{"foo":2015-10,"open":3500000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000}]|2012-05-08T00:00:00Z
                           ^ time missing opening quote

line 1: ABC|stuffs|[{"foo":"2015-10","open":3500000000,"high":3500,"low":3500,"close":3500,"volume":0,"adjclose":70000}]|2012-05-08T00:00:00Z
                            ^~~~~~~ unknown time format, must be "yyyy-mm-dd" or "yyyy-mm-ddThh:mm:ssZ"
```