### PR TITLE
Add environment variable ICICLE_CC_OPTIONS

### DIFF
--- a/test/Icicle/Test/Sea/Psv.hs
+++ b/test/Icicle/Test/Sea/Psv.hs
@@ -113,7 +113,9 @@ data ShowData = ShowDataOnError | ShowDataOnSuccess
 
 runTest :: ShowData -> WellTyped -> EitherT S.SeaError IO ()
 runTest showData wt = do
-  let options  = S.compilerOptions <> ["-O0", "-DICICLE_NOINLINE=1"]
+  options0 <- S.getCompilerOptions
+
+  let options  = options0 <> ["-O0", "-DICICLE_NOINLINE=1"]
       programs = Map.singleton (wtAttribute wt) (wtAvalanche wt)
       config   = S.PsvConfig (S.PsvSnapshot (wtTime wt))
                              (Map.singleton (wtAttribute wt) (Set.singleton tombstone))

--- a/test/Icicle/Test/Sea/Utils.hs
+++ b/test/Icicle/Test/Sea/Utils.hs
@@ -9,7 +9,7 @@ module Icicle.Test.Sea.Utils (
   ) where
 
 import qualified Icicle.Internal.Pretty as PP
-import           Icicle.Sea.Eval (compilerOptions)
+import           Icicle.Sea.Eval (getCompilerOptions)
 import           Icicle.Sea.Preamble (seaPreamble)
 import           Icicle.Test.Arbitrary ()
 
@@ -48,7 +48,8 @@ readLibrary code = do
   case mlib of
     Just elib -> hoistEither elib
     Nothing   -> do
-      elib <- liftIO (runEitherT (compileLibrary compilerOptions code))
+      opts <- getCompilerOptions
+      elib <- liftIO (runEitherT (compileLibrary opts code))
       liftIO (writeIORef libraryRef (Just elib))
       hoistEither elib
 


### PR DESCRIPTION
This will allow us to have warnings as errors on our dev boxes (read: with clang), even though we want icicle to be more forgiving when used with gcc.

For example:

```shell
export ICICLE_CC_OPTIONS="-Werror -Weverything"
```