### PR TITLE
fix trailing comma in case of tombstone

### DIFF
--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -79,7 +79,7 @@ convertValues a_fresh statements
   goA xx t v
    = case v of
        VArray arr
-         -> arrPrim 0 (XPrim a_fresh (PrimProject (PrimProjectArrayLength t)) `xApp` xx) t arr
+         -> arrPrim 0 (XValue a_fresh IntT (VInt (length arr))) t arr
        _ -> xx
 
   bufPrim n t b

--- a/src/Icicle/Sea/FromAvalanche/Psv.hs
+++ b/src/Icicle/Sea/FromAvalanche/Psv.hs
@@ -748,8 +748,8 @@ mappingOfField (StructField fname, ftype) vars0 = do
 
 -- * Output
 
-cond :: Doc -> Doc -> Doc
-cond n body
+conditional :: Doc -> Doc -> Doc
+conditional n body
  = vsep ["if (" <> n <> ")"
         , "{"
         , indent 4 body
@@ -881,12 +881,14 @@ seaOfWriteOutput ps oname@(OutputName name) otype0 ts0 ixStart
          SumT ErrorT otype1
           | (ErrorT : ts1) <- ts0
           , (ne     : _)   <- members
-          -> do (body, _, _) <- seaOfOutput False ps oname otype1 ts1 (ixStart+1) (const id)
-                let body'     = go body
-                pure $ cond (ne <> " == ierror_not_an_error") body'
+          -> do (m, body, _, _) <- seaOfOutput False ps oname otype1 ts1 (ixStart+1) (const id)
+                let body'        = seaOfOutputCond m body
+                let body''       = go body'
+                pure $ conditional (ne <> " == ierror_not_an_error") body''
          _
-          -> do (body, _, _) <- seaOfOutput False ps oname otype0 ts0 ixStart (const id)
-                return $ go body
+          -> do (m, body, _, _) <- seaOfOutput False ps oname otype0 ts0 ixStart (const id)
+                let body'        = seaOfOutputCond m body
+                return $ go body'
 
   where
     before = vsep [ outputValue  "string" ["entity", "entity_size"]
@@ -905,7 +907,8 @@ seaOfOutput
   -> [ValType]                     -- ^ types of arguments
   -> Int                           -- ^ struct index
   -> (ValType -> Doc -> Doc)       -- ^ apply this to struct members
-  -> Either SeaError ( Doc         -- output statements for consumed arguments
+  -> Either SeaError ( Maybe Doc   -- top level condition for the output statement
+                     , Doc         -- the output statement
                      , Int         -- where it's up to
                      , [ValType] ) -- unconsumed arguments
 seaOfOutput q ps oname@(OutputName name) otype0 ts0 ixStart transform
@@ -914,49 +917,86 @@ seaOfOutput q ps oname@(OutputName name) otype0 ts0 ixStart transform
        | tes@(t':_) <- meltType te
        , length ts0 == length tes
        , (arr : _)  <- members
-       -> do (body, ix, _) <- seaOfOutput True ps oname te tes ixStart (arrayIndex...transform)
+       -> do (mcond, body, ix, _) <- seaOfOutput True ps oname te tes ixStart (arrayIndex...transform)
+
+             -- End the body with a comma, if applicable
+             let body' = seaOfOutputCond mcond
+                       $ vsep [seaOfOutputArraySep, body]
+
              -- Special case for (ArrayT (ArrayT NotArrayThing)) as that is allowed in v0
              let ac         = arrayCount $ transform (ArrayT t') arr
-             body'         <- seaOfOutputArray body ac
+
+             -- Wrap the body in a for loop
+             body''        <- seaOfOutputArray body' ac
+
              let ts1        = List.drop (length tes) ts0
-             return (body', ix, ts1)
+             return (Nothing, body'', ix, ts1)
 
       MapT tk tv
        | tks        <- meltType tk
        , tvs        <- meltType tv
        , length ts0 == length tks + length tvs
        , (arr: _)   <- members
-       -> do (bk, ixk, _)   <- seaOfOutput True ps oname tk tks ixStart (arrayIndex...transform)
-             (bv, ixv, ts)  <- seaOfOutput True ps oname tv tvs ixk     (arrayIndex...transform)
-             body'          <- seaOfOutputArray (pair bk bv) (arrayCount arr)
-             return (body', ixv, ts)
+       -> do (mcondk, bk, ixk, _)  <- seaOfOutput True ps oname tk tks ixStart (arrayIndex...transform)
+             (mcondv, bv, ixv, ts) <- seaOfOutput True ps oname tv tvs ixk     (arrayIndex...transform)
 
-      OptionT otype1
-       | (BoolT : ts1) <- ts0
-       , (nb    : _)   <- members
-       -> do (body, ix, ts) <- seaOfOutput q ps oname otype1 ts1 (ixStart+1) transform
-             let nb' = transform otype1 nb
-             pure (cond nb' body, ix, ts)
+             let p  = pair bk bv
+             p'    <- case (mcondk, mcondv) of
+                        (Nothing, Nothing)
+                          -> pure p
+                        (Just cond, Just _)
+                          -> pure
+                           $ conditional cond
+                           $ vsep [seaOfOutputArraySep, p]
+                        _ -> Left mismatch
+
+             body  <- seaOfOutputArray p' (arrayCount arr)
+             return (Nothing, body, ixv, ts)
 
       PairT ta tb
        | tas <- meltType ta
        , tbs <- meltType tb
-       -> do (ba, ixa, _)  <- seaOfOutput True ps oname ta tas ixStart transform
-             (bb, ixb, ts) <- seaOfOutput True ps oname tb tbs ixa     transform
-             return (pair ba bb, ixb, ts)
+       -> do (mconda, ba, ixa, _)  <- seaOfOutput True ps oname ta tas ixStart transform
+             (mcondb, bb, ixb, ts) <- seaOfOutput True ps oname tb tbs ixa     transform
+
+             let p  = pair ba bb
+             p'    <- case (mconda, mcondb) of
+                        (Nothing, Nothing)
+                           -> pure p
+                        (Just cond, Just _)
+                           -> pure
+                            $ conditional cond
+                            $ vsep [seaOfOutputArraySep, p]
+                        _ -> Left mismatch
+
+             return (Nothing, p', ixb, ts)
+
+      -- Conditionals
+      OptionT otype1
+       | (BoolT : ts1) <- ts0
+       , (nb    : _)   <- members
+       -> do (mcond, body, ix, ts) <- seaOfOutput q ps oname otype1 ts1 (ixStart+1) transform
+
+             let body' = seaOfOutputCond mcond body
+             let nb' = transform otype1 nb
+             pure (Just nb', body', ix, ts)
 
       SumT ErrorT otype1
        | (ErrorT : ts1) <- ts0
        , (ne     : _)   <- members
-       -> do (body, ix, ts) <- seaOfOutput False ps oname otype1 ts1 (ixStart+1) transform
-             let ne' = transform otype1 ne
-             pure (cond (ne' <> " == ierror_not_an_error") body, ix, ts)
+       -> do (mcond, body, ix, ts) <- seaOfOutput False ps oname otype1 ts1 (ixStart+1) transform
+
+             let body' = seaOfOutputCond mcond body
+             let ne'   = transform otype1 ne
+             pure (Just (ne' <> " == ierror_not_an_error"), body', ix, ts)
+
+      -- Base
       _
        | (t  : ts) <- ts0
        , (mx : _)  <- members
        , mx'  <- transform t mx
        -> do d <- seaOfOutputBase' q t mx'
-             pure (d, ixStart + 1, ts)
+             pure (Nothing, d, ixStart + 1, ts)
 
       _ -> Left unsupported
 
@@ -983,14 +1023,22 @@ seaOfOutput q ps oname@(OutputName name) otype0 ts0 ixStart transform
     = pure (vsep [ outputChar '['
                  , forStmt counter countLimit numElems
                  , "{"
-                 , indent 4
-                     $ cond (counter <+> "> 0")
-                            (outputChar ',')
                  , indent 4 body
                  , "}"
                  , outputChar ']'
                  ]
            )
+
+   seaOfOutputArraySep
+     = conditional (counter <+> "> 0") (outputChar ',')
+
+seaOfOutputCond :: Maybe Doc -> Doc -> Doc
+seaOfOutputCond mcond body
+  = case mcond of
+      Nothing
+        -> body
+      Just cond
+        -> conditional cond body
 
 -- | Output single types
 seaOfOutputBase :: Bool -> SeaError -> ValType -> Doc -> Either SeaError Doc

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -117,8 +117,10 @@ gen$time = TIME
   } else {
     write flat$16$simp$32 = c$conv$13$simp$28;
     write flat$16$simp$33 = 0@{Int};
-    write flat$16$simp$34 = []@{Array Error};
-    write flat$16$simp$35 = []@{Array Int};
+    write flat$16$simp$34 = unsafe_Array_create#@{Error}
+                            (0@{Int});
+    write flat$16$simp$35 = unsafe_Array_create#@{Int}
+                            (0@{Int});
   }
   read@{Error} flat$16$simp$36 = flat$16$simp$32;
   read@{Int} flat$16$simp$37 = flat$16$simp$33;
@@ -329,8 +331,10 @@ gen$time = TIME
         write flat$24$simp$69 = flat$29;
       } else {
         write flat$24$simp$67 = flat$23$simp$65;
-        write flat$24$simp$68 = []@{Array Time};
-        write flat$24$simp$69 = []@{Array Int};
+        write flat$24$simp$68 = unsafe_Array_create#@{Time}
+                                (0@{Int});
+        write flat$24$simp$69 = unsafe_Array_create#@{Int}
+                                (0@{Int});
       }
       read@{Error} flat$24$simp$70 = flat$24$simp$67;
       read@{Array Time} flat$24$simp$71 = flat$24$simp$68;
@@ -340,8 +344,10 @@ gen$time = TIME
       write flat$19$simp$46 = flat$24$simp$72;
     } else {
       write flat$19$simp$44 = flat$16$simp$41;
-      write flat$19$simp$45 = []@{Array Time};
-      write flat$19$simp$46 = []@{Array Int};
+      write flat$19$simp$45 = unsafe_Array_create#@{Time}
+                              (0@{Int});
+      write flat$19$simp$46 = unsafe_Array_create#@{Int}
+                              (0@{Int});
     }
     read@{Error} flat$19$simp$73 = flat$19$simp$44;
     read@{Array Time} flat$19$simp$74 = flat$19$simp$45;


### PR DESCRIPTION
If you do a `latest 2 ~> value`, but one of the last 2 values is a tombstone, PSV output will not print it, but will print a comma. e.g. `"ID00000002|expression_latest_two|[c,]"`

this fixes the PSV output code so that the comma-outputting code is included inside the conditional.