### PR TITLE
no shadowed C names

### DIFF
--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -505,7 +505,7 @@ baseValueForType t
      <$> listOf ((,) <$> baseValueForType k <*> baseValueForType v))
 
     StringT
-     -> VString <$> arbitrary
+     -> VString <$> elements simpsons
     StructT (StructType fs)
      -> smaller
       (VStruct <$> traverse baseValueForType fs)


### PR DESCRIPTION
Some generated C names were being shadowed, e.g. to output an array of array of bools

```
for (iint_t kermit_i = 0, kermit_n = p->kermit->count; kermit_i < kermit_n; ++kermit_i) {
  for (iint_t kermit_i = 0, kermit_n = iarray_iarray_ibool_index(p->kermit)->count; kermit_i < kermit_n; ++kermit_i) {
     (BOOM)
  }
}
```

This is likely what was causing the intermittent segfaults in https://github.com/ambiata/icicle/issues/287.

Fixed the issue by adding a "used names environment" and passing it around, pretty savage.