### PR TITLE
WIP: fixing up the bubblegum

### DIFF
--- a/src/Icicle/Avalanche/Annot.hs
+++ b/src/Icicle/Avalanche/Annot.hs
@@ -38,8 +38,8 @@ reannotS f ss
     ForeachInts n x1 x2 s
      -> ForeachInts n (reannotX f x1) (reannotX f x2) (reannotS f s)
 
-    ForeachFacts fs t ft s
-     -> ForeachFacts fs t ft (reannotS f s)
+    ForeachFacts binds t ft s
+     -> ForeachFacts binds t ft (reannotS f s)
 
     Block s
      -> Block (fmap (reannotS f) s)

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -97,8 +97,8 @@ checkStatement frag ctx stmt
 
                ForeachInts n from' to' <$> go stmts
 
-        ForeachFacts ns vt lo stmts
-         -> ForeachFacts ns vt lo <$> go stmts
+        ForeachFacts binds vt lo stmts
+         -> ForeachFacts binds vt lo <$> go stmts
 
 
         Block stmts
@@ -190,9 +190,9 @@ statementContext frag ctx stmt
      -> do ctxX' <- insert (ctxExp ctx) n (FunT [] IntT)
            return (ctx { ctxExp = ctxX' })
 
-    ForeachFacts ns _ _ _
+    ForeachFacts binds _ _ _
      -> do let inserts m (n,ty) = insert m n (FunT [] ty)
-           ctxX' <- foldM inserts (ctxExp ctx) ns
+           ctxX' <- foldM inserts (ctxExp ctx) (factBindsAll binds)
            return (ctx { ctxExp = ctxX' })
 
     Block _

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -102,7 +102,7 @@ programFromCore namer p
    = factLoop FactLoopNew
 
   factLoop loopType
-   = ForeachFacts [(C.factValName p, inputType')] inputType' loopType
+   = ForeachFacts (FactBinds (C.factTimeName p) (C.factIdName p) [(C.factValName p, inputType')]) inputType' loopType
    $ Block factStmts
 
   inputType' = PairT (C.inputType p) TimeT

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -61,7 +61,7 @@ programFromCore namer p
     -- accums (filter (readFromHistory.snd) $ C.reduces p)
     -- ( factLoopHistory    <>
     ( createAccums
-    ( readaccum (C.inputName p, inputType') (initAccums (C.streams p)) <>
+    ( readaccum (C.factValName p, inputType') (initAccums (C.streams p)) <>
       mconcat (fmap loadResumables accNames) <>
       factLoopNew                            <>
       mconcat (fmap saveResumables accNames) <>
@@ -102,7 +102,7 @@ programFromCore namer p
    = factLoop FactLoopNew
 
   factLoop loopType
-   = ForeachFacts [(C.inputName p, inputType')] inputType' loopType
+   = ForeachFacts [(C.factValName p, inputType')] inputType' loopType
    $ Block factStmts
 
   inputType' = PairT (C.inputType p) TimeT
@@ -149,7 +149,7 @@ makeStatements
         -> ([(Name n, ValType)], [Statement () n Prim])
 makeStatements p namer streams
  = let (nms,stms) = go [] streams
-   in  ((C.inputName p, PairT (C.inputType p) TimeT) : nms, Write (namerAccPrefix namer $ C.inputName p) (X.XVar () $ C.inputName p) : stms)
+   in  ((C.factValName p, PairT (C.inputType p) TimeT) : nms, Write (namerAccPrefix namer $ C.factValName p) (X.XVar () $ C.factValName p) : stms)
  where
   go nms []
    = (nms, [])

--- a/src/Icicle/Avalanche/Prim/Eval.hs
+++ b/src/Icicle/Avalanche/Prim/Eval.hs
@@ -190,6 +190,8 @@ meltValue v t
      VTime{}   -> Just [v]
      VString{} -> Just [v]
      VError{}  -> Just [v]
+     VFactIdentifier{}
+               -> Just [v]
 
      VArray vs
       | Nothing <- tryMeltType t
@@ -318,6 +320,8 @@ unmeltValue' vs0 t
      (v:vs, TimeT{})   -> Just (v, vs)
      (v:vs, StringT{}) -> Just (v, vs)
      (v:vs, ErrorT{})  -> Just (v, vs)
+     (v:vs, FactIdentifierT{})
+                       -> Just (v, vs)
 
      (v:vs, ArrayT ta)
       | Just ts <- tryMeltType ta

--- a/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/src/Icicle/Avalanche/Prim/Flat.hs
@@ -193,6 +193,8 @@ meltType t
     TimeT   -> [t]
     StringT -> [t]
     ErrorT  -> [t]
+    FactIdentifierT
+            -> [t]
 
     PairT   a b -> meltType a <> meltType b
 
@@ -214,6 +216,7 @@ meltType t
 
      | otherwise
      -> concat $ fmap meltType (Map.elems fs)
+
 
 tryMeltType :: ValType -> Maybe [ValType]
 tryMeltType t

--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -349,7 +349,7 @@ flatX a_fresh xx stm
 
 
       Core.PrimLatest (Core.PrimLatestPush i t)
-       | [buf, e, _factid]    <- xs
+       | [buf, _factid, e]    <- xs
        -> flatX' e
        $  \e'
        -> flatX' buf

--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -349,7 +349,7 @@ flatX a_fresh xx stm
 
 
       Core.PrimLatest (Core.PrimLatestPush i t)
-       | [buf, e]    <- xs
+       | [buf, e, _factid]    <- xs
        -> flatX' e
        $  \e'
        -> flatX' buf
@@ -380,7 +380,7 @@ flatX a_fresh xx stm
       -- TODO: PrimWindow should probably be a Min primitive, or perhaps Flat primitive as well. This should keep fact in history if it is greater than newer than, but not less than older than.
       -- TODO: or perhaps just add an if and call KeepFactInHistory.
       Core.PrimWindow newerThan olderThan
-       | [now, fact, _] <- xs
+       | [now, fact, _factid] <- xs
        -> flatX' now
        $  \now'
        -> flatX' fact

--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -378,8 +378,9 @@ flatX a_fresh xx stm
        -> lift $ Left $ FlattenErrorPrimBadArgs p xs
 
       -- TODO: PrimWindow should probably be a Min primitive, or perhaps Flat primitive as well. This should keep fact in history if it is greater than newer than, but not less than older than.
+      -- TODO: or perhaps just add an if and call KeepFactInHistory.
       Core.PrimWindow newerThan olderThan
-       | [now, fact] <- xs
+       | [now, fact, _] <- xs
        -> flatX' now
        $  \now'
        -> flatX' fact

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -290,7 +290,7 @@ substXinS a_fresh name payload statements
       ForeachFacts binds@(FactBinds ntime nfid ns) x y ss
        | name `elem` fmap fst (factBindsAll binds)
        -> finished s
-       | any (flip Set.member frees . fst) ns
+       | any (flip Set.member frees . fst) (factBindsAll binds)
        -> do ntime'  <- fresh
              nfid'   <- fresh
              let subF n n' = substXinS a_fresh n (XVar a_fresh n')

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -287,11 +287,15 @@ substXinS a_fresh name payload statements
        | Set.member n frees
        -> freshen n ss $ \n' ss' -> Read n' x z ss'
 
-      ForeachFacts ns x y ss
-       | name `elem` fmap fst ns
+      ForeachFacts binds@(FactBinds ntime nfid ns) x y ss
+       | name `elem` fmap fst (factBindsAll binds)
        -> finished s
        | any (flip Set.member frees . fst) ns
-       -> freshenForeach [] ns x y ss
+       -> do ntime'  <- fresh
+             nfid'   <- fresh
+             let subF n n' = substXinS a_fresh n (XVar a_fresh n')
+             ss'     <- subF ntime  ntime' ss >>= subF nfid   nfid'
+             freshenForeach ntime'  nfid' [] ns x y ss'
 
       _
        -> return (True, s)
@@ -315,12 +319,12 @@ substXinS a_fresh name payload statements
         ss' <- substXinS a_fresh n (XVar a_fresh n') ss
         trans True (f n' ss')
 
-  freshenForeach ns [] x y ss
-   = return (True, ForeachFacts ns x y ss)
-  freshenForeach ns ((n,t):ns') x y ss
+  freshenForeach ntime nfid ns [] x y ss
+   = return (True, ForeachFacts (FactBinds ntime nfid ns) x y ss)
+  freshenForeach ntime nfid ns ((n,t):ns') x y ss
    = do n'  <- fresh
         ss' <- substXinS a_fresh n (XVar a_fresh n') ss
-        freshenForeach (ns <> [(n',t)]) ns' x y ss'
+        freshenForeach ntime nfid (ns <> [(n',t)]) ns' x y ss'
 
   frees = freevars payload
 

--- a/src/Icicle/Avalanche/Statement/Simp/Dead.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Dead.hs
@@ -60,9 +60,9 @@ deadS us statements
             fU       = usageX from
             tU       = usageX to
         in (mconcat [sU, fU, tU], ForeachInts n from to sS)
-    ForeachFacts ns vt ty ss
+    ForeachFacts binds vt ty ss
      -> let (sU, sS) = deadLoop us ss
-        in  (sU, ForeachFacts ns vt ty sS)
+        in  (sU, ForeachFacts binds vt ty sS)
 
     Block []
      -> (us, statements)

--- a/src/Icicle/Avalanche/Statement/Simp/Melt.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Melt.hs
@@ -141,9 +141,10 @@ meltForeachFacts a_fresh statements
 
   goStmt () stmt
    = case stmt of
-       ForeachFacts ns vt lt ss
-        -> do (ns', ss') <- meltFix ns ss
-              return ((), ForeachFacts ns' vt lt ss')
+       ForeachFacts binds vt lt ss
+        -> do (ns', ss') <- meltFix (factBindValue binds) ss
+              let binds' = binds { factBindValue = ns' }
+              return ((), ForeachFacts binds' vt lt ss')
        _
         -> return ((), stmt)
 

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -391,6 +391,8 @@ boxedType t
      ErrorT     -> "Error"
      BoolT      -> "Boolean"
      TimeT      -> "Integer"
+     FactIdentifierT
+                -> "Integer"
      ArrayT a   -> "ArrayList" <> angled (boxedType a)
      BufT _ a   -> "IcicleBuf" <> angled (boxedType a)
      MapT a b   -> "HashMap" <> angled (commas [boxedType a, boxedType b])

--- a/src/Icicle/Avalanche/ToJava.hs
+++ b/src/Icicle/Avalanche/ToJava.hs
@@ -81,7 +81,7 @@ statementsToJava ss
              S.FactLoopNew     -> "icicle.startNew();")
            <> line
            <> "while (icicle.nextRow())"
-           <> block (fmap readVar ns <> [statementsToJava s])
+           <> block (fmap readVar (S.factBindsAll ns) <> [statementsToJava s])
     Block blocks
      -> vcat (fmap (either bindingToJava statementsToJava) blocks)
 

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -13,6 +13,7 @@ module Icicle.Common.Base (
     , ExceptionInfo (..)
     , OutputName (..)
     , WindowUnit(..)
+    , FactIdentifier (..)
     ) where
 
 import              Icicle.Internal.Pretty
@@ -88,7 +89,13 @@ data BaseValue
  | VStruct   !(Map.Map StructField  BaseValue)
  | VBuf      ![BaseValue]
  | VError    !ExceptionInfo
+ | VFactIdentifier !FactIdentifier
  deriving (Show, Ord, Eq)
+
+newtype FactIdentifier
+ = FactIdentifier
+ { getFactIdentifierTimestamp :: Time }
+ deriving (Eq, Ord, Show)
 
 -- | Called "exceptions"
 -- because they aren't really errors,
@@ -164,8 +171,13 @@ instance Pretty BaseValue where
       -> text "Struct" <+> pretty (Map.toList mv)
      VError e
       -> pretty e
+     VFactIdentifier f
+      -> pretty f
      VBuf vs
       -> text "Buf" <+> pretty vs
+
+instance Pretty FactIdentifier where
+ pretty f = text "FactIdentifier" <+> (text $ T.unpack $ renderTime $ getFactIdentifierTimestamp f)
 
 instance Pretty StructField where
  pretty = text . T.unpack . nameOfStructField

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -92,9 +92,13 @@ data BaseValue
  | VFactIdentifier !FactIdentifier
  deriving (Show, Ord, Eq)
 
+-- | Fact identifiers are represented as indices into the input stream for
+-- Core and Avalanche evaluators, but for a real streaming model such as C
+-- we need to convert this as a unique (and consistent) identifier across runs.
+-- Perhaps a pair of timestamp and index
 newtype FactIdentifier
  = FactIdentifier
- { getFactIdentifierTimestamp :: Time }
+ { getFactIdentifierIndex :: Int }
  deriving (Eq, Ord, Show)
 
 -- | Called "exceptions"
@@ -177,7 +181,7 @@ instance Pretty BaseValue where
       -> text "Buf" <+> pretty vs
 
 instance Pretty FactIdentifier where
- pretty f = text "FactIdentifier" <+> (text $ T.unpack $ renderTime $ getFactIdentifierTimestamp f)
+ pretty f = text "FactIdentifier" <+> (pretty $ getFactIdentifierIndex f)
 
 instance Pretty StructField where
  pretty = text . T.unpack . nameOfStructField

--- a/src/Icicle/Common/Data.hs
+++ b/src/Icicle/Common/Data.hs
@@ -32,9 +32,8 @@ valueToCore dv vt
      (D.BooleanValue x, C.BoolT{})   -> Just (C.VBool x)
      (D.StringValue  x, C.StringT{}) -> Just (C.VString x)
      (D.TimeValue    x, C.TimeT{})   -> Just (C.VTime x)
-     -- fact identifiers only exist internally, but can be represented as times
-     (D.TimeValue    x, C.FactIdentifierT)
-                                     -> Just (C.VFactIdentifier $ C.FactIdentifier x)
+     -- fact identifiers only exist internally
+     (_, C.FactIdentifierT)          -> Nothing
 
      (D.Tombstone,      C.ErrorT{})  -> Just (C.VError C.ExceptTombstone)
 
@@ -78,9 +77,9 @@ valueFromCore = \case
   C.VInt    x -> Just (D.IntValue x)
   C.VDouble x -> Just (D.DoubleValue x)
   C.VTime   x -> Just (D.TimeValue x)
-  -- Fact identifiers only exist internally, but can be expressed as times
-  C.VFactIdentifier x
-              -> Just (D.TimeValue $ C.getFactIdentifierTimestamp x)
+  -- Fact identifiers only exist internally
+  C.VFactIdentifier _
+              -> Nothing
   C.VString x -> Just (D.StringValue x)
   C.VUnit     -> Just (D.IntValue 13013)
   C.VError  _ -> Just D.Tombstone

--- a/src/Icicle/Common/Data.hs
+++ b/src/Icicle/Common/Data.hs
@@ -32,6 +32,10 @@ valueToCore dv vt
      (D.BooleanValue x, C.BoolT{})   -> Just (C.VBool x)
      (D.StringValue  x, C.StringT{}) -> Just (C.VString x)
      (D.TimeValue    x, C.TimeT{})   -> Just (C.VTime x)
+     -- fact identifiers only exist internally, but can be represented as times
+     (D.TimeValue    x, C.FactIdentifierT)
+                                     -> Just (C.VFactIdentifier $ C.FactIdentifier x)
+
      (D.Tombstone,      C.ErrorT{})  -> Just (C.VError C.ExceptTombstone)
 
      (D.PairValue a b, C.PairT ta tb)
@@ -74,6 +78,9 @@ valueFromCore = \case
   C.VInt    x -> Just (D.IntValue x)
   C.VDouble x -> Just (D.DoubleValue x)
   C.VTime   x -> Just (D.TimeValue x)
+  -- Fact identifiers only exist internally, but can be expressed as times
+  C.VFactIdentifier x
+              -> Just (D.TimeValue $ getFactIdentifierTimestamp x)
   C.VString x -> Just (D.StringValue x)
   C.VUnit     -> Just (D.IntValue 13013)
   C.VError  _ -> Just D.Tombstone
@@ -92,3 +99,4 @@ valueFromCore = \case
   C.VStruct xs
    -> let go (C.StructField k, v) = (,) <$> pure (D.Attribute k) <*> valueFromCore v
       in D.StructValue . D.Struct <$> traverse go (Map.toList xs)
+

--- a/src/Icicle/Common/Data.hs
+++ b/src/Icicle/Common/Data.hs
@@ -80,7 +80,7 @@ valueFromCore = \case
   C.VTime   x -> Just (D.TimeValue x)
   -- Fact identifiers only exist internally, but can be expressed as times
   C.VFactIdentifier x
-              -> Just (D.TimeValue $ getFactIdentifierTimestamp x)
+              -> Just (D.TimeValue $ C.getFactIdentifierTimestamp x)
   C.VString x -> Just (D.StringValue x)
   C.VUnit     -> Just (D.IntValue 13013)
   C.VError  _ -> Just D.Tombstone

--- a/src/Icicle/Common/Type.hs
+++ b/src/Icicle/Common/Type.hs
@@ -58,6 +58,7 @@ data ValType
  | StringT
  | UnitT
  | ErrorT
+ | FactIdentifierT
  | ArrayT  !ValType
  | MapT    !ValType    !ValType
  | OptionT !ValType
@@ -93,6 +94,8 @@ defaultOfType typ
      StringT   -> VString T.empty
      UnitT     -> VUnit
      ErrorT    -> VError ExceptNotAnError
+     FactIdentifierT
+               -> VFactIdentifier (FactIdentifier $ timeOfDays 0)
      ArrayT  _ -> VArray []
      MapT  _ _ -> VMap Map.empty
      OptionT _ -> VNone
@@ -237,6 +240,11 @@ valueMatchesType v t
     (ErrorT, _)
      -> False
 
+    (FactIdentifierT, VFactIdentifier _)
+     -> True
+    (FactIdentifierT, _)
+     -> False
+
     (BoolT, VBool{})
      -> True
     (BoolT, _)
@@ -323,6 +331,8 @@ ppValType needParens vt =
     DoubleT    -> text "Double"
     UnitT      -> text "Unit"
     ErrorT     -> text "Error"
+    FactIdentifierT
+               -> text "FactIdentifier"
     BoolT      -> text "Bool"
     TimeT      -> text "Time"
     StringT    -> text "String"

--- a/src/Icicle/Common/Type.hs
+++ b/src/Icicle/Common/Type.hs
@@ -95,7 +95,7 @@ defaultOfType typ
      UnitT     -> VUnit
      ErrorT    -> VError ExceptNotAnError
      FactIdentifierT
-               -> VFactIdentifier (FactIdentifier $ timeOfDays 0)
+               -> VFactIdentifier (FactIdentifier 0)
      ArrayT  _ -> VArray []
      MapT  _ _ -> VMap Map.empty
      OptionT _ -> VNone

--- a/src/Icicle/Common/Value.hs
+++ b/src/Icicle/Common/Value.hs
@@ -4,6 +4,7 @@ module Icicle.Common.Value (
       Heap
     , Value     (..)
     , getBaseValue
+    , collectFactIdentifiersFromBufs
     ) where
 
 import              Icicle.Common.Base
@@ -13,6 +14,7 @@ import              Icicle.Internal.Pretty
 import              P
 
 import qualified    Data.Map as Map
+import qualified    Data.Set as Set
 
 -- | A heap is just a mapping from names to values.
 type Heap a n p
@@ -31,6 +33,38 @@ data Value a n p
 getBaseValue :: e -> Value a n p -> Either e BaseValue
 getBaseValue e VFun{}    = Left e
 getBaseValue _ (VBase v) = Right v
+
+collectFactIdentifiersFromBufs :: Value a n p -> Set.Set FactIdentifier
+collectFactIdentifiersFromBufs (VBase v) = collectFactIdentifiersFromBufs' v
+collectFactIdentifiersFromBufs (VFun{})  = Set.empty
+
+collectFactIdentifiersFromBufs' :: BaseValue -> Set.Set FactIdentifier
+collectFactIdentifiersFromBufs' v
+ = case v of
+    VInt _ -> no
+    VDouble _ -> no
+    VUnit -> no
+    VBool _ -> no
+    VTime _ -> no
+    VString _ -> no
+    VArray vs -> Set.unions $ fmap go vs
+    VPair a b -> go a `Set.union` go b
+    VLeft a -> go a
+    VRight a -> go a
+    VSome a -> go a
+    VNone -> no
+    VMap m -> Set.unions ( (fmap go $ Map.keys m) <> (fmap go $ Map.elems m) )
+    VStruct s -> Set.unions $ fmap go $ Map.elems s
+    VBuf vs -> Set.unions $ fmap goBuf vs
+    VError _ -> no
+    -- Do not collect this one because it is not inside a buf!
+    VFactIdentifier _ -> no
+ where
+  no = Set.empty
+  go = collectFactIdentifiersFromBufs'
+
+  goBuf (VPair (VFactIdentifier i) _) = Set.singleton i
+  goBuf under = go under
 
 
 instance (Pretty n, Pretty p) => Pretty (Value a n p) where

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -89,15 +89,15 @@ evalPrim p vs
       -> primError
 
      PrimLatest (PrimLatestPush i _)
-      | [VBase (VBuf as), VBase e] <- vs
+      | [VBase (VBuf as), VBase factid, VBase e] <- vs
       -> return . VBase . VBuf
-      $  circ i e as
+      $  circ i (VPair factid e) as
       | otherwise
       -> primError
 
      PrimLatest (PrimLatestRead _ _)
       | [VBase (VBuf as)] <- vs
-      -> return . VBase . VArray $ as
+      -> return . VBase . VArray $ fmap getSnd as
       | otherwise
       -> primError
 
@@ -127,6 +127,9 @@ evalPrim p vs
    = xs <> [x]
    | otherwise
    = List.drop 1 (xs <> [x])
+
+  getSnd (VPair _ b) = b
+  getSnd v           = v
 
   windowEdge now (Days   d) = minusDays   now d
   windowEdge now (Weeks  w) = minusDays   now $ 7 * w

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -114,7 +114,7 @@ evalPrim p vs
       -> primError
 
      PrimWindow newerThan olderThan
-      | [VBase (VTime now), VBase (VTime fact)] <- vs
+      | [VBase (VTime now), VBase (VTime fact), _] <- vs
       -> let newer = windowEdge now     newerThan 
              older = windowEdge now <$> olderThan
              range = fact >= newer && maybe True (fact <=) older

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -88,6 +88,18 @@ evalPrim p vs
       | otherwise
       -> primError
 
+     PrimMap (PrimMapLookup _ _)
+      | [VBase (VMap mm), VBase key] <- vs
+      -> case Map.lookup key mm of
+          Nothing
+           -> return $ VBase $ VNone
+          Just v
+           -> return $ VBase $ VSome v
+
+      | otherwise
+      -> primError
+
+
      PrimLatest (PrimLatestPush i _)
       | [VBase (VBuf as), VBase factid, VBase e] <- vs
       -> return . VBase . VBuf

--- a/src/Icicle/Core/Eval/Program.hs
+++ b/src/Icicle/Core/Eval/Program.hs
@@ -29,6 +29,7 @@ import              P
 
 import qualified    Data.Map as Map
 import              Data.Hashable (Hashable)
+import              Data.List (zipWith)
 
 
 -- | Things that can go wrong for program evaluation
@@ -84,11 +85,12 @@ eval d sv p
                  $ XV.evalExps XV.evalPrim  env0   (P.precomps     p)
 
         let mkstream f t = SV.StreamValue (fmap f sv) (defaultOfType t)
+        let idStream = SV.StreamValue (zipWith (\_ i -> VFactIdentifier $ FactIdentifier i) sv [0..]) (defaultOfType FactIdentifierT)
         let valueOfInput at = VPair (snd $ atFact at) (VTime $ atTime at)
 
         let inputHeap = Map.fromList 
                       [(P.factValName  p, mkstream valueOfInput (PairT (P.inputType p) TimeT))
-                      ,(P.factIdName   p, mkstream (VFactIdentifier . FactIdentifier . atTime) FactIdentifierT)
+                      ,(P.factIdName   p, idStream)
                       ,(P.factTimeName p, mkstream (VTime . atTime) TimeT)]
         (stms,bgs) <- evalStms pres inputHeap (P.streams      p)
 

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -105,7 +105,7 @@ typeOfPrim p
      -> FunT [funOfVal (BufT i t)] (ArrayT t)
 
     PrimWindow _ _
-     -> FunT [funOfVal TimeT, funOfVal TimeT] BoolT
+     -> FunT [funOfVal TimeT, funOfVal TimeT, funOfVal FactIdentifierT] BoolT
 
 
 -- Pretty -------------

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -55,6 +55,7 @@ data PrimArray
 data PrimMap
  = PrimMapInsertOrUpdate ValType ValType
  | PrimMapMapValues ValType ValType ValType
+ | PrimMapLookup ValType ValType
  deriving (Eq, Ord, Show)
 
 
@@ -94,6 +95,8 @@ typeOfPrim p
      -> FunT [FunT [funOfVal v] v, funOfVal v, funOfVal k, funOfVal (MapT k v)] (MapT k v)
     PrimMap (PrimMapMapValues k v v')
      -> FunT [FunT [funOfVal v] v', funOfVal (MapT k v)] (MapT k v')
+    PrimMap (PrimMapLookup k v)
+     -> FunT [funOfVal (MapT k v), funOfVal k] (OptionT v)
 
     -- Latest buffer primitives
     PrimLatest (PrimLatestPush i t)
@@ -132,6 +135,9 @@ instance Pretty Prim where
 
  pretty (PrimMap (PrimMapMapValues k v v'))
   = annotate (AnnType (k , v , v')) "Map_mapValues#"
+
+ pretty (PrimMap (PrimMapLookup k v))
+  = annotate (AnnType (k , v)) "Map_lookup#"
 
  pretty (PrimLatest (PrimLatestPush i t))
   = annotate (AnnType (BufT i t)) "Latest_push#"

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -97,7 +97,7 @@ typeOfPrim p
 
     -- Latest buffer primitives
     PrimLatest (PrimLatestPush i t)
-     -> FunT [funOfVal (BufT i t), funOfVal t] (BufT i t)
+     -> FunT [funOfVal (BufT i t), funOfVal FactIdentifierT, funOfVal t] (BufT i t)
     PrimLatest (PrimLatestRead i t)
      -> FunT [funOfVal (BufT i t)] (ArrayT t)
 

--- a/src/Icicle/Core/Program/Check.hs
+++ b/src/Icicle/Core/Program/Check.hs
@@ -27,8 +27,11 @@ checkProgram p
  = do   -- Check precomputations, starting with an empty environment
         let env0 = Map.singleton (snaptimeName p) (funOfVal $ TimeT)
         pres    <- checkExps ProgramErrorPre env0 (P.precomps     p)
-        pres'   <- insertOrDie ProgramErrorNameNotUnique pres (inputName    p) (funOfVal $ PairT (inputType p) TimeT)
-               >>= insertOrDie ProgramErrorNameNotUnique pres (factIdName   p) (funOfVal $ FactIdentifierT)
+
+        let ins k v env = insertOrDie ProgramErrorNameNotUnique env k v
+        pres'   <- ins (factValName  p) (funOfVal $ PairT (inputType p) TimeT) pres
+               >>= ins (factIdName   p) (funOfVal $ FactIdentifierT)
+               >>= ins (factTimeName p) (funOfVal $ TimeT)
 
         -- Check stream computations with precomputations in environment
         stms    <- checkStreams pres' (P.streams      p)

--- a/src/Icicle/Core/Program/Check.hs
+++ b/src/Icicle/Core/Program/Check.hs
@@ -28,6 +28,7 @@ checkProgram p
         let env0 = Map.singleton (snaptimeName p) (funOfVal $ TimeT)
         pres    <- checkExps ProgramErrorPre env0 (P.precomps     p)
         pres'   <- insertOrDie ProgramErrorNameNotUnique pres (inputName    p) (funOfVal $ PairT (inputType p) TimeT)
+               >>= insertOrDie ProgramErrorNameNotUnique pres (factIdName   p) (funOfVal $ FactIdentifierT)
 
         -- Check stream computations with precomputations in environment
         stms    <- checkStreams pres' (P.streams      p)

--- a/src/Icicle/Core/Program/Fusion.hs
+++ b/src/Icicle/Core/Program/Fusion.hs
@@ -44,6 +44,7 @@ fuseProgramsDistinctNames _ lp rp
  $ Program
  { inputName = inputName lp
  , inputType = inputType lp
+ , factIdName= factIdName lp
  , snaptimeName = snaptimeName lp
  , precomps  = precomps  lp <> substSnds (precomps  rp)
  , streams   = streams   lp <> substStms (streams   rp)
@@ -56,6 +57,7 @@ fuseProgramsDistinctNames _ lp rp
 
   inpsubst
    = [ (inputName    rp, inputName    lp)
+     , (factIdName   rp, factIdName   lp)
      , (snaptimeName rp, snaptimeName lp) ]
 
 

--- a/src/Icicle/Core/Program/Fusion.hs
+++ b/src/Icicle/Core/Program/Fusion.hs
@@ -42,9 +42,10 @@ fuseProgramsDistinctNames _ lp rp
  | otherwise
  = return
  $ Program
- { inputName = inputName lp
- , inputType = inputType lp
+ { inputType = inputType lp
+ , factValName = factValName lp
  , factIdName= factIdName lp
+ , factTimeName = factTimeName lp
  , snaptimeName = snaptimeName lp
  , precomps  = precomps  lp <> substSnds (precomps  rp)
  , streams   = streams   lp <> substStms (streams   rp)
@@ -56,8 +57,9 @@ fuseProgramsDistinctNames _ lp rp
   substStms = unsafeSubstStreams inpsubst
 
   inpsubst
-   = [ (inputName    rp, inputName    lp)
+   = [ (factValName  rp, factValName  lp)
      , (factIdName   rp, factIdName   lp)
+     , (factTimeName rp, factTimeName lp)
      , (snaptimeName rp, snaptimeName lp) ]
 
 

--- a/src/Icicle/Core/Program/Program.hs
+++ b/src/Icicle/Core/Program/Program.hs
@@ -22,6 +22,7 @@ data Program a n =
  -- | The type of the input/concrete feature
    inputType    :: ValType
  , inputName    :: Name n
+ , factIdName   :: Name n
  , snaptimeName :: Name n
 
  -- | All precomputations, made before starting to read from feature source
@@ -42,7 +43,8 @@ data Program a n =
 renameProgram :: (Name n -> Name n') -> Program a n -> Program a n'
 renameProgram f p
   = p
-  { inputName   = f $ inputName p
+  { inputName   = f $ inputName    p
+  , factIdName  = f $ factIdName   p
   , snaptimeName= f $ snaptimeName p
   , precomps    = binds  renameExp      (precomps   p)
   , streams     = fmap  (renameStream f)(streams    p)
@@ -61,7 +63,8 @@ renameProgram f p
 instance Pretty n => Pretty (Program a n) where
  pretty p
   =     text "Program ("
-  <> pretty (inputName p) <> " : Stream " <> pretty (inputType p) <> text ", "
+  <> pretty (inputName    p) <> " : Stream " <> pretty (inputType p) <> text ", "
+  <> pretty (factIdName   p) <> " : FactIdentifier), "
   <> pretty (snaptimeName p) <> " : SNAPSHOT_TIME)" <> line
 
   <>    text "Precomputations:"                        <> line

--- a/src/Icicle/Core/Program/Program.hs
+++ b/src/Icicle/Core/Program/Program.hs
@@ -21,8 +21,9 @@ data Program a n =
  Program {
  -- | The type of the input/concrete feature
    inputType    :: ValType
- , inputName    :: Name n
+ , factValName  :: Name n
  , factIdName   :: Name n
+ , factTimeName :: Name n
  , snaptimeName :: Name n
 
  -- | All precomputations, made before starting to read from feature source
@@ -43,8 +44,9 @@ data Program a n =
 renameProgram :: (Name n -> Name n') -> Program a n -> Program a n'
 renameProgram f p
   = p
-  { inputName   = f $ inputName    p
+  { factValName = f $ factValName    p
   , factIdName  = f $ factIdName   p
+  , factTimeName= f $ factTimeName p
   , snaptimeName= f $ snaptimeName p
   , precomps    = binds  renameExp      (precomps   p)
   , streams     = fmap  (renameStream f)(streams    p)
@@ -63,8 +65,9 @@ renameProgram f p
 instance Pretty n => Pretty (Program a n) where
  pretty p
   =     text "Program ("
-  <> pretty (inputName    p) <> " : Stream " <> pretty (inputType p) <> text ", "
-  <> pretty (factIdName   p) <> " : FactIdentifier), "
+  <> pretty (factValName  p) <> " : " <> pretty (inputType p) <> text ", "
+  <> pretty (factIdName   p) <> " : FactIdentifier, "
+  <> pretty (factTimeName p) <> " : Time, "
   <> pretty (snaptimeName p) <> " : SNAPSHOT_TIME)" <> line
 
   <>    text "Precomputations:"                        <> line

--- a/src/Icicle/Core/Stream/Check.hs
+++ b/src/Icicle/Core/Stream/Check.hs
@@ -13,31 +13,34 @@ import              Icicle.Core.Stream.Error
 import              P
 
 import              Data.Hashable (Hashable)
+import qualified    Data.Map as Map
+
 
 
 checkStream
         :: (Hashable n, Eq n)
         => Env n Type
+        -> Env n Type
         -> Stream a n
         -> Either (StreamError a n) (Env n Type)
-checkStream se s
+checkStream zenv kenv s
  = case s of
     SFold nm t z k
-     -> do  tz <- checkX se z
-            se'<- insertOrDie StreamErrorNameNotUnique se nm (funOfVal t)
-            tk <- checkX se' k
+     -> do  tz <- checkX zenv z
+            zenv' <- insertOrDie StreamErrorNameNotUnique zenv nm (funOfVal t)
+            tk <- checkX (Map.union zenv kenv)  k
             requireSame (StreamErrorTypeError z)
                         (funOfVal t) tz
             requireSame (StreamErrorTypeError k)
                         (funOfVal t) tk
-            return se'
+            return zenv'
 
     SFilter x ss
-     -> do  tx <- checkX se x
+     -> do  tx <- checkX (Map.union zenv kenv) x
             requireSame (StreamErrorTypeError x)
                         (funOfVal BoolT) tx
 
-            foldM       checkStream se  ss
+            foldM       (flip checkStream kenv) zenv ss
  where
   checkX env x
    = first StreamErrorExp $ typeExp coreFragmentWorkerFun env x

--- a/src/Icicle/Core/Stream/Check.hs
+++ b/src/Icicle/Core/Stream/Check.hs
@@ -28,7 +28,7 @@ checkStream zenv kenv s
     SFold nm t z k
      -> do  tz <- checkX zenv z
             zenv' <- insertOrDie StreamErrorNameNotUnique zenv nm (funOfVal t)
-            tk <- checkX (Map.union zenv kenv)  k
+            tk <- checkX (Map.union zenv' kenv)  k
             requireSame (StreamErrorTypeError z)
                         (funOfVal t) tz
             requireSame (StreamErrorTypeError k)

--- a/src/Icicle/Sea/FromAvalanche/Analysis.hs
+++ b/src/Icicle/Sea/FromAvalanche/Analysis.hs
@@ -62,9 +62,9 @@ factVarsOfStatement loopType stmt
      Output _ _ _          -> Nothing
      KeepFactInHistory     -> Nothing
 
-     ForeachFacts ns vt lt ss
+     ForeachFacts binds vt lt ss
       | lt == loopType
-      -> Just (vt, ns)
+      -> Just (vt, factBindValue binds)
 
       | otherwise
       -> factVarsOfStatement loopType ss
@@ -208,8 +208,8 @@ typesOfStatement stmt
      Write _ x             -> typesOfExp x
      KeepFactInHistory     -> Set.empty
 
-     ForeachFacts nts _ _ ss
-      -> Set.fromList (fmap snd nts) `Set.union`
+     ForeachFacts binds _ _ ss
+      -> Set.fromList (fmap snd $ factBindsAll binds) `Set.union`
          typesOfStatement ss
 
      InitAccumulator (Accumulator _ at x) ss

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -114,18 +114,23 @@ seaOfStatement stmt
               , "}"
               ]
 
-     ForeachFacts ns _ FactLoopNew stmt'
+     ForeachFacts (FactBinds ntime nfid ns) _ FactLoopNew stmt'
       -> let structAssign (n, t) = assign (defOfVar' 1 ("const" <+> seaOfValType t)
                                                        ("const" <+> pretty newPrefix <> seaOfName n))
                                           ("s->" <> pretty newPrefix <> seaOfName n) <> semi
              loopAssign   (n, t) = assign (defOfVar 0 t (seaOfName n))
                                           (pretty newPrefix <> seaOfName n <> "[i]") <> semi
+             factTime = case reverse ns of
+                         [] -> seaError "seaOfStatement: no facts" ()
+                         ((n,_):_) -> pretty newPrefix <> seaOfName n <> "[i]"
          in vsep $
             [ ""
             , assign (defOfVar' 0 ("const" <+> seaOfValType IntT) "new_count") "s->new_count;"
             ] <> fmap structAssign ns <>
             [ ""
             , "for (iint_t i = 0; i < new_count; i++) {"
+            , indent 4 $ assign (defOfVar 0 FactIdentifierT (seaOfName nfid))  "i"      <> semi
+            , indent 4 $ assign (defOfVar 0 TimeT           (seaOfName ntime)) factTime <> semi
             , indent 4 $ vsep (fmap loopAssign ns) <> line <> seaOfStatement stmt'
             , "}"
             , ""

--- a/src/Icicle/Sea/FromAvalanche/Type.hs
+++ b/src/Icicle/Sea/FromAvalanche/Type.hs
@@ -122,6 +122,8 @@ baseOfValType t
      DoubleT   -> "idouble"
      TimeT     -> "itime"
      ErrorT    -> "ierror"
+     FactIdentifierT
+                -> "itime"
 
      StringT   -> "istring"
      BufT n t' -> "ibuf_" <> int n <> "_" <> baseOfValType t'

--- a/src/Icicle/Sea/FromAvalanche/Type.hs
+++ b/src/Icicle/Sea/FromAvalanche/Type.hs
@@ -123,7 +123,7 @@ baseOfValType t
      TimeT     -> "itime"
      ErrorT    -> "ierror"
      FactIdentifierT
-                -> "itime"
+                -> "iint"
 
      StringT   -> "istring"
      BufT n t' -> "ibuf_" <> int n <> "_" <> baseOfValType t'

--- a/src/Icicle/Sea/Psv.hs
+++ b/src/Icicle/Sea/Psv.hs
@@ -226,6 +226,7 @@ needsCopy = \case
   DoubleT   -> False
   TimeT     -> False
   ErrorT    -> False
+  FactIdentifierT -> False
 
   -- these should have been melted
   PairT{}   -> False

--- a/src/Icicle/Sea/Psv/Output.hs
+++ b/src/Icicle/Sea/Psv/Output.hs
@@ -418,6 +418,8 @@ seaOfOutputBase quoteStrings err t val
       -> pure $ quotedOutput quoteStrings (outputValue "string" [val, "strlen(" <> val <> ")"])
      TimeT
       -> pure $ quotedOutput quoteStrings (outputValue "time" [val])
+     FactIdentifierT
+      -> pure $ outputValue "int" [val]
 
      _ -> Left err
 

--- a/src/Icicle/Source/Checker/Invariants.hs
+++ b/src/Icicle/Source/Checker/Invariants.hs
@@ -39,7 +39,10 @@ invariantQ ctx (Query (c:cs) xfinal)
      -> errBanGroup "Consider moving the window to the start of the query"
     Latest{}
      | allowLatest inv
-     -> goBanGroup
+     -- | XXX: ban latest inside latests.
+     -- This is because latest needs access to the current fact identifier, but this isn't captured in the latest buffer.
+     -- This is a bug in the code generator and should be fixed.
+     -> goBanAll
      | otherwise
      -> errBanLatest
     GroupBy _ x
@@ -85,7 +88,9 @@ invariantQ ctx (Query (c:cs) xfinal)
   errBanLatest
    = errorSuggestions
       (ErrorContextNotAllowedHere (annotOfContext c) c)
-      [ Suggest "Latest not allowed here" ]
+      [ Suggest "Latest is not allowed inside group-fold or another latest."
+      , Suggest "If you are using latest inside a latest, you should be able to rewrite your query to use a single latest."
+      , Suggest "Note that 'newest' is implemented using latest, but if you have `latest 5 ~> newest value` you might be able to just use `newest value`."]
 
   errBanGroup sug
    = errorSuggestions

--- a/src/Icicle/Source/ToCore/Base.hs
+++ b/src/Icicle/Source/ToCore/Base.hs
@@ -11,6 +11,8 @@ module Icicle.Source.ToCore.Base (
   , convertInputName
   , convertInputType
   , convertDateName
+  , convertFactIdName
+  , convertFactTimeName
   , convertWithInput
   , convertWithInputName
   , convertError
@@ -62,19 +64,23 @@ programOfBinds
     -> ValType
     -> Name n
     -> Name n
+    -> Name n
+    -> Name n
     -> CoreBinds a n
     -> a
     -> Name n
     -> C.Program a n
-programOfBinds outputName inpType inpName postDate binds a_ret ret
+programOfBinds outputName inpType factValName factIdName factTimeName postDate binds a_ret ret
  = C.Program
- { C.inputType  = inpType
- , C.inputName  = inpName
+ { C.inputType    = inpType
+ , C.factValName  = factValName
+ , C.factIdName   = factIdName
+ , C.factTimeName = factTimeName
  , C.snaptimeName = postDate
- , C.precomps   = precomps  binds
- , C.streams    = streams   binds
- , C.postcomps  = postcomps binds
- , C.returns    = [(outputName, X.XVar a_ret ret)]
+ , C.precomps     = precomps  binds
+ , C.streams      = streams   binds
+ , C.postcomps    = postcomps binds
+ , C.returns      = [(outputName, X.XVar a_ret ret)]
  }
 
 
@@ -162,11 +168,13 @@ type ConvertM a n r
 
 data ConvertState n
  = ConvertState
- { csInputName  :: Name n
- , csInputType  :: ValType
- , csDateName   :: Name n
- , csFeatures   :: FeatureContext () n
- , csFreshen    :: Map.Map (Name n) (Name n)
+ { csInputName    :: Name n
+ , csInputType    :: ValType
+ , csFactIdName   :: Name n
+ , csFactTimeName :: Name n
+ , csDateName     :: Name n
+ , csFeatures     :: FeatureContext () n
+ , csFreshen      :: Map.Map (Name n) (Name n)
  }
 
 convertInput :: ConvertM a n (Name n, ValType)
@@ -180,6 +188,15 @@ convertInputName
 convertInputType :: ConvertM a n ValType
 convertInputType
  = csInputType <$> get
+
+convertFactIdName :: ConvertM a n (Name n)
+convertFactIdName
+ = csFactIdName <$> get
+
+convertFactTimeName :: ConvertM a n (Name n)
+convertFactTimeName
+ = csFactTimeName <$> get
+
 
 convertDateName :: ConvertM a n (Name n)
 convertDateName

--- a/src/Icicle/Source/ToCore/Fold.hs
+++ b/src/Icicle/Source/ToCore/Fold.hs
@@ -229,7 +229,6 @@ convertFold q
                      CE.@~ (foldKons res CE.@~ prev') CE.@~ prev' CE.@~ e' )
             return (res { foldKons = k' })
 
-    -- If latest is being used in this position, it must be after a group.
     (Latest _ i : _)
      | case getTemporalityOrPure $ annResult $ annotOfQuery q' of
         TemporalityElement  -> True

--- a/src/Icicle/Source/ToCore/Fold.hs
+++ b/src/Icicle/Source/ToCore/Fold.hs
@@ -243,9 +243,12 @@ convertFold q
            let t'arr  = T.ArrayT t'e
            let t'buf  = T.BufT i t'e
 
+           factid    <- convertFactIdName
+
            let kons  = CE.xLam n'acc t'buf
                      ( CE.pushBuf i t'e
                          CE.@~ CE.xVar n'acc
+                         CE.@~ CE.xVar factid
                          CE.@~ res )
            let zero  = CE.emptyBuf i t'e
 

--- a/src/Icicle/Source/ToCore/Fold.hs
+++ b/src/Icicle/Source/ToCore/Fold.hs
@@ -274,9 +274,12 @@ convertFold q
            let t'x    = typeFold res
            let t'r    = typeExtract res
 
+           factid    <- convertFactIdName
+
            let kons  = CE.xLam n'acc t'buf
                      ( CE.pushBuf i t'e
                          CE.@~ CE.xVar n'acc
+                         CE.@~ CE.xVar factid
                          CE.@~ CE.xVar inp )
            let zero  = CE.emptyBuf i t'e
 

--- a/src/Icicle/Source/ToCore/ToCore.hs
+++ b/src/Icicle/Source/ToCore/ToCore.hs
@@ -385,7 +385,7 @@ convertQuery q
             let r = sfold n' pairt (pair (CE.emptyMap tkey T.UnitT) (foldZero res)) (beta kons)
 
             -- Perform a fold over that map
-            let p = post n'' $ xsnd $ CE.xVar n'
+            let p = post n'' $ beta (mapExtract res CE.@~ xsnd (CE.xVar n'))
 
             return (r <> p, n'')
 

--- a/src/Icicle/Source/ToCore/ToCore.hs
+++ b/src/Icicle/Source/ToCore/ToCore.hs
@@ -139,9 +139,10 @@ convertQuery q
      -> do  (bs, b) <- convertQuery q'
             now  <- convertDateName
             time <- convertFactTimeName
+            fact <- convertFactIdName
 
             let e'  = CE.makeApps () (CE.xPrim $ C.PrimWindow newerThan olderThan)
-                    [ CE.xVar now, CE.xVar time ]
+                    [ CE.xVar now, CE.xVar time, CE.xVar fact ]
             let bs' = filt e' (streams bs) <> bs { streams = [] }
             return (bs', b)
 

--- a/src/Icicle/Source/ToCore/ToCore.hs
+++ b/src/Icicle/Source/ToCore/ToCore.hs
@@ -406,12 +406,16 @@ convertQuery q
 
                 convertModifyFeaturesMap (Map.insert b (FeatureVariable (annResult $ annotOfExp def) xfst False) . Map.map (\fv -> fv { featureVariableExp = featureVariableExp fv . xsnd }))
 
-                let pair = (CE.xPrim $ C.PrimMinimal $ Min.PrimConst $ Min.PrimConstPair t' inpty)
-                         CE.@~ e' CE.@~ CE.xVar inpstream
+                let pairC l r
+                     = (CE.xPrim $ C.PrimMinimal $ Min.PrimConst $ Min.PrimConstPair t' inpty)
+                         CE.@~ l CE.@~ r
+                let pair = pairC e' (CE.xVar inpstream)
+                let defT ty = CE.xValue ty (T.defaultOfType ty)
+                let pairD= pairC (defT t') (defT inpty)
 
 
                 n'r     <- lift fresh
-                let bs   = sfold n'r inpty' pair pair
+                let bs   = sfold n'r inpty' pairD pair
                 (bs', n'') <- convertWithInput n'r inpty' $ convertQuery q'
 
                 return (bs <> bs', n'')

--- a/src/Icicle/Source/ToCore/ToCore.hs
+++ b/src/Icicle/Source/ToCore/ToCore.hs
@@ -378,8 +378,8 @@ convertQuery q
 
             let kons    = CE.xLet n'key e'
                         ( CE.xPrim (C.PrimFold (C.PrimFoldOption T.UnitT) pairt)
-                        CE.@~ CE.xLam n'ignore2 T.UnitT update_step
-                        CE.@~ CE.xVar n'
+                        CE.@~ CE.xLam n'ignore2 T.UnitT (CE.xVar n')
+                        CE.@~ update_step
                         CE.@~ check_if_exists )
 
             -- Perform the map fold

--- a/src/Icicle/Source/Type/Base.hs
+++ b/src/Icicle/Source/Type/Base.hs
@@ -63,6 +63,12 @@ typeOfValType vt
     CT.StringT      -> StringT
     CT.UnitT        -> UnitT
     CT.ErrorT       -> ErrorT
+
+    -- Fact identifiers are represented as timestamps.
+    -- However they should not really need to be displayed as Source types
+    CT.FactIdentifierT
+                    -> TimeT
+
     CT.ArrayT a     -> ArrayT (go a)
     CT.BufT  _ a    -> ArrayT (go a)
     CT.MapT  k v    -> GroupT (go k) (go v)

--- a/src/Icicle/Source/Type/Base.hs
+++ b/src/Icicle/Source/Type/Base.hs
@@ -64,10 +64,9 @@ typeOfValType vt
     CT.UnitT        -> UnitT
     CT.ErrorT       -> ErrorT
 
-    -- Fact identifiers are represented as timestamps.
-    -- However they should not really need to be displayed as Source types
+    -- Fact identifiers are represented as integers.
     CT.FactIdentifierT
-                    -> TimeT
+                    -> IntT
 
     CT.ArrayT a     -> ArrayT (go a)
     CT.BufT  _ a    -> ArrayT (go a)

--- a/test/Icicle/Test/Avalanche/EvalCommutes.hs
+++ b/test/Icicle/Test/Avalanche/EvalCommutes.hs
@@ -7,8 +7,6 @@ module Icicle.Test.Avalanche.EvalCommutes where
 import           Icicle.Test.Core.Arbitrary
 import           Icicle.Test.Arbitrary
 
-import           Icicle.BubbleGum
-import           Icicle.Common.Base
 import           Icicle.Core.Program.Check
 import qualified Icicle.Core.Eval.Exp       as XV
 import qualified Icicle.Core.Eval.Program   as PV
@@ -23,7 +21,6 @@ import           P
 import           System.IO
 
 import           Test.QuickCheck
-import           Data.List (sort)
 
 -- We need a way to differentiate stream variables from scalars
 namer = AC.namerText (flip Var 0)
@@ -58,6 +55,7 @@ prop_eval_commutes_value t =
 -- going to Avalanche doesn't affect history
 --
 -- TODO: this is disabled because the Core evaluator currently ignores bubblegum
+{-
 zprop_eval_commutes_history t =
  forAll (programForStreamType t)
  $ \p ->
@@ -72,11 +70,11 @@ zprop_eval_commutes_history t =
       _
        -> property False
 
-
 prefixBubbleGum (BubbleGumReduction n v)
  = BubbleGumReduction (modName (Var "acc" 0) n) v
 prefixBubbleGum bg
  = bg
+-}
 
 
 

--- a/test/Icicle/Test/Avalanche/Melt.hs
+++ b/test/Icicle/Test/Avalanche/Melt.hs
@@ -85,7 +85,7 @@ prop_melt_total t
        | notAllowed (getType x1) -> Just stm
        | notAllowed (getType x2) -> Just stm
        | otherwise               -> unmelted s
-      ForeachFacts xs _ _ ss
+      ForeachFacts (FactBinds _ _ xs) _ _ ss
        | or $ fmap (notAllowed . snd) xs  -> Just stm
        | otherwise                        -> unmelted ss
       Block ss                            -> foldr (<|>) Nothing $ fmap unmelted ss

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -334,7 +334,7 @@ programForStreamType streamType
 programForStreamType' :: ValType -> Gen (Program () Var)
 programForStreamType' streamType
  = do   Var fresh_name _ <- arbitrary
-        let freshN i = Name $ Var fresh_name i
+        let freshN i = nameOf $ NameBase $ Var fresh_name i
         let ninput = freshN 0
         let nid    = freshN 1
         let ntime  = freshN 2

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -177,7 +177,7 @@ instance (Arbitrary a, Arbitrary n, Hashable n) => Arbitrary (Stream a n) where
 
 instance (Arbitrary a, Arbitrary n, Hashable n) => Arbitrary (Program a n) where
  arbitrary =
-   Program <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
+   Program <$> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary <*> arbitrary
 
 
 -- | Make an effort to generate a well typed expression that has some given type.
@@ -334,8 +334,14 @@ programForStreamType streamType
 programForStreamType' :: ValType -> Gen (Program () Var)
 programForStreamType' streamType
  = do   ninput      <- arbitrary
-        ndate       <- freshInEnv (Map.singleton ninput streamType)
+        let gen_not_input = freshInEnv (Map.singleton ninput streamType)
+        nid         <- gen_not_input
+        ntime       <- gen_not_input
+        ndate       <- gen_not_input
+
         let avoid = Map.fromList [ ( ninput, FunT [] (PairT streamType TimeT))
+                                 , ( nid,    FunT [] FactIdentifierT)
+                                 , ( ntime,  FunT [] TimeT)
                                  , ( ndate,  FunT [] TimeT) ]
 
         -- Generate a few precomputation expressions
@@ -360,7 +366,9 @@ programForStreamType' streamType
 
         return Program
                { P.inputType    = streamType
-               , P.inputName    = ninput
+               , P.factValName  = ninput
+               , P.factIdName   = nid
+               , P.factTimeName = ntime
                , P.snaptimeName = ndate
                , P.precomps     = pres
                , P.streams      = strs

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -445,6 +445,8 @@ baseValueForType t
      -> VBool <$> arbitrary
     TimeT
      -> VTime <$> arbitrary
+    FactIdentifierT
+     -> VFactIdentifier . FactIdentifier <$> arbitrary
     ArrayT t'
      -> smaller (VArray <$> listOf (baseValueForType t'))
     BufT n t'

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -455,7 +455,7 @@ baseValueForType t
     TimeT
      -> VTime <$> arbitrary
     FactIdentifierT
-     -> VFactIdentifier . FactIdentifier <$> arbitrary
+     -> discard
     ArrayT t'
      -> smaller (VArray <$> listOf (baseValueForType t'))
     BufT n t'

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -333,11 +333,12 @@ programForStreamType streamType
 
 programForStreamType' :: ValType -> Gen (Program () Var)
 programForStreamType' streamType
- = do   ninput      <- arbitrary
-        let gen_not_input = freshInEnv (Map.singleton ninput streamType)
-        nid         <- gen_not_input
-        ntime       <- gen_not_input
-        ndate       <- gen_not_input
+ = do   Var fresh_name _ <- arbitrary
+        let freshN i = Name $ Var fresh_name i
+        let ninput = freshN 0
+        let nid    = freshN 1
+        let ntime  = freshN 2
+        let ndate  = freshN 3
 
         let avoid = Map.fromList [ ( ninput, FunT [] (PairT streamType TimeT))
                                  , ( nid,    FunT [] FactIdentifierT)

--- a/test/Icicle/Test/Core/Program/Fusion.hs
+++ b/test/Icicle/Test/Core/Program/Fusion.hs
@@ -121,4 +121,4 @@ return []
 tests :: IO Bool
 -- tests = $quickCheckAll
 -- try harder to generate well-typed programs, since many tests require more than one
-tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 1000, maxSize = 100, maxDiscardRatio = 1000000})
+tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 100, maxSize = 10, maxDiscardRatio = 1000000})

--- a/test/Icicle/Test/Core/Program/Fusion.hs
+++ b/test/Icicle/Test/Core/Program/Fusion.hs
@@ -80,7 +80,10 @@ prop_fuseeval2 t =
  case (eval p1, eval p2, fusePrograms () left p1 right p2) of
   (Right v1, Right v2, Right p')
       -- Evaluate the fused program
-   -> case eval p' of
+   ->counterexample ("Left:          " <> (show $ pretty p1))
+   $ counterexample ("Right:         " <> (show $ pretty p2))
+   $ counterexample ("Fused:         " <> (show $ pretty p'))
+   $  case eval p' of
        -- It should not be an error
        Left  _  -> property False
        -- It evaluated fine, so the values should match
@@ -118,4 +121,4 @@ return []
 tests :: IO Bool
 -- tests = $quickCheckAll
 -- try harder to generate well-typed programs, since many tests require more than one
-tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 100, maxSize = 10, maxDiscardRatio = 1000000})
+tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 1000, maxSize = 100, maxDiscardRatio = 1000000})

--- a/test/Icicle/Test/Sea/Arbitrary.hs
+++ b/test/Icicle/Test/Sea/Arbitrary.hs
@@ -152,6 +152,8 @@ isSupportedInput = \case
   IntT      -> True
   DoubleT   -> True
   TimeT     -> True
+  FactIdentifierT
+            -> True
   StringT   -> True
 
   UnitT     -> False
@@ -177,6 +179,8 @@ isSupportedInputElem = \case
   IntT      -> True
   DoubleT   -> True
   TimeT     -> True
+  FactIdentifierT
+            -> True
   StringT   -> True
 
   UnitT     -> False
@@ -197,6 +201,7 @@ isSupportedInputField = \case
   IntT            -> True
   DoubleT         -> True
   TimeT           -> True
+  FactIdentifierT -> True
   StringT         -> True
   OptionT BoolT   -> True
   OptionT IntT    -> True
@@ -245,6 +250,8 @@ isSupportedOutputBase = \case
   IntT      -> True
   DoubleT   -> True
   TimeT     -> True
+  FactIdentifierT
+            -> True
   StringT   -> True
 
   UnitT     -> False
@@ -261,6 +268,8 @@ isSupportedType = \case
   IntT      -> True
   DoubleT   -> True
   TimeT     -> True
+  FactIdentifierT
+            -> True
   StringT   -> True
   ErrorT    -> True
   MapT{}    -> True

--- a/test/cli/repl/t03-distinct/expected
+++ b/test/cli/repl/t03-distinct/expected
@@ -9,8 +9,8 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 > - Core evaluation:
 [homer, 5,marge, 1]
 
-> > -- Average of distincts. That is, find the *last* for each time, and average all lasts
+> > -- Average of distincts. That is, find the *first* for each time, and average all lasts
 > - Core evaluation:
-[homer, 300.0,marge, 20.0]
+[homer, 300.0,marge, 0.0]
 
 > 

--- a/test/cli/repl/t03-distinct/script
+++ b/test/cli/repl/t03-distinct/script
@@ -4,5 +4,5 @@ feature salary ~> distinct value ~> count value
 -- Distinct by time. Expect 5 and 1
 feature salary ~> distinct time ~> count value
 
--- Average of distincts. That is, find the *last* for each time, and average all lasts
+-- Average of distincts. That is, find the *first* for each time, and average all lasts
 feature salary ~> distinct time ~> mean value

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -6,81 +6,78 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 ok, avalanche is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Avalanche:
-conv$1 = TIME
+conv$3 = TIME
 {
-  init acc$conv$0@{((Sum Error Int), Time)} = (Left ExceptNotAnError, 1858-11-17)@{((Sum Error Int), Time)};
-  init acc$conv$24@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
-  init acc$c$conv$9@{(Sum Error Int)} = Left ExceptNotAnError@{(Sum Error Int)};
-  init acc$conv$8@{((Sum Error Int), ((Sum Error Int), Time))} = (Left ExceptNotAnError, (Left ExceptNotAnError, 1858-11-17))@{((Sum Error Int), ((Sum Error Int), Time))};
-  read@{((Sum Error Int), Time)} anf$6 = acc$conv$0;
-  let anf$0 = fst#@{(Sum Error Int), Time} anf$6;
-  write acc$conv$8 = pair#@{(Sum Error Int) ((Sum Error Int), Time)} anf$0
-                     anf$6;
-  write acc$c$conv$9 = Right 0@{(Sum Error Int)};
-  load_resumable@{((Sum Error Int), Time)} acc$conv$0;
-  load_resumable@{Buf 3 (Sum Error Int)} acc$conv$24;
-  load_resumable@{(Sum Error Int)} acc$c$conv$9;
-  load_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$8;
-  for_facts (conv$0@{((Sum Error Int), Time)}) in new {
-    write acc$conv$0 = conv$0;
-    let anf$1 = fst#@{(Sum Error Int), Time} conv$0;
-    let anf$2 = Sum_fold#@{(Error,Int)}@{(Sum Error Bool)} (
-                \reify$0$conv$2@{Error} left#@{Error Bool}
-                                reify$0$conv$2) (
-                \reify$1$conv$3@{Int} right#@{Error Bool} (gt#@{Int}
-                                        reify$1$conv$3 (10@{Int}))) anf$1;
+  let anf$5 = (Left ExceptNotAnError, 1858-11-17)@{((Sum Error Int), Time)};
+  init acc$conv$26@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
+  init acc$c$conv$11@{(Sum Error Int)} = Left ExceptNotAnError@{(Sum Error Int)};
+  init acc$conv$10@{((Sum Error Int), ((Sum Error Int), Time))} = (Left ExceptNotAnError, (Left ExceptNotAnError, 1858-11-17))@{((Sum Error Int), ((Sum Error Int), Time))};
+  write acc$c$conv$11 = Right 0@{(Sum Error Int)};
+  load_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
+  load_resumable@{(Sum Error Int)} acc$c$conv$11;
+  load_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0@{((Sum Error Int), Time)}) in new {
+    let anf$0 = fst#@{(Sum Error Int), Time} conv$0;
+    let anf$1 = Sum_fold#@{(Error,Int)}@{(Sum Error Bool)} (
+                \reify$0$conv$4@{Error} left#@{Error Bool}
+                                reify$0$conv$4) (
+                \reify$1$conv$5@{Int} right#@{Error Bool} (gt#@{Int}
+                                        reify$1$conv$5 (10@{Int}))) anf$0;
     if (Sum_fold#@{(Error,Bool)}@{Bool} (
-        \reify$2$conv$5@{Error} True@{Bool}) (
-        \reify$3$conv$6@{Bool} reify$3$conv$6)
-        anf$2) {
-      let anf$3 = anf$1;
-      write acc$conv$8 = pair#@{(Sum Error Int) ((Sum Error Int), Time)} anf$3
-                         conv$0;
-      read@{((Sum Error Int), ((Sum Error Int), Time))} conv$8 = acc$conv$8;
-      read@{(Sum Error Int)} c$conv$9 = acc$c$conv$9;
-      let anf$4 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$8;
-      write acc$c$conv$9 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-                           \reify$6$conv$10@{Error} left#@{Error Int}
-                                            reify$6$conv$10) (
-                           \reify$7$conv$11@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-                                            \reify$8$conv$15@{Error} left#@{Error Int}
-                                                             reify$8$conv$15) (
-                                            \reify$9$conv$16@{Int} right#@{Error Int}
-                                                             reify$9$conv$16)
-                                            (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-                                             \reify$4$conv$12@{Error} left#@{Error Int}
-                                                              reify$4$conv$12) (
-                                             \reify$5$conv$13@{Int} right#@{Error Int} (add#@{Int}
-                                                                      reify$5$conv$13
-                                                                      (1@{Int})))
-                                             c$conv$9)) anf$4;
+        \reify$2$conv$7@{Error} True@{Bool}) (
+        \reify$3$conv$8@{Bool} reify$3$conv$8)
+        anf$1) {
+      let anf$2 = anf$0;
+      write acc$conv$10 = pair#@{(Sum Error Int) ((Sum Error Int), Time)} anf$2
+                          conv$0;
+      read@{((Sum Error Int), ((Sum Error Int), Time))} conv$10 = acc$conv$10;
+      read@{(Sum Error Int)} c$conv$11 = acc$c$conv$11;
+      let anf$3 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$10;
+      write acc$c$conv$11 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
+                            (
+                            \reify$6$conv$12@{Error} left#@{Error Int}
+                                             reify$6$conv$12) (
+                            \reify$7$conv$13@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
+                                             \reify$8$conv$17@{Error} left#@{Error Int}
+                                                              reify$8$conv$17) (
+                                             \reify$9$conv$18@{Int} right#@{Error Int}
+                                                              reify$9$conv$18)
+                                             (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
+                                              \reify$4$conv$14@{Error} left#@{Error Int}
+                                                               reify$4$conv$14)
+                                              (
+                                              \reify$5$conv$15@{Int} right#@{Error Int} (add#@{Int}
+                                                                       reify$5$conv$15
+                                                                       (1@{Int})))
+                                              c$conv$11)) anf$3;
     }
-    read@{Buf 3 (Sum Error Int)} conv$24 = acc$conv$24;
-    let anf$5 = anf$1;
-    write acc$conv$24 = Latest_push#@{Buf 3 (Sum Error Int)}
-                        conv$24 anf$5;
+    read@{Buf 3 (Sum Error Int)} conv$26 = acc$conv$26;
+    let anf$4 = anf$0;
+    write acc$conv$26 = Latest_push#@{Buf 3 (Sum Error Int)}
+                        conv$26 conv$1 anf$4;
   }
-  save_resumable@{((Sum Error Int), Time)} acc$conv$0;
-  save_resumable@{Buf 3 (Sum Error Int)} acc$conv$24;
-  save_resumable@{(Sum Error Int)} acc$c$conv$9;
-  save_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$8;
-  read@{Buf 3 (Sum Error Int)} conv$24 = acc$conv$24;
-  read@{(Sum Error Int)} c$conv$9 = acc$c$conv$9;
-  let conv$29 = Sum_fold#@{(Error,Int)}@{(Sum Error (Int, Array (Sum Error Int)))} (
-                \reify$10$conv$19@{Error} 
-                let conv$20 = left#@{Error (Int, Array (Sum Error Int))}
-                              reify$10$conv$19
-                 in conv$20) (
-                \reify$11$conv$21@{Int} 
-                let conv$25 = Latest_read#@{Array (Sum Error Int)}
-                              conv$24
+  save_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
+  save_resumable@{(Sum Error Int)} acc$c$conv$11;
+  save_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
+  read@{Buf 3 (Sum Error Int)} conv$26 = acc$conv$26;
+  read@{(Sum Error Int)} c$conv$11 = acc$c$conv$11;
+  let conv$31 = Sum_fold#@{(Error,Int)}@{(Sum Error (Int, Array (Sum Error Int)))} (
+                \reify$10$conv$21@{Error} 
+                let conv$22 = left#@{Error (Int, Array (Sum Error Int))}
+                              reify$10$conv$21
+                 in conv$22) (
+                \reify$11$conv$23@{Int} 
+                let conv$27 = Latest_read#@{Array (Sum Error Int)}
+                              conv$26
                  in 
-                let conv$26 = pair#@{Int Array (Sum Error Int)}
-                              reify$11$conv$21 conv$25
+                let conv$28 = pair#@{Int Array (Sum Error Int)}
+                              reify$11$conv$23 conv$27
                  in 
-                let conv$27 = right#@{Error (Int, Array (Sum Error Int))} conv$26
-                 in conv$27) c$conv$9;
-  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$29@{(Sum Error (Int, Array (Sum Error Int)))});
+                let conv$29 = right#@{Error (Int, Array (Sum Error Int))} conv$28
+                 in conv$29) c$conv$11;
+  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$31@{(Sum Error (Int, Array (Sum Error Int)))});
 }
 
 - Core evaluation:
@@ -89,74 +86,77 @@ conv$1 = TIME
 
 > > -- Something involves the abstract buffer type
 > - Avalanche:
-conv$1 = TIME
+conv$3 = TIME
 {
   let anf$2 = (Left ExceptNotAnError, 1858-11-17)@{((Sum Error Int), Time)};
-  init acc$conv$2@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
-  load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$2;
-  for_facts (conv$0@{((Sum Error Int), Time)}) in new {
-    read@{Map Time (Buf 2 ((Sum Error Int), Time))} conv$2 = acc$conv$2;
+  init acc$conv$4@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
+  load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0@{((Sum Error Int), Time)}) in new {
+    read@{Map Time (Buf 2 ((Sum Error Int), Time))} conv$4 = acc$conv$4;
     let anf$0 = Latest_push#@{Buf 2 ((Sum Error Int), Time)}
-                (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$0;
+                (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0;
     let anf$1 = snd#@{(Sum Error Int), Time} conv$0;
-    write acc$conv$2 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))}
+    write acc$conv$4 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))}
                        (
-                       \conv$4@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$4
-                               conv$0) anf$0 anf$1 conv$2;
+                       \conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6
+                               conv$1 conv$0) anf$0 anf$1
+                       conv$4;
   }
-  save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$2;
-  read@{Map Time (Buf 2 ((Sum Error Int), Time))} conv$2 = acc$conv$2;
-  let conv$37 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} (
-                \conv$34@{(Sum Error (Map Time Int))} 
-                \conv$29@{Time} 
-                \conv$31@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} (
-                         \conv$36@{Error} left#@{Error Map Time Int} conv$36) (
-                         \conv$35@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} (
-                                  \conv$36@{Error} left#@{Error Map Time Int} conv$36) (
-                                  \conv$32@{Int} right#@{Error Map Time Int}
+  save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
+  read@{Map Time (Buf 2 ((Sum Error Int), Time))} conv$4 = acc$conv$4;
+  let conv$39 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} (
+                \conv$36@{(Sum Error (Map Time Int))} 
+                \conv$31@{Time} 
+                \conv$33@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} (
+                         \conv$38@{Error} left#@{Error Map Time Int} conv$38) (
+                         \conv$37@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} (
+                                  \conv$38@{Error} left#@{Error Map Time Int} conv$38) (
+                                  \conv$34@{Int} right#@{Error Map Time Int}
                                            (Map_insertOrUpdate#@{(Time,Int)} (
-                                            \conv$33@{Int} conv$33) conv$32
-                                            conv$29 conv$35)) (
-                                  let conv$8 = 
-                                               let conv$3 = Latest_read#@{Array ((Sum Error Int), Time)}
-                                                            conv$31
-                                                in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} (
-                                                   \conv$7@{((Sum Error Int), (Sum Error Int))} 
-                                                   \conv$6@{((Sum Error Int), Time)} 
-                                                   let conv$25 = snd#@{(Sum Error Int), (Sum Error Int)} conv$7
-                                                    in 
-                                                   let v$inline$0$conv$10 = fst#@{(Sum Error Int), Time}
-                                                                            conv$6
-                                                    in pair#@{(Sum Error Int) (Sum Error Int)} v$inline$0$conv$10
-                                                       (
-                                                       let s$conv$19 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
-                                                                       (
-                                                                       \reify$0$conv$12@{Error}
-                                                                       left#@{Error Int}
-                                                                       reify$0$conv$12)
-                                                                       (
-                                                                       \reify$1$conv$13@{Int}
-                                                                       Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
-                                                                       (
-                                                                       \reify$2$conv$14@{Error}
-                                                                       left#@{Error Int}
-                                                                       reify$2$conv$14)
-                                                                       (
-                                                                       \reify$3$conv$15@{Int}
-                                                                       right#@{Error Int}
-                                                                       (add#@{Int}
-                                                                        reify$1$conv$13
-                                                                        reify$3$conv$15))
-                                                                       conv$25)
-                                                                       v$inline$0$conv$10
-                                                        in s$conv$19))
-                                                   ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))})
-                                                   conv$3
+                                            \conv$35@{Int} conv$35) conv$34
+                                            conv$31 conv$37)) (
+                                  let conv$10 = 
+                                                let conv$5 = Latest_read#@{Array ((Sum Error Int), Time)}
+                                                             conv$33
+                                                 in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} (
+                                                    \conv$9@{((Sum Error Int), (Sum Error Int))} 
+                                                    \conv$8@{((Sum Error Int), Time)} 
+                                                    let conv$27 = snd#@{(Sum Error Int), (Sum Error Int)} conv$9
+                                                     in 
+                                                    let v$inline$0$conv$12 = fst#@{(Sum Error Int), Time}
+                                                                             conv$8
+                                                     in pair#@{(Sum Error Int) (Sum Error Int)} v$inline$0$conv$12
+                                                        (
+                                                        let s$conv$21 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
+                                                                        (
+                                                                        \reify$0$conv$14@{Error}
+                                                                        left#@{Error Int}
+                                                                        reify$0$conv$14)
+                                                                        (
+                                                                        \reify$1$conv$15@{Int}
+                                                                        Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
+                                                                        (
+                                                                        \reify$2$conv$16@{Error}
+                                                                        left#@{Error Int}
+                                                                        reify$2$conv$16)
+                                                                        (
+                                                                        \reify$3$conv$17@{Int}
+                                                                        right#@{Error Int}
+                                                                        (add#@{Int}
+                                                                         reify$1$conv$15
+                                                                         reify$3$conv$17))
+                                                                        conv$27)
+                                                                        v$inline$0$conv$12
+                                                         in s$conv$21))
+                                                    ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))})
+                                                    conv$5
                                    in 
-                                  let conv$28 = snd#@{(Sum Error Int), (Sum Error Int)} conv$8
-                                   in conv$28)) conv$34)
-                (Right Map []@{(Sum Error (Map Time Int))}) conv$2;
-  output@{(Sum Error (Map Time Int))} repl (conv$37@{(Sum Error (Map Time Int))});
+                                  let conv$30 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
+                                   in conv$30)) conv$36)
+                (Right Map []@{(Sum Error (Map Time Int))}) conv$4;
+  output@{(Sum Error (Map Time Int))} repl (conv$39@{(Sum Error (Map Time Int))});
 }
 
 - Core evaluation:

--- a/test/cli/repl/t10.2-core/expected
+++ b/test/cli/repl/t10.2-core/expected
@@ -7,7 +7,7 @@ ok, core-type is now on
 ok, core-simp is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Core:
-Program (conv$0 : Stream (Sum Error Int), conv$1 : SNAPSHOT_TIME)
+Program (conv$0 : (Sum Error Int), conv$1 : FactIdentifier, conv$2 : Time, conv$3 : SNAPSHOT_TIME)
 Precomputations:
 
 
@@ -16,61 +16,59 @@ sfilter
 let simp$2 = fst#@{(Sum Error Int), Time} conv$0
  in 
 let simp$3 = Sum_fold#@{(Error,Int)}@{(Sum Error Bool)} (
-             \reify$0$conv$2@{Error} left#@{Error Bool}
-                             reify$0$conv$2) (
-             \reify$1$conv$3@{Int} right#@{Error Bool} (gt#@{Int}
-                                     reify$1$conv$3 (10@{Int}))) simp$2
+             \reify$0$conv$4@{Error} left#@{Error Bool}
+                             reify$0$conv$4) (
+             \reify$1$conv$5@{Int} right#@{Error Bool} (gt#@{Int}
+                                     reify$1$conv$5 (10@{Int}))) simp$2
  in Sum_fold#@{(Error,Bool)}@{Bool} (
-    \reify$2$conv$5@{Error} True@{Bool}) (
-    \reify$3$conv$6@{Bool} reify$3$conv$6)
+    \reify$2$conv$7@{Error} True@{Bool}) (
+    \reify$3$conv$8@{Bool} reify$3$conv$8)
     simp$3
-  conv$8               = sfold [((Sum Error Int), ((Sum Error Int), Time))] (
+  conv$10              = sfold [((Sum Error Int), ((Sum Error Int), Time))] ((Left ExceptNotAnError, (Left ExceptNotAnError, 1858-11-17))@{((Sum Error Int), ((Sum Error Int), Time))}) then (
   let simp$5 = fst#@{(Sum Error Int), Time} conv$0
-   in pair#@{(Sum Error Int) ((Sum Error Int), Time)} simp$5 conv$0) then (
-  let simp$7 = fst#@{(Sum Error Int), Time} conv$0
-   in pair#@{(Sum Error Int) ((Sum Error Int), Time)} simp$7 conv$0)
-  c$conv$9             = sfold [(Sum Error Int)] (Right 0@{(Sum Error Int)}) then (
-  let simp$9 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$8
+   in pair#@{(Sum Error Int) ((Sum Error Int), Time)} simp$5 conv$0)
+  c$conv$11            = sfold [(Sum Error Int)] (Right 0@{(Sum Error Int)}) then (
+  let simp$7 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$10
    in Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-      \reify$6$conv$10@{Error} left#@{Error Int}
-                       reify$6$conv$10) (
-      \reify$7$conv$11@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-                       \reify$8$conv$15@{Error} left#@{Error Int}
-                                        reify$8$conv$15) (
-                       \reify$9$conv$16@{Int} right#@{Error Int}
-                                        reify$9$conv$16) (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
-                                                          \reify$4$conv$12@{Error} left#@{Error Int}
-                                                                           reify$4$conv$12)
+      \reify$6$conv$12@{Error} left#@{Error Int}
+                       reify$6$conv$12) (
+      \reify$7$conv$13@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
+                       \reify$8$conv$17@{Error} left#@{Error Int}
+                                        reify$8$conv$17) (
+                       \reify$9$conv$18@{Int} right#@{Error Int}
+                                        reify$9$conv$18) (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} (
+                                                          \reify$4$conv$14@{Error} left#@{Error Int}
+                                                                           reify$4$conv$14)
                                                           (
-                                                          \reify$5$conv$13@{Int}
+                                                          \reify$5$conv$15@{Int}
                                                           right#@{Error Int} (add#@{Int}
-                                                                  reify$5$conv$13
+                                                                  reify$5$conv$15
                                                                   (1@{Int})))
-                                                          c$conv$9)) simp$9)
-conv$24              = sfold [Buf 3 (Sum Error Int)] (Buf []@{Buf 3 (Sum Error Int)}) then (
-let simp$11 = fst#@{(Sum Error Int), Time} conv$0
- in Latest_push#@{Buf 3 (Sum Error Int)} conv$24
-    simp$11)
+                                                          c$conv$11)) simp$7)
+conv$26              = sfold [Buf 3 (Sum Error Int)] (Buf []@{Buf 3 (Sum Error Int)}) then (
+let simp$9 = fst#@{(Sum Error Int), Time} conv$0
+ in Latest_push#@{Buf 3 (Sum Error Int)} conv$26 conv$1
+    simp$9)
 
 Postcomputations
-  conv$29              = Sum_fold#@{(Error,Int)}@{(Sum Error (Int, Array (Sum Error Int)))}
+  conv$31              = Sum_fold#@{(Error,Int)}@{(Sum Error (Int, Array (Sum Error Int)))}
                          (
-                         \reify$10$conv$19@{Error} 
-                         let conv$20 = left#@{Error (Int, Array (Sum Error Int))}
-                                       reify$10$conv$19
-                          in conv$20) (
-                         \reify$11$conv$21@{Int} 
-                         let conv$25 = Latest_read#@{Array (Sum Error Int)}
-                                       conv$24
+                         \reify$10$conv$21@{Error} 
+                         let conv$22 = left#@{Error (Int, Array (Sum Error Int))}
+                                       reify$10$conv$21
+                          in conv$22) (
+                         \reify$11$conv$23@{Int} 
+                         let conv$27 = Latest_read#@{Array (Sum Error Int)}
+                                       conv$26
                           in 
-                         let conv$26 = pair#@{Int Array (Sum Error Int)}
-                                       reify$11$conv$21 conv$25
+                         let conv$28 = pair#@{Int Array (Sum Error Int)}
+                                       reify$11$conv$23 conv$27
                           in 
-                         let conv$27 = right#@{Error (Int, Array (Sum Error Int))} conv$26
-                          in conv$27) c$conv$9
+                         let conv$29 = right#@{Error (Int, Array (Sum Error Int))} conv$28
+                          in conv$29) c$conv$11
 
 Returning:
-  repl                 = conv$29
+  repl                 = conv$31
 
 
 - Core type:
@@ -83,77 +81,78 @@ Returning:
 
 > > -- Something involves the abstract buffer type
 > - Core:
-Program (conv$0 : Stream (Sum Error Int), conv$1 : SNAPSHOT_TIME)
+Program (conv$0 : (Sum Error Int), conv$1 : FactIdentifier, conv$2 : Time, conv$3 : SNAPSHOT_TIME)
 Precomputations:
 
 
 Streams:
-conv$2               = sfold [Map Time (Buf 2 ((Sum Error Int), Time))] (Map []@{Map Time (Buf 2 ((Sum Error Int), Time))}) then (
+conv$4               = sfold [Map Time (Buf 2 ((Sum Error Int), Time))] (Map []@{Map Time (Buf 2 ((Sum Error Int), Time))}) then (
 let simp$2 = Latest_push#@{Buf 2 ((Sum Error Int), Time)}
-             (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$0
+             (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0
  in 
 let simp$3 = snd#@{(Sum Error Int), Time} conv$0
  in Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} (
-    \conv$4@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$4
-            conv$0) simp$2 simp$3 conv$2)
+    \conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6
+            conv$1 conv$0) simp$2 simp$3
+    conv$4)
 
 Postcomputations
-  conv$37              = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))}
+  conv$39              = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))}
                          (
-                         \conv$34@{(Sum Error (Map Time Int))} 
-                         \conv$29@{Time} 
-                         \conv$31@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} (
-                                  \conv$36@{Error} left#@{Error Map Time Int} conv$36) (
-                                  \conv$35@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} (
-                                           \conv$36@{Error} left#@{Error Map Time Int} conv$36) (
-                                           \conv$32@{Int} right#@{Error Map Time Int}
+                         \conv$36@{(Sum Error (Map Time Int))} 
+                         \conv$31@{Time} 
+                         \conv$33@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} (
+                                  \conv$38@{Error} left#@{Error Map Time Int} conv$38) (
+                                  \conv$37@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} (
+                                           \conv$38@{Error} left#@{Error Map Time Int} conv$38) (
+                                           \conv$34@{Int} right#@{Error Map Time Int}
                                                     (Map_insertOrUpdate#@{(Time,Int)} (
-                                                     \conv$33@{Int} conv$33) conv$32
-                                                     conv$29 conv$35)) (
-                                           let conv$8 = 
-                                                        let conv$3 = Latest_read#@{Array ((Sum Error Int), Time)}
-                                                                     conv$31
-                                                         in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} (
-                                                            \conv$7@{((Sum Error Int), (Sum Error Int))} 
-                                                            \conv$6@{((Sum Error Int), Time)} 
-                                                            let conv$25 = snd#@{(Sum Error Int), (Sum Error Int)}
-                                                                          conv$7
-                                                             in 
-                                                            let v$inline$0$conv$10 = fst#@{(Sum Error Int), Time}
-                                                                                     conv$6
-                                                             in pair#@{(Sum Error Int) (Sum Error Int)}
-                                                                v$inline$0$conv$10
-                                                                (
-                                                                let s$conv$19 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
-                                                                                (
-                                                                                \reify$0$conv$12@{Error}
-                                                                                left#@{Error Int}
-                                                                                reify$0$conv$12)
-                                                                                (
-                                                                                \reify$1$conv$13@{Int}
-                                                                                Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
-                                                                                (
-                                                                                \reify$2$conv$14@{Error}
-                                                                                left#@{Error Int}
-                                                                                reify$2$conv$14)
-                                                                                (
-                                                                                \reify$3$conv$15@{Int}
-                                                                                right#@{Error Int}
-                                                                                (add#@{Int}
-                                                                                 reify$1$conv$13
-                                                                                 reify$3$conv$15))
-                                                                                conv$25)
-                                                                                v$inline$0$conv$10
-                                                                 in s$conv$19))
-                                                            ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))})
-                                                            conv$3
+                                                     \conv$35@{Int} conv$35) conv$34
+                                                     conv$31 conv$37)) (
+                                           let conv$10 = 
+                                                         let conv$5 = Latest_read#@{Array ((Sum Error Int), Time)}
+                                                                      conv$33
+                                                          in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} (
+                                                             \conv$9@{((Sum Error Int), (Sum Error Int))} 
+                                                             \conv$8@{((Sum Error Int), Time)} 
+                                                             let conv$27 = snd#@{(Sum Error Int), (Sum Error Int)}
+                                                                           conv$9
+                                                              in 
+                                                             let v$inline$0$conv$12 = fst#@{(Sum Error Int), Time}
+                                                                                      conv$8
+                                                              in pair#@{(Sum Error Int) (Sum Error Int)}
+                                                                 v$inline$0$conv$12
+                                                                 (
+                                                                 let s$conv$21 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
+                                                                                 (
+                                                                                 \reify$0$conv$14@{Error}
+                                                                                 left#@{Error Int}
+                                                                                 reify$0$conv$14)
+                                                                                 (
+                                                                                 \reify$1$conv$15@{Int}
+                                                                                 Sum_fold#@{(Error,Int)}@{(Sum Error Int)}
+                                                                                 (
+                                                                                 \reify$2$conv$16@{Error}
+                                                                                 left#@{Error Int}
+                                                                                 reify$2$conv$16)
+                                                                                 (
+                                                                                 \reify$3$conv$17@{Int}
+                                                                                 right#@{Error Int}
+                                                                                 (add#@{Int}
+                                                                                  reify$1$conv$15
+                                                                                  reify$3$conv$17))
+                                                                                 conv$27)
+                                                                                 v$inline$0$conv$12
+                                                                  in s$conv$21))
+                                                             ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))})
+                                                             conv$5
                                             in 
-                                           let conv$28 = snd#@{(Sum Error Int), (Sum Error Int)} conv$8
-                                            in conv$28)) conv$34)
-                         (Right Map []@{(Sum Error (Map Time Int))}) conv$2
+                                           let conv$30 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
+                                            in conv$30)) conv$36)
+                         (Right Map []@{(Sum Error (Map Time Int))}) conv$4
 
 Returning:
-  repl                 = conv$37
+  repl                 = conv$39
 
 
 - Core type:

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -6,41 +6,42 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 ok, flatten is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Flattened:
-conv$1 = TIME
+conv$3 = TIME
 {
-  init acc$conv$24$simp$7@{Buf 3 Error} = Buf []@{Buf 3 Error};
-  init acc$conv$24$simp$8@{Buf 3 Int} = Buf []@{Buf 3 Int};
-  init acc$c$conv$9$simp$9@{Error} = ExceptNotAnError@{Error};
-  init acc$c$conv$9$simp$10@{Int} = 0@{Int};
-  init acc$conv$8$simp$11@{Error} = ExceptNotAnError@{Error};
-  write acc$conv$8$simp$11 = ExceptNotAnError@{Error};
-  write acc$c$conv$9$simp$9 = ExceptNotAnError@{Error};
-  write acc$c$conv$9$simp$10 = 0@{Int};
-  load_resumable@{Buf 3 Error} acc$conv$24$simp$7;
-  load_resumable@{Buf 3 Int} acc$conv$24$simp$8;
-  load_resumable@{Error} acc$c$conv$9$simp$9;
-  load_resumable@{Int} acc$c$conv$9$simp$10;
-  load_resumable@{Error} acc$conv$8$simp$11;
-  for_facts (conv$0$simp$56@{Error},
-             conv$0$simp$57@{Int},
-             conv$0$simp$58@{Time}) in new {
-    init flat$0$simp$19@{Error} = ExceptNotAnError@{Error};
-    init flat$0$simp$20@{Bool} = False@{Bool};
-    if (eq#@{Error} conv$0$simp$56
+  init acc$conv$26$simp$4@{Buf 3 Error} = Buf []@{Buf 3 Error};
+  init acc$conv$26$simp$5@{Buf 3 Int} = Buf []@{Buf 3 Int};
+  init acc$c$conv$11$simp$6@{Error} = ExceptNotAnError@{Error};
+  init acc$c$conv$11$simp$7@{Int} = 0@{Int};
+  init acc$conv$10$simp$8@{Error} = ExceptNotAnError@{Error};
+  write acc$c$conv$11$simp$6 = ExceptNotAnError@{Error};
+  write acc$c$conv$11$simp$7 = 0@{Int};
+  load_resumable@{Buf 3 Error} acc$conv$26$simp$4;
+  load_resumable@{Buf 3 Int} acc$conv$26$simp$5;
+  load_resumable@{Error} acc$c$conv$11$simp$6;
+  load_resumable@{Int} acc$c$conv$11$simp$7;
+  load_resumable@{Error} acc$conv$10$simp$8;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0$simp$50@{Error},
+             conv$0$simp$51@{Int},
+             conv$0$simp$52@{Time}) in new {
+    init flat$0$simp$13@{Error} = ExceptNotAnError@{Error};
+    init flat$0$simp$14@{Bool} = False@{Bool};
+    if (eq#@{Error} conv$0$simp$50
         (ExceptNotAnError@{Error})) {
-      write flat$0$simp$19 = ExceptNotAnError@{Error};
-      write flat$0$simp$20 = gt#@{Int}
-                             conv$0$simp$57 (10@{Int});
+      write flat$0$simp$13 = ExceptNotAnError@{Error};
+      write flat$0$simp$14 = gt#@{Int}
+                             conv$0$simp$51 (10@{Int});
     } else {
-      write flat$0$simp$19 = conv$0$simp$56;
-      write flat$0$simp$20 = False@{Bool};
+      write flat$0$simp$13 = conv$0$simp$50;
+      write flat$0$simp$14 = False@{Bool};
     }
-    read@{Error} flat$0$simp$21 = flat$0$simp$19;
-    read@{Bool} flat$0$simp$22 = flat$0$simp$20;
+    read@{Error} flat$0$simp$15 = flat$0$simp$13;
+    read@{Bool} flat$0$simp$16 = flat$0$simp$14;
     init flat$1@{Bool} = False@{Bool};
-    if (eq#@{Error} flat$0$simp$21
+    if (eq#@{Error} flat$0$simp$15
         (ExceptNotAnError@{Error})) {
-      write flat$1 = flat$0$simp$22;
+      write flat$1 = flat$0$simp$16;
     } 
      else {
       write flat$1 = True@{Bool};
@@ -48,96 +49,96 @@ conv$1 = TIME
     
     read@{Bool} flat$1 = flat$1;
     if (flat$1) {
-      write acc$conv$8$simp$11 = conv$0$simp$56;
-      read@{Error} conv$8$simp$23 = acc$conv$8$simp$11;
-      read@{Error} c$conv$9$simp$28 = acc$c$conv$9$simp$9;
-      read@{Int} c$conv$9$simp$29 = acc$c$conv$9$simp$10;
-      init flat$2$simp$30@{Error} = ExceptNotAnError@{Error};
-      init flat$2$simp$31@{Int} = 0@{Int};
-      if (eq#@{Error} conv$8$simp$23
+      write acc$conv$10$simp$8 = conv$0$simp$50;
+      read@{Error} conv$10$simp$17 = acc$conv$10$simp$8;
+      read@{Error} c$conv$11$simp$22 = acc$c$conv$11$simp$6;
+      read@{Int} c$conv$11$simp$23 = acc$c$conv$11$simp$7;
+      init flat$2$simp$24@{Error} = ExceptNotAnError@{Error};
+      init flat$2$simp$25@{Int} = 0@{Int};
+      if (eq#@{Error} conv$10$simp$17
           (ExceptNotAnError@{Error})) {
-        init flat$5$simp$32@{Error} = ExceptNotAnError@{Error};
-        init flat$5$simp$33@{Int} = 0@{Int};
-        if (eq#@{Error} c$conv$9$simp$28
+        init flat$5$simp$26@{Error} = ExceptNotAnError@{Error};
+        init flat$5$simp$27@{Int} = 0@{Int};
+        if (eq#@{Error} c$conv$11$simp$22
             (ExceptNotAnError@{Error})) {
-          write flat$5$simp$32 = ExceptNotAnError@{Error};
-          write flat$5$simp$33 = add#@{Int}
-                                 c$conv$9$simp$29 (1@{Int});
+          write flat$5$simp$26 = ExceptNotAnError@{Error};
+          write flat$5$simp$27 = add#@{Int}
+                                 c$conv$11$simp$23 (1@{Int});
         } else {
-          write flat$5$simp$32 = c$conv$9$simp$28;
-          write flat$5$simp$33 = 0@{Int};
+          write flat$5$simp$26 = c$conv$11$simp$22;
+          write flat$5$simp$27 = 0@{Int};
         }
-        read@{Error} flat$5$simp$34 = flat$5$simp$32;
-        read@{Int} flat$5$simp$35 = flat$5$simp$33;
-        init flat$6$simp$36@{Error} = ExceptNotAnError@{Error};
-        init flat$6$simp$37@{Int} = 0@{Int};
-        if (eq#@{Error} flat$5$simp$34
+        read@{Error} flat$5$simp$28 = flat$5$simp$26;
+        read@{Int} flat$5$simp$29 = flat$5$simp$27;
+        init flat$6$simp$30@{Error} = ExceptNotAnError@{Error};
+        init flat$6$simp$31@{Int} = 0@{Int};
+        if (eq#@{Error} flat$5$simp$28
             (ExceptNotAnError@{Error})) {
-          write flat$6$simp$36 = ExceptNotAnError@{Error};
-          write flat$6$simp$37 = flat$5$simp$35;
+          write flat$6$simp$30 = ExceptNotAnError@{Error};
+          write flat$6$simp$31 = flat$5$simp$29;
         } else {
-          write flat$6$simp$36 = flat$5$simp$34;
-          write flat$6$simp$37 = 0@{Int};
+          write flat$6$simp$30 = flat$5$simp$28;
+          write flat$6$simp$31 = 0@{Int};
         }
-        read@{Error} flat$6$simp$38 = flat$6$simp$36;
-        read@{Int} flat$6$simp$39 = flat$6$simp$37;
-        write flat$2$simp$30 = flat$6$simp$38;
-        write flat$2$simp$31 = flat$6$simp$39;
+        read@{Error} flat$6$simp$32 = flat$6$simp$30;
+        read@{Int} flat$6$simp$33 = flat$6$simp$31;
+        write flat$2$simp$24 = flat$6$simp$32;
+        write flat$2$simp$25 = flat$6$simp$33;
       } else {
-        write flat$2$simp$30 = conv$8$simp$23;
-        write flat$2$simp$31 = 0@{Int};
+        write flat$2$simp$24 = conv$10$simp$17;
+        write flat$2$simp$25 = 0@{Int};
       }
-      read@{Error} flat$2$simp$40 = flat$2$simp$30;
-      read@{Int} flat$2$simp$41 = flat$2$simp$31;
-      write acc$c$conv$9$simp$9 = flat$2$simp$40;
-      write acc$c$conv$9$simp$10 = flat$2$simp$41;
+      read@{Error} flat$2$simp$34 = flat$2$simp$24;
+      read@{Int} flat$2$simp$35 = flat$2$simp$25;
+      write acc$c$conv$11$simp$6 = flat$2$simp$34;
+      write acc$c$conv$11$simp$7 = flat$2$simp$35;
     }
-    read@{Buf 3 Error} acc$conv$24$simp$7 = acc$conv$24$simp$7;
-    write acc$conv$24$simp$7 = Buf_push#@{Buf 3 Error}
-                               acc$conv$24$simp$7
-                               conv$0$simp$56;
-    read@{Buf 3 Int} acc$conv$24$simp$8 = acc$conv$24$simp$8;
-    write acc$conv$24$simp$8 = Buf_push#@{Buf 3 Int}
-                               acc$conv$24$simp$8
-                               conv$0$simp$57;
+    read@{Buf 3 Error} acc$conv$26$simp$4 = acc$conv$26$simp$4;
+    write acc$conv$26$simp$4 = Buf_push#@{Buf 3 Error}
+                               acc$conv$26$simp$4
+                               conv$0$simp$50;
+    read@{Buf 3 Int} acc$conv$26$simp$5 = acc$conv$26$simp$5;
+    write acc$conv$26$simp$5 = Buf_push#@{Buf 3 Int}
+                               acc$conv$26$simp$5
+                               conv$0$simp$51;
   }
-  save_resumable@{Buf 3 Error} acc$conv$24$simp$7;
-  save_resumable@{Buf 3 Int} acc$conv$24$simp$8;
-  save_resumable@{Error} acc$c$conv$9$simp$9;
-  save_resumable@{Int} acc$c$conv$9$simp$10;
-  save_resumable@{Error} acc$conv$8$simp$11;
-  read@{Buf 3 Error} conv$24$simp$44 = acc$conv$24$simp$7;
-  read@{Buf 3 Int} conv$24$simp$45 = acc$conv$24$simp$8;
-  read@{Error} c$conv$9$simp$46 = acc$c$conv$9$simp$9;
-  read@{Int} c$conv$9$simp$47 = acc$c$conv$9$simp$10;
-  init flat$16$simp$48@{Error} = ExceptNotAnError@{Error};
-  init flat$16$simp$49@{Int} = 0@{Int};
-  init flat$16$simp$50@{Array Error} = []@{Array Error};
-  init flat$16$simp$51@{Array Int} = []@{Array Int};
-  if (eq#@{Error} c$conv$9$simp$46
+  save_resumable@{Buf 3 Error} acc$conv$26$simp$4;
+  save_resumable@{Buf 3 Int} acc$conv$26$simp$5;
+  save_resumable@{Error} acc$c$conv$11$simp$6;
+  save_resumable@{Int} acc$c$conv$11$simp$7;
+  save_resumable@{Error} acc$conv$10$simp$8;
+  read@{Buf 3 Error} conv$26$simp$38 = acc$conv$26$simp$4;
+  read@{Buf 3 Int} conv$26$simp$39 = acc$conv$26$simp$5;
+  read@{Error} c$conv$11$simp$40 = acc$c$conv$11$simp$6;
+  read@{Int} c$conv$11$simp$41 = acc$c$conv$11$simp$7;
+  init flat$16$simp$42@{Error} = ExceptNotAnError@{Error};
+  init flat$16$simp$43@{Int} = 0@{Int};
+  init flat$16$simp$44@{Array Error} = []@{Array Error};
+  init flat$16$simp$45@{Array Int} = []@{Array Int};
+  if (eq#@{Error} c$conv$11$simp$40
       (ExceptNotAnError@{Error})) {
-    write flat$16$simp$48 = ExceptNotAnError@{Error};
-    write flat$16$simp$49 = c$conv$9$simp$47;
-    write flat$16$simp$50 = Buf_read#@{Array Error}
-                            conv$24$simp$44;
-    write flat$16$simp$51 = Buf_read#@{Array Int}
-                            conv$24$simp$45;
+    write flat$16$simp$42 = ExceptNotAnError@{Error};
+    write flat$16$simp$43 = c$conv$11$simp$41;
+    write flat$16$simp$44 = Buf_read#@{Array Error}
+                            conv$26$simp$38;
+    write flat$16$simp$45 = Buf_read#@{Array Int}
+                            conv$26$simp$39;
   } else {
-    write flat$16$simp$48 = c$conv$9$simp$46;
-    write flat$16$simp$49 = 0@{Int};
-    write flat$16$simp$50 = unsafe_Array_create#@{Error}
+    write flat$16$simp$42 = c$conv$11$simp$40;
+    write flat$16$simp$43 = 0@{Int};
+    write flat$16$simp$44 = unsafe_Array_create#@{Error}
                             (0@{Int});
-    write flat$16$simp$51 = unsafe_Array_create#@{Int}
+    write flat$16$simp$45 = unsafe_Array_create#@{Int}
                             (0@{Int});
   }
-  read@{Error} flat$16$simp$52 = flat$16$simp$48;
-  read@{Int} flat$16$simp$53 = flat$16$simp$49;
-  read@{Array Error} flat$16$simp$54 = flat$16$simp$50;
-  read@{Array Int} flat$16$simp$55 = flat$16$simp$51;
-  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$16$simp$52@{Error},
-               flat$16$simp$53@{Int},
-               flat$16$simp$54@{Array Error},
-               flat$16$simp$55@{Array Int});
+  read@{Error} flat$16$simp$46 = flat$16$simp$42;
+  read@{Int} flat$16$simp$47 = flat$16$simp$43;
+  read@{Array Error} flat$16$simp$48 = flat$16$simp$44;
+  read@{Array Int} flat$16$simp$49 = flat$16$simp$45;
+  output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$16$simp$46@{Error},
+               flat$16$simp$47@{Int},
+               flat$16$simp$48@{Array Error},
+               flat$16$simp$49@{Array Int});
 }
 
 - Core evaluation:
@@ -146,20 +147,22 @@ conv$1 = TIME
 
 > > -- Something involves the abstract buffer type
 > - Flattened:
-conv$1 = TIME
+conv$3 = TIME
 {
-  init acc$conv$2$simp$14@{Array Time} = []@{Array Time};
-  init acc$conv$2$simp$15@{Array (Buf 2 Error)} = []@{Array (Buf 2 Error)};
-  init acc$conv$2$simp$16@{Array (Buf 2 Int)} = []@{Array (Buf 2 Int)};
-  load_resumable@{Array Time} acc$conv$2$simp$14;
-  load_resumable@{Array (Buf 2 Error)} acc$conv$2$simp$15;
-  load_resumable@{Array (Buf 2 Int)} acc$conv$2$simp$16;
-  for_facts (conv$0$simp$79@{Error},
+  init acc$conv$4$simp$14@{Array Time} = []@{Array Time};
+  init acc$conv$4$simp$15@{Array (Buf 2 Error)} = []@{Array (Buf 2 Error)};
+  init acc$conv$4$simp$16@{Array (Buf 2 Int)} = []@{Array (Buf 2 Int)};
+  load_resumable@{Array Time} acc$conv$4$simp$14;
+  load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$15;
+  load_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$16;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0$simp$79@{Error},
              conv$0$simp$80@{Int},
              conv$0$simp$81@{Time}) in new {
-    read@{Array Time} conv$2$simp$18 = acc$conv$2$simp$14;
-    read@{Array (Buf 2 Error)} conv$2$simp$19 = acc$conv$2$simp$15;
-    read@{Array (Buf 2 Int)} conv$2$simp$20 = acc$conv$2$simp$16;
+    read@{Array Time} conv$4$simp$18 = acc$conv$4$simp$14;
+    read@{Array (Buf 2 Error)} conv$4$simp$19 = acc$conv$4$simp$15;
+    read@{Array (Buf 2 Int)} conv$4$simp$20 = acc$conv$4$simp$16;
     let simp$407 = Buf_make#@{Buf 2 Error} (()@{Unit});
     let simp$219 = Buf_push#@{Buf 2 Error}
                    simp$407 conv$0$simp$79;
@@ -167,9 +170,9 @@ conv$1 = TIME
     let simp$221 = Buf_push#@{Buf 2 Int}
                    simp$409 conv$0$simp$80;
     init flat$1@{Bool} = False@{Bool};
-    init flat$2@{Array Time} = conv$2$simp$18;
-    init flat$3$simp$22@{Array (Buf 2 Error)} = conv$2$simp$19;
-    init flat$3$simp$23@{Array (Buf 2 Int)} = conv$2$simp$20;
+    init flat$2@{Array Time} = conv$4$simp$18;
+    init flat$3$simp$22@{Array (Buf 2 Error)} = conv$4$simp$19;
+    init flat$3$simp$23@{Array (Buf 2 Int)} = conv$4$simp$20;
     read@{Array Time} flat$2 = flat$2;
     let flat$4 = Array_length#@{Time}
                  flat$2;
@@ -219,30 +222,30 @@ conv$1 = TIME
     read@{Array Time} flat$2 = flat$2;
     read@{Array (Buf 2 Error)} flat$3$simp$31 = flat$3$simp$22;
     read@{Array (Buf 2 Int)} flat$3$simp$32 = flat$3$simp$23;
-    write acc$conv$2$simp$14 = flat$2;
-    write acc$conv$2$simp$15 = flat$3$simp$31;
-    write acc$conv$2$simp$16 = flat$3$simp$32;
+    write acc$conv$4$simp$14 = flat$2;
+    write acc$conv$4$simp$15 = flat$3$simp$31;
+    write acc$conv$4$simp$16 = flat$3$simp$32;
   }
-  save_resumable@{Array Time} acc$conv$2$simp$14;
-  save_resumable@{Array (Buf 2 Error)} acc$conv$2$simp$15;
-  save_resumable@{Array (Buf 2 Int)} acc$conv$2$simp$16;
-  read@{Array Time} conv$2$simp$34 = acc$conv$2$simp$14;
-  read@{Array (Buf 2 Error)} conv$2$simp$35 = acc$conv$2$simp$15;
-  read@{Array (Buf 2 Int)} conv$2$simp$36 = acc$conv$2$simp$16;
+  save_resumable@{Array Time} acc$conv$4$simp$14;
+  save_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$15;
+  save_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$16;
+  read@{Array Time} conv$4$simp$34 = acc$conv$4$simp$14;
+  read@{Array (Buf 2 Error)} conv$4$simp$35 = acc$conv$4$simp$15;
+  read@{Array (Buf 2 Int)} conv$4$simp$36 = acc$conv$4$simp$16;
   init flat$16$simp$38@{Error} = ExceptNotAnError@{Error};
   init flat$16$simp$39@{Array Time} = []@{Array Time};
   init flat$16$simp$40@{Array Int} = []@{Array Int};
   foreach (flat$17 in 0@{Int}..Array_length#@{Time}
-                         conv$2$simp$34) {
+                         conv$4$simp$34) {
     read@{Error} flat$16$simp$41 = flat$16$simp$38;
     read@{Array Time} flat$16$simp$42 = flat$16$simp$39;
     read@{Array Int} flat$16$simp$43 = flat$16$simp$40;
     let simp$307 = unsafe_Array_index#@{Time}
-                   conv$2$simp$34 flat$17;
+                   conv$4$simp$34 flat$17;
     let simp$309 = unsafe_Array_index#@{Buf 2 Error}
-                   conv$2$simp$35 flat$17;
+                   conv$4$simp$35 flat$17;
     let simp$311 = unsafe_Array_index#@{Buf 2 Int}
-                   conv$2$simp$36 flat$17;
+                   conv$4$simp$36 flat$17;
     init flat$19$simp$44@{Error} = ExceptNotAnError@{Error};
     init flat$19$simp$45@{Array Time} = []@{Array Time};
     init flat$19$simp$46@{Array Int} = []@{Array Int};

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -24,659 +24,595 @@ ok, c is now on
                                     \_____________)
 > > -- An interesting expression with structs and strings
 > - Flattened:
-conv$1 = TIME
+conv$3 = TIME
 {
-  init acc$a$conv$61$simp$78@{Error} = ExceptNotAnError@{Error};
-  init acc$a$conv$61$simp$79@{Double} = 0.0@{Double};
-  init acc$a$conv$61$simp$80@{Double} = 0.0@{Double};
-  init acc$a$conv$61$simp$81@{Double} = 0.0@{Double};
-  init acc$conv$60$simp$82@{Error} = ExceptNotAnError@{Error};
-  init acc$conv$60$simp$83@{Double} = 0.0@{Double};
-  init acc$conv$56$simp$92@{Error} = ExceptNotAnError@{Error};
-  init acc$conv$56$simp$93@{Int} = 0@{Int};
-  init acc$conv$55$simp$100@{Error} = ExceptNotAnError@{Error};
-  init acc$conv$55$simp$101@{Int} = 0@{Int};
-  init acc$s$reify$6$conv$10$simp$106@{Error} = ExceptNotAnError@{Error};
-  init acc$s$reify$6$conv$10$simp$107@{Double} = 0.0@{Double};
-  init acc$s$reify$6$conv$10$simp$108@{Double} = 0.0@{Double};
-  init acc$conv$9$simp$109@{Error} = ExceptNotAnError@{Error};
-  init acc$conv$9$simp$110@{Double} = 0.0@{Double};
-  init acc$conv$5$simp$117@{Error} = ExceptNotAnError@{Error};
-  init acc$conv$5$simp$118@{Double} = 0.0@{Double};
-  init flat$0$simp$127@{Error} = ExceptNotAnError@{Error};
-  init flat$0$simp$128@{Int} = 0@{Int};
-  write flat$0$simp$127 = ExceptNotAnError@{Error};
-  write flat$0$simp$128 = 0@{Int};
-  read@{Error} flat$0$simp$129 = flat$0$simp$127;
-  read@{Int} flat$0$simp$130 = flat$0$simp$128;
-  init flat$1$simp$131@{Error} = ExceptNotAnError@{Error};
-  init flat$1$simp$132@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$0$simp$129
-      (ExceptNotAnError@{Error})) {
-    write flat$1$simp$131 = ExceptNotAnError@{Error};
-    write flat$1$simp$132 = doubleOfInt#
-                            flat$0$simp$130;
-  } else {
-    write flat$1$simp$131 = flat$0$simp$129;
-    write flat$1$simp$132 = 0.0@{Double};
-  }
-  read@{Error} flat$1$simp$133 = flat$1$simp$131;
-  read@{Double} flat$1$simp$134 = flat$1$simp$132;
-  write acc$conv$5$simp$117 = flat$1$simp$133;
-  write acc$conv$5$simp$118 = flat$1$simp$134;
-  read@{Error} elem$conv$5$simp$135 = acc$conv$5$simp$117;
-  read@{Double} elem$conv$5$simp$136 = acc$conv$5$simp$118;
-  init flat$2$simp$141@{Error} = ExceptNotAnError@{Error};
-  init flat$2$simp$142@{Double} = 0.0@{Double};
-  if (eq#@{Error} elem$conv$5$simp$135
-      (ExceptNotAnError@{Error})) {
-    write flat$2$simp$141 = ExceptNotAnError@{Error};
-    write flat$2$simp$142 = elem$conv$5$simp$136;
-  } else {
-    write flat$2$simp$141 = elem$conv$5$simp$135;
-    write flat$2$simp$142 = 0.0@{Double};
-  }
-  read@{Error} flat$2$simp$143 = flat$2$simp$141;
-  read@{Double} flat$2$simp$144 = flat$2$simp$142;
-  write acc$conv$9$simp$109 = flat$2$simp$143;
-  write acc$conv$9$simp$110 = flat$2$simp$144;
-  write acc$s$reify$6$conv$10$simp$106 = ExceptFold1NoValue@{Error};
-  write acc$s$reify$6$conv$10$simp$107 = 0.0@{Double};
-  write acc$s$reify$6$conv$10$simp$108 = 0.0@{Double};
-  init flat$3$simp$145@{Error} = ExceptNotAnError@{Error};
-  init flat$3$simp$146@{Int} = 0@{Int};
-  write flat$3$simp$145 = ExceptNotAnError@{Error};
-  write flat$3$simp$146 = 0@{Int};
-  read@{Error} flat$3$simp$147 = flat$3$simp$145;
-  read@{Int} flat$3$simp$148 = flat$3$simp$146;
-  write acc$conv$55$simp$100 = flat$3$simp$147;
-  write acc$conv$55$simp$101 = flat$3$simp$148;
-  read@{Error} elem$conv$55$simp$149 = acc$conv$55$simp$100;
-  read@{Int} elem$conv$55$simp$150 = acc$conv$55$simp$101;
-  write acc$conv$56$simp$92 = elem$conv$55$simp$149;
-  write acc$conv$56$simp$93 = elem$conv$55$simp$150;
-  read@{Error} elem$conv$56$simp$155 = acc$conv$56$simp$92;
-  read@{Int} elem$conv$56$simp$156 = acc$conv$56$simp$93;
-  init flat$4$simp$163@{Error} = ExceptNotAnError@{Error};
-  init flat$4$simp$164@{Double} = 0.0@{Double};
-  if (eq#@{Error} elem$conv$56$simp$155
-      (ExceptNotAnError@{Error})) {
-    write flat$4$simp$163 = ExceptNotAnError@{Error};
-    write flat$4$simp$164 = doubleOfInt#
-                            elem$conv$56$simp$156;
-  } else {
-    write flat$4$simp$163 = elem$conv$56$simp$155;
-    write flat$4$simp$164 = 0.0@{Double};
-  }
-  read@{Error} flat$4$simp$165 = flat$4$simp$163;
-  read@{Double} flat$4$simp$166 = flat$4$simp$164;
-  write acc$conv$60$simp$82 = flat$4$simp$165;
-  write acc$conv$60$simp$83 = flat$4$simp$166;
-  write acc$a$conv$61$simp$78 = ExceptNotAnError@{Error};
-  write acc$a$conv$61$simp$79 = 0.0@{Double};
-  write acc$a$conv$61$simp$80 = 0.0@{Double};
-  write acc$a$conv$61$simp$81 = 0.0@{Double};
-  load_resumable@{Error} acc$a$conv$61$simp$78;
-  load_resumable@{Double} acc$a$conv$61$simp$79;
-  load_resumable@{Double} acc$a$conv$61$simp$80;
-  load_resumable@{Double} acc$a$conv$61$simp$81;
-  load_resumable@{Error} acc$conv$60$simp$82;
-  load_resumable@{Double} acc$conv$60$simp$83;
-  load_resumable@{Error} acc$conv$56$simp$92;
-  load_resumable@{Int} acc$conv$56$simp$93;
-  load_resumable@{Error} acc$conv$55$simp$100;
-  load_resumable@{Int} acc$conv$55$simp$101;
-  load_resumable@{Error} acc$s$reify$6$conv$10$simp$106;
-  load_resumable@{Double} acc$s$reify$6$conv$10$simp$107;
-  load_resumable@{Double} acc$s$reify$6$conv$10$simp$108;
-  load_resumable@{Error} acc$conv$9$simp$109;
-  load_resumable@{Double} acc$conv$9$simp$110;
-  load_resumable@{Error} acc$conv$5$simp$117;
-  load_resumable@{Double} acc$conv$5$simp$118;
-  for_facts (conv$0$simp$389@{Error},
-             conv$0$simp$390@{String},
-             conv$0$simp$391@{Int},
-             conv$0$simp$392@{Time}) in new {
-    init flat$5$simp$167@{Error} = ExceptNotAnError@{Error};
-    init flat$5$simp$168@{Int} = 0@{Int};
-    if (eq#@{Error} conv$0$simp$389
+  init acc$a$conv$63$simp$66@{Error} = ExceptNotAnError@{Error};
+  init acc$a$conv$63$simp$67@{Double} = 0.0@{Double};
+  init acc$a$conv$63$simp$68@{Double} = 0.0@{Double};
+  init acc$a$conv$63$simp$69@{Double} = 0.0@{Double};
+  init acc$conv$62$simp$70@{Error} = ExceptNotAnError@{Error};
+  init acc$conv$62$simp$71@{Double} = 0.0@{Double};
+  init acc$conv$58$simp$80@{Error} = ExceptNotAnError@{Error};
+  init acc$conv$58$simp$81@{Int} = 0@{Int};
+  init acc$conv$57$simp$88@{Error} = ExceptNotAnError@{Error};
+  init acc$conv$57$simp$89@{Int} = 0@{Int};
+  init acc$s$reify$6$conv$12$simp$94@{Error} = ExceptNotAnError@{Error};
+  init acc$s$reify$6$conv$12$simp$95@{Double} = 0.0@{Double};
+  init acc$s$reify$6$conv$12$simp$96@{Double} = 0.0@{Double};
+  init acc$conv$11$simp$97@{Error} = ExceptNotAnError@{Error};
+  init acc$conv$11$simp$98@{Double} = 0.0@{Double};
+  init acc$conv$7$simp$105@{Error} = ExceptNotAnError@{Error};
+  init acc$conv$7$simp$106@{Double} = 0.0@{Double};
+  write acc$s$reify$6$conv$12$simp$94 = ExceptFold1NoValue@{Error};
+  write acc$s$reify$6$conv$12$simp$95 = 0.0@{Double};
+  write acc$s$reify$6$conv$12$simp$96 = 0.0@{Double};
+  write acc$a$conv$63$simp$66 = ExceptNotAnError@{Error};
+  write acc$a$conv$63$simp$67 = 0.0@{Double};
+  write acc$a$conv$63$simp$68 = 0.0@{Double};
+  write acc$a$conv$63$simp$69 = 0.0@{Double};
+  load_resumable@{Error} acc$a$conv$63$simp$66;
+  load_resumable@{Double} acc$a$conv$63$simp$67;
+  load_resumable@{Double} acc$a$conv$63$simp$68;
+  load_resumable@{Double} acc$a$conv$63$simp$69;
+  load_resumable@{Error} acc$conv$62$simp$70;
+  load_resumable@{Double} acc$conv$62$simp$71;
+  load_resumable@{Error} acc$conv$58$simp$80;
+  load_resumable@{Int} acc$conv$58$simp$81;
+  load_resumable@{Error} acc$conv$57$simp$88;
+  load_resumable@{Int} acc$conv$57$simp$89;
+  load_resumable@{Error} acc$s$reify$6$conv$12$simp$94;
+  load_resumable@{Double} acc$s$reify$6$conv$12$simp$95;
+  load_resumable@{Double} acc$s$reify$6$conv$12$simp$96;
+  load_resumable@{Error} acc$conv$11$simp$97;
+  load_resumable@{Double} acc$conv$11$simp$98;
+  load_resumable@{Error} acc$conv$7$simp$105;
+  load_resumable@{Double} acc$conv$7$simp$106;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0$simp$333@{Error},
+             conv$0$simp$334@{String},
+             conv$0$simp$335@{Int},
+             conv$0$simp$336@{Time}) in new {
+    init flat$0$simp$111@{Error} = ExceptNotAnError@{Error};
+    init flat$0$simp$112@{Int} = 0@{Int};
+    if (eq#@{Error} conv$0$simp$333
         (ExceptNotAnError@{Error})) {
-      write flat$5$simp$167 = ExceptNotAnError@{Error};
-      write flat$5$simp$168 = conv$0$simp$391;
+      write flat$0$simp$111 = ExceptNotAnError@{Error};
+      write flat$0$simp$112 = conv$0$simp$335;
     } else {
-      write flat$5$simp$167 = conv$0$simp$389;
-      write flat$5$simp$168 = 0@{Int};
+      write flat$0$simp$111 = conv$0$simp$333;
+      write flat$0$simp$112 = 0@{Int};
     }
-    read@{Error} flat$5$simp$169 = flat$5$simp$167;
-    read@{Int} flat$5$simp$170 = flat$5$simp$168;
-    init flat$6$simp$171@{Error} = ExceptNotAnError@{Error};
-    init flat$6$simp$172@{Double} = 0.0@{Double};
-    if (eq#@{Error} flat$5$simp$169
+    read@{Error} flat$0$simp$113 = flat$0$simp$111;
+    read@{Int} flat$0$simp$114 = flat$0$simp$112;
+    init flat$1$simp$115@{Error} = ExceptNotAnError@{Error};
+    init flat$1$simp$116@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat$0$simp$113
         (ExceptNotAnError@{Error})) {
-      write flat$6$simp$171 = ExceptNotAnError@{Error};
-      write flat$6$simp$172 = doubleOfInt#
-                              flat$5$simp$170;
+      write flat$1$simp$115 = ExceptNotAnError@{Error};
+      write flat$1$simp$116 = doubleOfInt#
+                              flat$0$simp$114;
     } else {
-      write flat$6$simp$171 = flat$5$simp$169;
-      write flat$6$simp$172 = 0.0@{Double};
+      write flat$1$simp$115 = flat$0$simp$113;
+      write flat$1$simp$116 = 0.0@{Double};
     }
-    read@{Error} flat$6$simp$173 = flat$6$simp$171;
-    read@{Double} flat$6$simp$174 = flat$6$simp$172;
-    write acc$conv$5$simp$117 = flat$6$simp$173;
-    write acc$conv$5$simp$118 = flat$6$simp$174;
-    read@{Error} conv$5$simp$175 = acc$conv$5$simp$117;
-    read@{Double} conv$5$simp$176 = acc$conv$5$simp$118;
-    init flat$7$simp$181@{Error} = ExceptNotAnError@{Error};
-    init flat$7$simp$182@{Double} = 0.0@{Double};
-    if (eq#@{Error} conv$5$simp$175
+    read@{Error} flat$1$simp$117 = flat$1$simp$115;
+    read@{Double} flat$1$simp$118 = flat$1$simp$116;
+    write acc$conv$7$simp$105 = flat$1$simp$117;
+    write acc$conv$7$simp$106 = flat$1$simp$118;
+    read@{Error} conv$7$simp$119 = acc$conv$7$simp$105;
+    read@{Double} conv$7$simp$120 = acc$conv$7$simp$106;
+    init flat$2$simp$125@{Error} = ExceptNotAnError@{Error};
+    init flat$2$simp$126@{Double} = 0.0@{Double};
+    if (eq#@{Error} conv$7$simp$119
         (ExceptNotAnError@{Error})) {
-      write flat$7$simp$181 = ExceptNotAnError@{Error};
-      write flat$7$simp$182 = conv$5$simp$176;
+      write flat$2$simp$125 = ExceptNotAnError@{Error};
+      write flat$2$simp$126 = conv$7$simp$120;
     } else {
-      write flat$7$simp$181 = conv$5$simp$175;
-      write flat$7$simp$182 = 0.0@{Double};
+      write flat$2$simp$125 = conv$7$simp$119;
+      write flat$2$simp$126 = 0.0@{Double};
     }
-    read@{Error} flat$7$simp$183 = flat$7$simp$181;
-    read@{Double} flat$7$simp$184 = flat$7$simp$182;
-    write acc$conv$9$simp$109 = flat$7$simp$183;
-    write acc$conv$9$simp$110 = flat$7$simp$184;
-    read@{Error} conv$9$simp$185 = acc$conv$9$simp$109;
-    read@{Double} conv$9$simp$186 = acc$conv$9$simp$110;
-    read@{Error} s$reify$6$conv$10$simp$193 = acc$s$reify$6$conv$10$simp$106;
-    read@{Double} s$reify$6$conv$10$simp$194 = acc$s$reify$6$conv$10$simp$107;
-    read@{Double} s$reify$6$conv$10$simp$195 = acc$s$reify$6$conv$10$simp$108;
-    init flat$8$simp$196@{Error} = ExceptNotAnError@{Error};
-    init flat$8$simp$197@{Double} = 0.0@{Double};
-    init flat$8$simp$198@{Double} = 0.0@{Double};
+    read@{Error} flat$2$simp$127 = flat$2$simp$125;
+    read@{Double} flat$2$simp$128 = flat$2$simp$126;
+    write acc$conv$11$simp$97 = flat$2$simp$127;
+    write acc$conv$11$simp$98 = flat$2$simp$128;
+    read@{Error} conv$11$simp$129 = acc$conv$11$simp$97;
+    read@{Double} conv$11$simp$130 = acc$conv$11$simp$98;
+    read@{Error} s$reify$6$conv$12$simp$137 = acc$s$reify$6$conv$12$simp$94;
+    read@{Double} s$reify$6$conv$12$simp$138 = acc$s$reify$6$conv$12$simp$95;
+    read@{Double} s$reify$6$conv$12$simp$139 = acc$s$reify$6$conv$12$simp$96;
+    init flat$3$simp$140@{Error} = ExceptNotAnError@{Error};
+    init flat$3$simp$141@{Double} = 0.0@{Double};
+    init flat$3$simp$142@{Double} = 0.0@{Double};
     if (eq#@{Error}
-        s$reify$6$conv$10$simp$193
+        s$reify$6$conv$12$simp$137
         (ExceptNotAnError@{Error})) {
-      init flat$15$simp$199@{Error} = ExceptNotAnError@{Error};
-      init flat$15$simp$200@{Double} = 0.0@{Double};
-      init flat$15$simp$201@{Double} = 0.0@{Double};
+      init flat$10$simp$143@{Error} = ExceptNotAnError@{Error};
+      init flat$10$simp$144@{Double} = 0.0@{Double};
+      init flat$10$simp$145@{Double} = 0.0@{Double};
       if (eq#@{Error}
-          s$reify$6$conv$10$simp$193
+          s$reify$6$conv$12$simp$137
           (ExceptNotAnError@{Error})) {
-        init flat$18$simp$202@{Error} = ExceptNotAnError@{Error};
-        init flat$18$simp$203@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv$9$simp$185
+        init flat$13$simp$146@{Error} = ExceptNotAnError@{Error};
+        init flat$13$simp$147@{Double} = 0.0@{Double};
+        if (eq#@{Error} conv$11$simp$129
             (ExceptNotAnError@{Error})) {
-          write flat$18$simp$202 = ExceptNotAnError@{Error};
-          write flat$18$simp$203 = sub#@{Double}
-                                   conv$9$simp$186
-                                   s$reify$6$conv$10$simp$194;
+          write flat$13$simp$146 = ExceptNotAnError@{Error};
+          write flat$13$simp$147 = sub#@{Double}
+                                   conv$11$simp$130
+                                   s$reify$6$conv$12$simp$138;
         } else {
-          write flat$18$simp$202 = conv$9$simp$185;
-          write flat$18$simp$203 = 0.0@{Double};
+          write flat$13$simp$146 = conv$11$simp$129;
+          write flat$13$simp$147 = 0.0@{Double};
         }
-        read@{Error} flat$18$simp$204 = flat$18$simp$202;
-        read@{Double} flat$18$simp$205 = flat$18$simp$203;
-        init flat$19$simp$206@{Error} = ExceptNotAnError@{Error};
-        init flat$19$simp$207@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$18$simp$204
+        read@{Error} flat$13$simp$148 = flat$13$simp$146;
+        read@{Double} flat$13$simp$149 = flat$13$simp$147;
+        init flat$14$simp$150@{Error} = ExceptNotAnError@{Error};
+        init flat$14$simp$151@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$13$simp$148
             (ExceptNotAnError@{Error})) {
-          let simp$729 = add#@{Double}
-                         s$reify$6$conv$10$simp$195
+          let simp$457 = add#@{Double}
+                         s$reify$6$conv$12$simp$139
                          (1.0@{Double});
-          write flat$19$simp$206 = ExceptNotAnError@{Error};
-          write flat$19$simp$207 = div#
-                                   flat$18$simp$205 simp$729;
+          write flat$14$simp$150 = ExceptNotAnError@{Error};
+          write flat$14$simp$151 = div#
+                                   flat$13$simp$149 simp$457;
         } else {
-          write flat$19$simp$206 = flat$18$simp$204;
-          write flat$19$simp$207 = 0.0@{Double};
+          write flat$14$simp$150 = flat$13$simp$148;
+          write flat$14$simp$151 = 0.0@{Double};
         }
-        read@{Error} flat$19$simp$208 = flat$19$simp$206;
-        read@{Double} flat$19$simp$209 = flat$19$simp$207;
-        init flat$20$simp$210@{Error} = ExceptNotAnError@{Error};
-        init flat$20$simp$211@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$19$simp$208
+        read@{Error} flat$14$simp$152 = flat$14$simp$150;
+        read@{Double} flat$14$simp$153 = flat$14$simp$151;
+        init flat$15$simp$154@{Error} = ExceptNotAnError@{Error};
+        init flat$15$simp$155@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$14$simp$152
             (ExceptNotAnError@{Error})) {
-          write flat$20$simp$210 = ExceptNotAnError@{Error};
-          write flat$20$simp$211 = add#@{Double}
-                                   s$reify$6$conv$10$simp$194
-                                   flat$19$simp$209;
+          write flat$15$simp$154 = ExceptNotAnError@{Error};
+          write flat$15$simp$155 = add#@{Double}
+                                   s$reify$6$conv$12$simp$138
+                                   flat$14$simp$153;
         } else {
-          write flat$20$simp$210 = flat$19$simp$208;
-          write flat$20$simp$211 = 0.0@{Double};
+          write flat$15$simp$154 = flat$14$simp$152;
+          write flat$15$simp$155 = 0.0@{Double};
         }
-        read@{Error} flat$20$simp$212 = flat$20$simp$210;
-        read@{Double} flat$20$simp$213 = flat$20$simp$211;
-        init flat$21$simp$214@{Error} = ExceptNotAnError@{Error};
-        init flat$21$simp$215@{Double} = 0.0@{Double};
-        init flat$21$simp$216@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$20$simp$212
+        read@{Error} flat$15$simp$156 = flat$15$simp$154;
+        read@{Double} flat$15$simp$157 = flat$15$simp$155;
+        init flat$16$simp$158@{Error} = ExceptNotAnError@{Error};
+        init flat$16$simp$159@{Double} = 0.0@{Double};
+        init flat$16$simp$160@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$15$simp$156
             (ExceptNotAnError@{Error})) {
-          write flat$21$simp$214 = ExceptNotAnError@{Error};
-          write flat$21$simp$215 = flat$20$simp$213;
-          write flat$21$simp$216 = add#@{Double}
-                                   s$reify$6$conv$10$simp$195
+          write flat$16$simp$158 = ExceptNotAnError@{Error};
+          write flat$16$simp$159 = flat$15$simp$157;
+          write flat$16$simp$160 = add#@{Double}
+                                   s$reify$6$conv$12$simp$139
                                    (1.0@{Double});
         } else {
-          write flat$21$simp$214 = flat$20$simp$212;
-          write flat$21$simp$215 = 0.0@{Double};
-          write flat$21$simp$216 = 0.0@{Double};
+          write flat$16$simp$158 = flat$15$simp$156;
+          write flat$16$simp$159 = 0.0@{Double};
+          write flat$16$simp$160 = 0.0@{Double};
         }
-        read@{Error} flat$21$simp$217 = flat$21$simp$214;
-        read@{Double} flat$21$simp$218 = flat$21$simp$215;
-        read@{Double} flat$21$simp$219 = flat$21$simp$216;
-        write flat$15$simp$199 = flat$21$simp$217;
-        write flat$15$simp$200 = flat$21$simp$218;
-        write flat$15$simp$201 = flat$21$simp$219;
+        read@{Error} flat$16$simp$161 = flat$16$simp$158;
+        read@{Double} flat$16$simp$162 = flat$16$simp$159;
+        read@{Double} flat$16$simp$163 = flat$16$simp$160;
+        write flat$10$simp$143 = flat$16$simp$161;
+        write flat$10$simp$144 = flat$16$simp$162;
+        write flat$10$simp$145 = flat$16$simp$163;
       } else {
-        write flat$15$simp$199 = s$reify$6$conv$10$simp$193;
-        write flat$15$simp$200 = 0.0@{Double};
-        write flat$15$simp$201 = 0.0@{Double};
+        write flat$10$simp$143 = s$reify$6$conv$12$simp$137;
+        write flat$10$simp$144 = 0.0@{Double};
+        write flat$10$simp$145 = 0.0@{Double};
       }
-      read@{Error} flat$15$simp$220 = flat$15$simp$199;
-      read@{Double} flat$15$simp$221 = flat$15$simp$200;
-      read@{Double} flat$15$simp$222 = flat$15$simp$201;
-      write flat$8$simp$196 = flat$15$simp$220;
-      write flat$8$simp$197 = flat$15$simp$221;
-      write flat$8$simp$198 = flat$15$simp$222;
+      read@{Error} flat$10$simp$164 = flat$10$simp$143;
+      read@{Double} flat$10$simp$165 = flat$10$simp$144;
+      read@{Double} flat$10$simp$166 = flat$10$simp$145;
+      write flat$3$simp$140 = flat$10$simp$164;
+      write flat$3$simp$141 = flat$10$simp$165;
+      write flat$3$simp$142 = flat$10$simp$166;
     } else {
-      init flat$11$simp$223@{Error} = ExceptNotAnError@{Error};
-      init flat$11$simp$224@{Double} = 0.0@{Double};
-      init flat$11$simp$225@{Double} = 0.0@{Double};
+      init flat$6$simp$167@{Error} = ExceptNotAnError@{Error};
+      init flat$6$simp$168@{Double} = 0.0@{Double};
+      init flat$6$simp$169@{Double} = 0.0@{Double};
       if (eq#@{Error} (ExceptFold1NoValue@{Error})
-          s$reify$6$conv$10$simp$193) {
-        init flat$12$simp$226@{Error} = ExceptNotAnError@{Error};
-        init flat$12$simp$227@{Double} = 0.0@{Double};
-        init flat$12$simp$228@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv$9$simp$185
+          s$reify$6$conv$12$simp$137) {
+        init flat$7$simp$170@{Error} = ExceptNotAnError@{Error};
+        init flat$7$simp$171@{Double} = 0.0@{Double};
+        init flat$7$simp$172@{Double} = 0.0@{Double};
+        if (eq#@{Error} conv$11$simp$129
             (ExceptNotAnError@{Error})) {
-          write flat$12$simp$226 = ExceptNotAnError@{Error};
-          write flat$12$simp$227 = conv$9$simp$186;
-          write flat$12$simp$228 = 1.0@{Double};
+          write flat$7$simp$170 = ExceptNotAnError@{Error};
+          write flat$7$simp$171 = conv$11$simp$130;
+          write flat$7$simp$172 = 1.0@{Double};
         } else {
-          write flat$12$simp$226 = conv$9$simp$185;
-          write flat$12$simp$227 = 0.0@{Double};
-          write flat$12$simp$228 = 0.0@{Double};
+          write flat$7$simp$170 = conv$11$simp$129;
+          write flat$7$simp$171 = 0.0@{Double};
+          write flat$7$simp$172 = 0.0@{Double};
         }
-        read@{Error} flat$12$simp$229 = flat$12$simp$226;
-        read@{Double} flat$12$simp$230 = flat$12$simp$227;
-        read@{Double} flat$12$simp$231 = flat$12$simp$228;
-        write flat$11$simp$223 = flat$12$simp$229;
-        write flat$11$simp$224 = flat$12$simp$230;
-        write flat$11$simp$225 = flat$12$simp$231;
+        read@{Error} flat$7$simp$173 = flat$7$simp$170;
+        read@{Double} flat$7$simp$174 = flat$7$simp$171;
+        read@{Double} flat$7$simp$175 = flat$7$simp$172;
+        write flat$6$simp$167 = flat$7$simp$173;
+        write flat$6$simp$168 = flat$7$simp$174;
+        write flat$6$simp$169 = flat$7$simp$175;
       } else {
-        write flat$11$simp$223 = s$reify$6$conv$10$simp$193;
-        write flat$11$simp$224 = 0.0@{Double};
-        write flat$11$simp$225 = 0.0@{Double};
+        write flat$6$simp$167 = s$reify$6$conv$12$simp$137;
+        write flat$6$simp$168 = 0.0@{Double};
+        write flat$6$simp$169 = 0.0@{Double};
       }
-      read@{Error} flat$11$simp$232 = flat$11$simp$223;
-      read@{Double} flat$11$simp$233 = flat$11$simp$224;
-      read@{Double} flat$11$simp$234 = flat$11$simp$225;
-      write flat$8$simp$196 = flat$11$simp$232;
-      write flat$8$simp$197 = flat$11$simp$233;
-      write flat$8$simp$198 = flat$11$simp$234;
+      read@{Error} flat$6$simp$176 = flat$6$simp$167;
+      read@{Double} flat$6$simp$177 = flat$6$simp$168;
+      read@{Double} flat$6$simp$178 = flat$6$simp$169;
+      write flat$3$simp$140 = flat$6$simp$176;
+      write flat$3$simp$141 = flat$6$simp$177;
+      write flat$3$simp$142 = flat$6$simp$178;
     }
-    read@{Error} flat$8$simp$235 = flat$8$simp$196;
-    read@{Double} flat$8$simp$236 = flat$8$simp$197;
-    read@{Double} flat$8$simp$237 = flat$8$simp$198;
-    write acc$s$reify$6$conv$10$simp$106 = flat$8$simp$235;
-    write acc$s$reify$6$conv$10$simp$107 = flat$8$simp$236;
-    write acc$s$reify$6$conv$10$simp$108 = flat$8$simp$237;
-    init flat$30$simp$238@{Error} = ExceptNotAnError@{Error};
-    init flat$30$simp$239@{String} = ""@{String};
-    if (eq#@{Error} conv$0$simp$389
+    read@{Error} flat$3$simp$179 = flat$3$simp$140;
+    read@{Double} flat$3$simp$180 = flat$3$simp$141;
+    read@{Double} flat$3$simp$181 = flat$3$simp$142;
+    write acc$s$reify$6$conv$12$simp$94 = flat$3$simp$179;
+    write acc$s$reify$6$conv$12$simp$95 = flat$3$simp$180;
+    write acc$s$reify$6$conv$12$simp$96 = flat$3$simp$181;
+    init flat$25$simp$182@{Error} = ExceptNotAnError@{Error};
+    init flat$25$simp$183@{String} = ""@{String};
+    if (eq#@{Error} conv$0$simp$333
         (ExceptNotAnError@{Error})) {
-      write flat$30$simp$238 = ExceptNotAnError@{Error};
-      write flat$30$simp$239 = conv$0$simp$390;
+      write flat$25$simp$182 = ExceptNotAnError@{Error};
+      write flat$25$simp$183 = conv$0$simp$334;
     } else {
-      write flat$30$simp$238 = conv$0$simp$389;
-      write flat$30$simp$239 = ""@{String};
+      write flat$25$simp$182 = conv$0$simp$333;
+      write flat$25$simp$183 = ""@{String};
     }
-    read@{Error} flat$30$simp$240 = flat$30$simp$238;
-    read@{String} flat$30$simp$241 = flat$30$simp$239;
-    init flat$31$simp$242@{Error} = ExceptNotAnError@{Error};
-    init flat$31$simp$243@{Bool} = False@{Bool};
-    if (eq#@{Error} flat$30$simp$240
+    read@{Error} flat$25$simp$184 = flat$25$simp$182;
+    read@{String} flat$25$simp$185 = flat$25$simp$183;
+    init flat$26$simp$186@{Error} = ExceptNotAnError@{Error};
+    init flat$26$simp$187@{Bool} = False@{Bool};
+    if (eq#@{Error} flat$25$simp$184
         (ExceptNotAnError@{Error})) {
-      write flat$31$simp$242 = ExceptNotAnError@{Error};
-      write flat$31$simp$243 = eq#@{String}
-                               flat$30$simp$241 ("torso"@{String});
+      write flat$26$simp$186 = ExceptNotAnError@{Error};
+      write flat$26$simp$187 = eq#@{String}
+                               flat$25$simp$185 ("torso"@{String});
     } else {
-      write flat$31$simp$242 = flat$30$simp$240;
-      write flat$31$simp$243 = False@{Bool};
+      write flat$26$simp$186 = flat$25$simp$184;
+      write flat$26$simp$187 = False@{Bool};
     }
-    read@{Error} flat$31$simp$244 = flat$31$simp$242;
-    read@{Bool} flat$31$simp$245 = flat$31$simp$243;
-    init flat$32@{Bool} = False@{Bool};
-    if (eq#@{Error} flat$31$simp$244
+    read@{Error} flat$26$simp$188 = flat$26$simp$186;
+    read@{Bool} flat$26$simp$189 = flat$26$simp$187;
+    init flat$27@{Bool} = False@{Bool};
+    if (eq#@{Error} flat$26$simp$188
         (ExceptNotAnError@{Error})) {
-      write flat$32 = flat$31$simp$245;
+      write flat$27 = flat$26$simp$189;
     } 
      else {
-      write flat$32 = True@{Bool};
+      write flat$27 = True@{Bool};
     } 
     
-    read@{Bool} flat$32 = flat$32;
-    if (flat$32) {
-      init flat$33$simp$252@{Error} = ExceptNotAnError@{Error};
-      init flat$33$simp$253@{Int} = 0@{Int};
-      if (eq#@{Error} conv$0$simp$389
+    read@{Bool} flat$27 = flat$27;
+    if (flat$27) {
+      init flat$28$simp$196@{Error} = ExceptNotAnError@{Error};
+      init flat$28$simp$197@{Int} = 0@{Int};
+      if (eq#@{Error} conv$0$simp$333
           (ExceptNotAnError@{Error})) {
-        write flat$33$simp$252 = ExceptNotAnError@{Error};
-        write flat$33$simp$253 = conv$0$simp$391;
+        write flat$28$simp$196 = ExceptNotAnError@{Error};
+        write flat$28$simp$197 = conv$0$simp$335;
       } else {
-        write flat$33$simp$252 = conv$0$simp$389;
-        write flat$33$simp$253 = 0@{Int};
+        write flat$28$simp$196 = conv$0$simp$333;
+        write flat$28$simp$197 = 0@{Int};
       }
-      read@{Error} flat$33$simp$254 = flat$33$simp$252;
-      read@{Int} flat$33$simp$255 = flat$33$simp$253;
-      write acc$conv$55$simp$100 = flat$33$simp$254;
-      write acc$conv$55$simp$101 = flat$33$simp$255;
-      read@{Error} conv$55$simp$256 = acc$conv$55$simp$100;
-      read@{Int} conv$55$simp$257 = acc$conv$55$simp$101;
-      write acc$conv$56$simp$92 = conv$55$simp$256;
-      write acc$conv$56$simp$93 = conv$55$simp$257;
-      read@{Error} conv$56$simp$268 = acc$conv$56$simp$92;
-      read@{Int} conv$56$simp$269 = acc$conv$56$simp$93;
-      init flat$34$simp$276@{Error} = ExceptNotAnError@{Error};
-      init flat$34$simp$277@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv$56$simp$268
+      read@{Error} flat$28$simp$198 = flat$28$simp$196;
+      read@{Int} flat$28$simp$199 = flat$28$simp$197;
+      write acc$conv$57$simp$88 = flat$28$simp$198;
+      write acc$conv$57$simp$89 = flat$28$simp$199;
+      read@{Error} conv$57$simp$200 = acc$conv$57$simp$88;
+      read@{Int} conv$57$simp$201 = acc$conv$57$simp$89;
+      write acc$conv$58$simp$80 = conv$57$simp$200;
+      write acc$conv$58$simp$81 = conv$57$simp$201;
+      read@{Error} conv$58$simp$212 = acc$conv$58$simp$80;
+      read@{Int} conv$58$simp$213 = acc$conv$58$simp$81;
+      init flat$29$simp$220@{Error} = ExceptNotAnError@{Error};
+      init flat$29$simp$221@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv$58$simp$212
           (ExceptNotAnError@{Error})) {
-        write flat$34$simp$276 = ExceptNotAnError@{Error};
-        write flat$34$simp$277 = doubleOfInt#
-                                 conv$56$simp$269;
+        write flat$29$simp$220 = ExceptNotAnError@{Error};
+        write flat$29$simp$221 = doubleOfInt#
+                                 conv$58$simp$213;
       } else {
-        write flat$34$simp$276 = conv$56$simp$268;
-        write flat$34$simp$277 = 0.0@{Double};
+        write flat$29$simp$220 = conv$58$simp$212;
+        write flat$29$simp$221 = 0.0@{Double};
       }
-      read@{Error} flat$34$simp$278 = flat$34$simp$276;
-      read@{Double} flat$34$simp$279 = flat$34$simp$277;
-      write acc$conv$60$simp$82 = flat$34$simp$278;
-      write acc$conv$60$simp$83 = flat$34$simp$279;
-      read@{Error} conv$60$simp$286 = acc$conv$60$simp$82;
-      read@{Double} conv$60$simp$287 = acc$conv$60$simp$83;
-      read@{Error} a$conv$61$simp$296 = acc$a$conv$61$simp$78;
-      read@{Double} a$conv$61$simp$297 = acc$a$conv$61$simp$79;
-      read@{Double} a$conv$61$simp$298 = acc$a$conv$61$simp$80;
-      read@{Double} a$conv$61$simp$299 = acc$a$conv$61$simp$81;
-      init flat$35$simp$300@{Error} = ExceptNotAnError@{Error};
-      init flat$35$simp$301@{Double} = 0.0@{Double};
-      init flat$35$simp$302@{Double} = 0.0@{Double};
-      init flat$35$simp$303@{Double} = 0.0@{Double};
-      if (eq#@{Error} a$conv$61$simp$296
+      read@{Error} flat$29$simp$222 = flat$29$simp$220;
+      read@{Double} flat$29$simp$223 = flat$29$simp$221;
+      write acc$conv$62$simp$70 = flat$29$simp$222;
+      write acc$conv$62$simp$71 = flat$29$simp$223;
+      read@{Error} conv$62$simp$230 = acc$conv$62$simp$70;
+      read@{Double} conv$62$simp$231 = acc$conv$62$simp$71;
+      read@{Error} a$conv$63$simp$240 = acc$a$conv$63$simp$66;
+      read@{Double} a$conv$63$simp$241 = acc$a$conv$63$simp$67;
+      read@{Double} a$conv$63$simp$242 = acc$a$conv$63$simp$68;
+      read@{Double} a$conv$63$simp$243 = acc$a$conv$63$simp$69;
+      init flat$30$simp$244@{Error} = ExceptNotAnError@{Error};
+      init flat$30$simp$245@{Double} = 0.0@{Double};
+      init flat$30$simp$246@{Double} = 0.0@{Double};
+      init flat$30$simp$247@{Double} = 0.0@{Double};
+      if (eq#@{Error} a$conv$63$simp$240
           (ExceptNotAnError@{Error})) {
-        let nn$conv$68 = add#@{Double}
-                         a$conv$61$simp$297 (1.0@{Double});
-        init flat$38$simp$304@{Error} = ExceptNotAnError@{Error};
-        init flat$38$simp$305@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv$60$simp$286
+        let nn$conv$70 = add#@{Double}
+                         a$conv$63$simp$241 (1.0@{Double});
+        init flat$33$simp$248@{Error} = ExceptNotAnError@{Error};
+        init flat$33$simp$249@{Double} = 0.0@{Double};
+        if (eq#@{Error} conv$62$simp$230
             (ExceptNotAnError@{Error})) {
-          write flat$38$simp$304 = ExceptNotAnError@{Error};
-          write flat$38$simp$305 = sub#@{Double}
-                                   conv$60$simp$287
-                                   a$conv$61$simp$298;
+          write flat$33$simp$248 = ExceptNotAnError@{Error};
+          write flat$33$simp$249 = sub#@{Double}
+                                   conv$62$simp$231
+                                   a$conv$63$simp$242;
         } else {
-          write flat$38$simp$304 = conv$60$simp$286;
-          write flat$38$simp$305 = 0.0@{Double};
+          write flat$33$simp$248 = conv$62$simp$230;
+          write flat$33$simp$249 = 0.0@{Double};
         }
-        read@{Error} flat$38$simp$306 = flat$38$simp$304;
-        read@{Double} flat$38$simp$307 = flat$38$simp$305;
-        init flat$39$simp$308@{Error} = ExceptNotAnError@{Error};
-        init flat$39$simp$309@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$38$simp$306
+        read@{Error} flat$33$simp$250 = flat$33$simp$248;
+        read@{Double} flat$33$simp$251 = flat$33$simp$249;
+        init flat$34$simp$252@{Error} = ExceptNotAnError@{Error};
+        init flat$34$simp$253@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$33$simp$250
             (ExceptNotAnError@{Error})) {
-          write flat$39$simp$308 = ExceptNotAnError@{Error};
-          write flat$39$simp$309 = div#
-                                   flat$38$simp$307 nn$conv$68;
+          write flat$34$simp$252 = ExceptNotAnError@{Error};
+          write flat$34$simp$253 = div#
+                                   flat$33$simp$251 nn$conv$70;
         } else {
-          write flat$39$simp$308 = flat$38$simp$306;
-          write flat$39$simp$309 = 0.0@{Double};
+          write flat$34$simp$252 = flat$33$simp$250;
+          write flat$34$simp$253 = 0.0@{Double};
         }
-        read@{Error} flat$39$simp$310 = flat$39$simp$308;
-        read@{Double} flat$39$simp$311 = flat$39$simp$309;
-        init flat$40$simp$312@{Error} = ExceptNotAnError@{Error};
-        init flat$40$simp$313@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$39$simp$310
+        read@{Error} flat$34$simp$254 = flat$34$simp$252;
+        read@{Double} flat$34$simp$255 = flat$34$simp$253;
+        init flat$35$simp$256@{Error} = ExceptNotAnError@{Error};
+        init flat$35$simp$257@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$34$simp$254
             (ExceptNotAnError@{Error})) {
-          write flat$40$simp$312 = ExceptNotAnError@{Error};
-          write flat$40$simp$313 = add#@{Double}
-                                   a$conv$61$simp$298
-                                   flat$39$simp$311;
+          write flat$35$simp$256 = ExceptNotAnError@{Error};
+          write flat$35$simp$257 = add#@{Double}
+                                   a$conv$63$simp$242
+                                   flat$34$simp$255;
         } else {
-          write flat$40$simp$312 = flat$39$simp$310;
-          write flat$40$simp$313 = 0.0@{Double};
+          write flat$35$simp$256 = flat$34$simp$254;
+          write flat$35$simp$257 = 0.0@{Double};
         }
-        read@{Error} flat$40$simp$314 = flat$40$simp$312;
-        read@{Double} flat$40$simp$315 = flat$40$simp$313;
-        init flat$41$simp$316@{Error} = ExceptNotAnError@{Error};
-        init flat$41$simp$317@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$38$simp$306
+        read@{Error} flat$35$simp$258 = flat$35$simp$256;
+        read@{Double} flat$35$simp$259 = flat$35$simp$257;
+        init flat$36$simp$260@{Error} = ExceptNotAnError@{Error};
+        init flat$36$simp$261@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$33$simp$250
             (ExceptNotAnError@{Error})) {
-          init flat$56$simp$318@{Error} = ExceptNotAnError@{Error};
-          init flat$56$simp$319@{Double} = 0.0@{Double};
-          if (eq#@{Error} conv$60$simp$286
+          init flat$51$simp$262@{Error} = ExceptNotAnError@{Error};
+          init flat$51$simp$263@{Double} = 0.0@{Double};
+          if (eq#@{Error} conv$62$simp$230
               (ExceptNotAnError@{Error})) {
-            init flat$62$simp$320@{Error} = ExceptNotAnError@{Error};
-            init flat$62$simp$321@{Double} = 0.0@{Double};
-            if (eq#@{Error} flat$40$simp$314
+            init flat$57$simp$264@{Error} = ExceptNotAnError@{Error};
+            init flat$57$simp$265@{Double} = 0.0@{Double};
+            if (eq#@{Error} flat$35$simp$258
                 (ExceptNotAnError@{Error})) {
-              write flat$62$simp$320 = ExceptNotAnError@{Error};
-              write flat$62$simp$321 = sub#@{Double}
-                                       conv$60$simp$287
-                                       flat$40$simp$315;
+              write flat$57$simp$264 = ExceptNotAnError@{Error};
+              write flat$57$simp$265 = sub#@{Double}
+                                       conv$62$simp$231
+                                       flat$35$simp$259;
             } else {
-              write flat$62$simp$320 = flat$40$simp$314;
-              write flat$62$simp$321 = 0.0@{Double};
+              write flat$57$simp$264 = flat$35$simp$258;
+              write flat$57$simp$265 = 0.0@{Double};
             }
-            read@{Error} flat$62$simp$322 = flat$62$simp$320;
-            read@{Double} flat$62$simp$323 = flat$62$simp$321;
-            write flat$56$simp$318 = flat$62$simp$322;
-            write flat$56$simp$319 = flat$62$simp$323;
+            read@{Error} flat$57$simp$266 = flat$57$simp$264;
+            read@{Double} flat$57$simp$267 = flat$57$simp$265;
+            write flat$51$simp$262 = flat$57$simp$266;
+            write flat$51$simp$263 = flat$57$simp$267;
           } else {
-            write flat$56$simp$318 = conv$60$simp$286;
-            write flat$56$simp$319 = 0.0@{Double};
+            write flat$51$simp$262 = conv$62$simp$230;
+            write flat$51$simp$263 = 0.0@{Double};
           }
-          read@{Error} flat$56$simp$324 = flat$56$simp$318;
-          read@{Double} flat$56$simp$325 = flat$56$simp$319;
-          init flat$57$simp$326@{Error} = ExceptNotAnError@{Error};
-          init flat$57$simp$327@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat$56$simp$324
+          read@{Error} flat$51$simp$268 = flat$51$simp$262;
+          read@{Double} flat$51$simp$269 = flat$51$simp$263;
+          init flat$52$simp$270@{Error} = ExceptNotAnError@{Error};
+          init flat$52$simp$271@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat$51$simp$268
               (ExceptNotAnError@{Error})) {
-            write flat$57$simp$326 = ExceptNotAnError@{Error};
-            write flat$57$simp$327 = mul#@{Double}
-                                     flat$38$simp$307
-                                     flat$56$simp$325;
+            write flat$52$simp$270 = ExceptNotAnError@{Error};
+            write flat$52$simp$271 = mul#@{Double}
+                                     flat$33$simp$251
+                                     flat$51$simp$269;
           } else {
-            write flat$57$simp$326 = flat$56$simp$324;
-            write flat$57$simp$327 = 0.0@{Double};
+            write flat$52$simp$270 = flat$51$simp$268;
+            write flat$52$simp$271 = 0.0@{Double};
           }
-          read@{Error} flat$57$simp$328 = flat$57$simp$326;
-          read@{Double} flat$57$simp$329 = flat$57$simp$327;
-          write flat$41$simp$316 = flat$57$simp$328;
-          write flat$41$simp$317 = flat$57$simp$329;
+          read@{Error} flat$52$simp$272 = flat$52$simp$270;
+          read@{Double} flat$52$simp$273 = flat$52$simp$271;
+          write flat$36$simp$260 = flat$52$simp$272;
+          write flat$36$simp$261 = flat$52$simp$273;
         } else {
-          write flat$41$simp$316 = flat$38$simp$306;
-          write flat$41$simp$317 = 0.0@{Double};
+          write flat$36$simp$260 = flat$33$simp$250;
+          write flat$36$simp$261 = 0.0@{Double};
         }
-        read@{Error} flat$41$simp$330 = flat$41$simp$316;
-        read@{Double} flat$41$simp$331 = flat$41$simp$317;
-        init flat$42$simp$332@{Error} = ExceptNotAnError@{Error};
-        init flat$42$simp$333@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$41$simp$330
+        read@{Error} flat$36$simp$274 = flat$36$simp$260;
+        read@{Double} flat$36$simp$275 = flat$36$simp$261;
+        init flat$37$simp$276@{Error} = ExceptNotAnError@{Error};
+        init flat$37$simp$277@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$36$simp$274
             (ExceptNotAnError@{Error})) {
-          write flat$42$simp$332 = ExceptNotAnError@{Error};
-          write flat$42$simp$333 = add#@{Double}
-                                   a$conv$61$simp$299
-                                   flat$41$simp$331;
+          write flat$37$simp$276 = ExceptNotAnError@{Error};
+          write flat$37$simp$277 = add#@{Double}
+                                   a$conv$63$simp$243
+                                   flat$36$simp$275;
         } else {
-          write flat$42$simp$332 = flat$41$simp$330;
-          write flat$42$simp$333 = 0.0@{Double};
+          write flat$37$simp$276 = flat$36$simp$274;
+          write flat$37$simp$277 = 0.0@{Double};
         }
-        read@{Error} flat$42$simp$334 = flat$42$simp$332;
-        read@{Double} flat$42$simp$335 = flat$42$simp$333;
-        init flat$43$simp$336@{Error} = ExceptNotAnError@{Error};
-        init flat$43$simp$337@{Double} = 0.0@{Double};
-        init flat$43$simp$338@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$40$simp$314
+        read@{Error} flat$37$simp$278 = flat$37$simp$276;
+        read@{Double} flat$37$simp$279 = flat$37$simp$277;
+        init flat$38$simp$280@{Error} = ExceptNotAnError@{Error};
+        init flat$38$simp$281@{Double} = 0.0@{Double};
+        init flat$38$simp$282@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$35$simp$258
             (ExceptNotAnError@{Error})) {
-          write flat$43$simp$336 = ExceptNotAnError@{Error};
-          write flat$43$simp$337 = add#@{Double}
-                                   a$conv$61$simp$297 (1.0@{Double});
-          write flat$43$simp$338 = flat$40$simp$315;
+          write flat$38$simp$280 = ExceptNotAnError@{Error};
+          write flat$38$simp$281 = add#@{Double}
+                                   a$conv$63$simp$241 (1.0@{Double});
+          write flat$38$simp$282 = flat$35$simp$259;
         } else {
-          write flat$43$simp$336 = flat$40$simp$314;
-          write flat$43$simp$337 = 0.0@{Double};
-          write flat$43$simp$338 = 0.0@{Double};
+          write flat$38$simp$280 = flat$35$simp$258;
+          write flat$38$simp$281 = 0.0@{Double};
+          write flat$38$simp$282 = 0.0@{Double};
         }
-        read@{Error} flat$43$simp$339 = flat$43$simp$336;
-        read@{Double} flat$43$simp$340 = flat$43$simp$337;
-        read@{Double} flat$43$simp$341 = flat$43$simp$338;
-        init flat$44$simp$342@{Error} = ExceptNotAnError@{Error};
-        init flat$44$simp$343@{Double} = 0.0@{Double};
-        init flat$44$simp$344@{Double} = 0.0@{Double};
-        init flat$44$simp$345@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$43$simp$339
+        read@{Error} flat$38$simp$283 = flat$38$simp$280;
+        read@{Double} flat$38$simp$284 = flat$38$simp$281;
+        read@{Double} flat$38$simp$285 = flat$38$simp$282;
+        init flat$39$simp$286@{Error} = ExceptNotAnError@{Error};
+        init flat$39$simp$287@{Double} = 0.0@{Double};
+        init flat$39$simp$288@{Double} = 0.0@{Double};
+        init flat$39$simp$289@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$38$simp$283
             (ExceptNotAnError@{Error})) {
-          init flat$47$simp$346@{Error} = ExceptNotAnError@{Error};
-          init flat$47$simp$347@{Double} = 0.0@{Double};
-          init flat$47$simp$348@{Double} = 0.0@{Double};
-          init flat$47$simp$349@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat$42$simp$334
+          init flat$42$simp$290@{Error} = ExceptNotAnError@{Error};
+          init flat$42$simp$291@{Double} = 0.0@{Double};
+          init flat$42$simp$292@{Double} = 0.0@{Double};
+          init flat$42$simp$293@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat$37$simp$278
               (ExceptNotAnError@{Error})) {
-            write flat$47$simp$346 = ExceptNotAnError@{Error};
-            write flat$47$simp$347 = flat$43$simp$340;
-            write flat$47$simp$348 = flat$43$simp$341;
-            write flat$47$simp$349 = flat$42$simp$335;
+            write flat$42$simp$290 = ExceptNotAnError@{Error};
+            write flat$42$simp$291 = flat$38$simp$284;
+            write flat$42$simp$292 = flat$38$simp$285;
+            write flat$42$simp$293 = flat$37$simp$279;
           } else {
-            write flat$47$simp$346 = flat$42$simp$334;
-            write flat$47$simp$347 = 0.0@{Double};
-            write flat$47$simp$348 = 0.0@{Double};
-            write flat$47$simp$349 = 0.0@{Double};
+            write flat$42$simp$290 = flat$37$simp$278;
+            write flat$42$simp$291 = 0.0@{Double};
+            write flat$42$simp$292 = 0.0@{Double};
+            write flat$42$simp$293 = 0.0@{Double};
           }
-          read@{Error} flat$47$simp$350 = flat$47$simp$346;
-          read@{Double} flat$47$simp$351 = flat$47$simp$347;
-          read@{Double} flat$47$simp$352 = flat$47$simp$348;
-          read@{Double} flat$47$simp$353 = flat$47$simp$349;
-          write flat$44$simp$342 = flat$47$simp$350;
-          write flat$44$simp$343 = flat$47$simp$351;
-          write flat$44$simp$344 = flat$47$simp$352;
-          write flat$44$simp$345 = flat$47$simp$353;
+          read@{Error} flat$42$simp$294 = flat$42$simp$290;
+          read@{Double} flat$42$simp$295 = flat$42$simp$291;
+          read@{Double} flat$42$simp$296 = flat$42$simp$292;
+          read@{Double} flat$42$simp$297 = flat$42$simp$293;
+          write flat$39$simp$286 = flat$42$simp$294;
+          write flat$39$simp$287 = flat$42$simp$295;
+          write flat$39$simp$288 = flat$42$simp$296;
+          write flat$39$simp$289 = flat$42$simp$297;
         } else {
-          write flat$44$simp$342 = flat$43$simp$339;
-          write flat$44$simp$343 = 0.0@{Double};
-          write flat$44$simp$344 = 0.0@{Double};
-          write flat$44$simp$345 = 0.0@{Double};
+          write flat$39$simp$286 = flat$38$simp$283;
+          write flat$39$simp$287 = 0.0@{Double};
+          write flat$39$simp$288 = 0.0@{Double};
+          write flat$39$simp$289 = 0.0@{Double};
         }
-        read@{Error} flat$44$simp$354 = flat$44$simp$342;
-        read@{Double} flat$44$simp$355 = flat$44$simp$343;
-        read@{Double} flat$44$simp$356 = flat$44$simp$344;
-        read@{Double} flat$44$simp$357 = flat$44$simp$345;
-        write flat$35$simp$300 = flat$44$simp$354;
-        write flat$35$simp$301 = flat$44$simp$355;
-        write flat$35$simp$302 = flat$44$simp$356;
-        write flat$35$simp$303 = flat$44$simp$357;
+        read@{Error} flat$39$simp$298 = flat$39$simp$286;
+        read@{Double} flat$39$simp$299 = flat$39$simp$287;
+        read@{Double} flat$39$simp$300 = flat$39$simp$288;
+        read@{Double} flat$39$simp$301 = flat$39$simp$289;
+        write flat$30$simp$244 = flat$39$simp$298;
+        write flat$30$simp$245 = flat$39$simp$299;
+        write flat$30$simp$246 = flat$39$simp$300;
+        write flat$30$simp$247 = flat$39$simp$301;
       } else {
-        write flat$35$simp$300 = a$conv$61$simp$296;
-        write flat$35$simp$301 = 0.0@{Double};
-        write flat$35$simp$302 = 0.0@{Double};
-        write flat$35$simp$303 = 0.0@{Double};
+        write flat$30$simp$244 = a$conv$63$simp$240;
+        write flat$30$simp$245 = 0.0@{Double};
+        write flat$30$simp$246 = 0.0@{Double};
+        write flat$30$simp$247 = 0.0@{Double};
       }
-      read@{Error} flat$35$simp$358 = flat$35$simp$300;
-      read@{Double} flat$35$simp$359 = flat$35$simp$301;
-      read@{Double} flat$35$simp$360 = flat$35$simp$302;
-      read@{Double} flat$35$simp$361 = flat$35$simp$303;
-      write acc$a$conv$61$simp$78 = flat$35$simp$358;
-      write acc$a$conv$61$simp$79 = flat$35$simp$359;
-      write acc$a$conv$61$simp$80 = flat$35$simp$360;
-      write acc$a$conv$61$simp$81 = flat$35$simp$361;
+      read@{Error} flat$30$simp$302 = flat$30$simp$244;
+      read@{Double} flat$30$simp$303 = flat$30$simp$245;
+      read@{Double} flat$30$simp$304 = flat$30$simp$246;
+      read@{Double} flat$30$simp$305 = flat$30$simp$247;
+      write acc$a$conv$63$simp$66 = flat$30$simp$302;
+      write acc$a$conv$63$simp$67 = flat$30$simp$303;
+      write acc$a$conv$63$simp$68 = flat$30$simp$304;
+      write acc$a$conv$63$simp$69 = flat$30$simp$305;
     }
   }
-  save_resumable@{Error} acc$a$conv$61$simp$78;
-  save_resumable@{Double} acc$a$conv$61$simp$79;
-  save_resumable@{Double} acc$a$conv$61$simp$80;
-  save_resumable@{Double} acc$a$conv$61$simp$81;
-  save_resumable@{Error} acc$conv$60$simp$82;
-  save_resumable@{Double} acc$conv$60$simp$83;
-  save_resumable@{Error} acc$conv$56$simp$92;
-  save_resumable@{Int} acc$conv$56$simp$93;
-  save_resumable@{Error} acc$conv$55$simp$100;
-  save_resumable@{Int} acc$conv$55$simp$101;
-  save_resumable@{Error} acc$s$reify$6$conv$10$simp$106;
-  save_resumable@{Double} acc$s$reify$6$conv$10$simp$107;
-  save_resumable@{Double} acc$s$reify$6$conv$10$simp$108;
-  save_resumable@{Error} acc$conv$9$simp$109;
-  save_resumable@{Double} acc$conv$9$simp$110;
-  save_resumable@{Error} acc$conv$5$simp$117;
-  save_resumable@{Double} acc$conv$5$simp$118;
-  read@{Error} a$conv$61$simp$362 = acc$a$conv$61$simp$78;
-  read@{Double} a$conv$61$simp$363 = acc$a$conv$61$simp$79;
-  read@{Double} a$conv$61$simp$365 = acc$a$conv$61$simp$81;
-  read@{Error} s$reify$6$conv$10$simp$366 = acc$s$reify$6$conv$10$simp$106;
-  read@{Double} s$reify$6$conv$10$simp$367 = acc$s$reify$6$conv$10$simp$107;
-  init flat$87$simp$369@{Error} = ExceptNotAnError@{Error};
-  init flat$87$simp$370@{Double} = 0.0@{Double};
+  save_resumable@{Error} acc$a$conv$63$simp$66;
+  save_resumable@{Double} acc$a$conv$63$simp$67;
+  save_resumable@{Double} acc$a$conv$63$simp$68;
+  save_resumable@{Double} acc$a$conv$63$simp$69;
+  save_resumable@{Error} acc$conv$62$simp$70;
+  save_resumable@{Double} acc$conv$62$simp$71;
+  save_resumable@{Error} acc$conv$58$simp$80;
+  save_resumable@{Int} acc$conv$58$simp$81;
+  save_resumable@{Error} acc$conv$57$simp$88;
+  save_resumable@{Int} acc$conv$57$simp$89;
+  save_resumable@{Error} acc$s$reify$6$conv$12$simp$94;
+  save_resumable@{Double} acc$s$reify$6$conv$12$simp$95;
+  save_resumable@{Double} acc$s$reify$6$conv$12$simp$96;
+  save_resumable@{Error} acc$conv$11$simp$97;
+  save_resumable@{Double} acc$conv$11$simp$98;
+  save_resumable@{Error} acc$conv$7$simp$105;
+  save_resumable@{Double} acc$conv$7$simp$106;
+  read@{Error} a$conv$63$simp$306 = acc$a$conv$63$simp$66;
+  read@{Double} a$conv$63$simp$307 = acc$a$conv$63$simp$67;
+  read@{Double} a$conv$63$simp$309 = acc$a$conv$63$simp$69;
+  read@{Error} s$reify$6$conv$12$simp$310 = acc$s$reify$6$conv$12$simp$94;
+  read@{Double} s$reify$6$conv$12$simp$311 = acc$s$reify$6$conv$12$simp$95;
+  init flat$82$simp$313@{Error} = ExceptNotAnError@{Error};
+  init flat$82$simp$314@{Double} = 0.0@{Double};
   if (eq#@{Error}
-      s$reify$6$conv$10$simp$366
+      s$reify$6$conv$12$simp$310
       (ExceptNotAnError@{Error})) {
-    write flat$87$simp$369 = ExceptNotAnError@{Error};
-    write flat$87$simp$370 = s$reify$6$conv$10$simp$367;
+    write flat$82$simp$313 = ExceptNotAnError@{Error};
+    write flat$82$simp$314 = s$reify$6$conv$12$simp$311;
   } else {
-    write flat$87$simp$369 = s$reify$6$conv$10$simp$366;
-    write flat$87$simp$370 = 0.0@{Double};
+    write flat$82$simp$313 = s$reify$6$conv$12$simp$310;
+    write flat$82$simp$314 = 0.0@{Double};
   }
-  read@{Error} flat$87$simp$371 = flat$87$simp$369;
-  read@{Double} flat$87$simp$372 = flat$87$simp$370;
-  init flat$88$simp$373@{Error} = ExceptNotAnError@{Error};
-  init flat$88$simp$374@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$87$simp$371
+  read@{Error} flat$82$simp$315 = flat$82$simp$313;
+  read@{Double} flat$82$simp$316 = flat$82$simp$314;
+  init flat$83$simp$317@{Error} = ExceptNotAnError@{Error};
+  init flat$83$simp$318@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat$82$simp$315
       (ExceptNotAnError@{Error})) {
-    init flat$91$simp$375@{Error} = ExceptNotAnError@{Error};
-    init flat$91$simp$376@{Double} = 0.0@{Double};
-    if (eq#@{Error} a$conv$61$simp$362
+    init flat$86$simp$319@{Error} = ExceptNotAnError@{Error};
+    init flat$86$simp$320@{Double} = 0.0@{Double};
+    if (eq#@{Error} a$conv$63$simp$306
         (ExceptNotAnError@{Error})) {
-      let conv$116 = sub#@{Double}
-                     a$conv$61$simp$363 (1.0@{Double});
-      let simp$1786 = div#
-                      a$conv$61$simp$365 conv$116;
-      write flat$91$simp$375 = ExceptNotAnError@{Error};
-      write flat$91$simp$376 = simp$1786;
+      let conv$118 = sub#@{Double}
+                     a$conv$63$simp$307 (1.0@{Double});
+      let simp$1408 = div#
+                      a$conv$63$simp$309 conv$118;
+      write flat$86$simp$319 = ExceptNotAnError@{Error};
+      write flat$86$simp$320 = simp$1408;
     } else {
-      write flat$91$simp$375 = a$conv$61$simp$362;
-      write flat$91$simp$376 = 0.0@{Double};
+      write flat$86$simp$319 = a$conv$63$simp$306;
+      write flat$86$simp$320 = 0.0@{Double};
     }
-    read@{Error} flat$91$simp$377 = flat$91$simp$375;
-    read@{Double} flat$91$simp$378 = flat$91$simp$376;
-    init flat$92$simp$379@{Error} = ExceptNotAnError@{Error};
-    init flat$92$simp$380@{Double} = 0.0@{Double};
-    if (eq#@{Error} flat$91$simp$377
+    read@{Error} flat$86$simp$321 = flat$86$simp$319;
+    read@{Double} flat$86$simp$322 = flat$86$simp$320;
+    init flat$87$simp$323@{Error} = ExceptNotAnError@{Error};
+    init flat$87$simp$324@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat$86$simp$321
         (ExceptNotAnError@{Error})) {
-      write flat$92$simp$379 = ExceptNotAnError@{Error};
-      write flat$92$simp$380 = sqrt#
-                               flat$91$simp$378;
+      write flat$87$simp$323 = ExceptNotAnError@{Error};
+      write flat$87$simp$324 = sqrt#
+                               flat$86$simp$322;
     } else {
-      write flat$92$simp$379 = flat$91$simp$377;
-      write flat$92$simp$380 = 0.0@{Double};
+      write flat$87$simp$323 = flat$86$simp$321;
+      write flat$87$simp$324 = 0.0@{Double};
     }
-    read@{Error} flat$92$simp$381 = flat$92$simp$379;
-    read@{Double} flat$92$simp$382 = flat$92$simp$380;
-    init flat$93$simp$383@{Error} = ExceptNotAnError@{Error};
-    init flat$93$simp$384@{Double} = 0.0@{Double};
-    if (eq#@{Error} flat$92$simp$381
+    read@{Error} flat$87$simp$325 = flat$87$simp$323;
+    read@{Double} flat$87$simp$326 = flat$87$simp$324;
+    init flat$88$simp$327@{Error} = ExceptNotAnError@{Error};
+    init flat$88$simp$328@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat$87$simp$325
         (ExceptNotAnError@{Error})) {
-      write flat$93$simp$383 = ExceptNotAnError@{Error};
-      write flat$93$simp$384 = mul#@{Double}
-                               flat$87$simp$372
-                               flat$92$simp$382;
+      write flat$88$simp$327 = ExceptNotAnError@{Error};
+      write flat$88$simp$328 = mul#@{Double}
+                               flat$82$simp$316
+                               flat$87$simp$326;
     } else {
-      write flat$93$simp$383 = flat$92$simp$381;
-      write flat$93$simp$384 = 0.0@{Double};
+      write flat$88$simp$327 = flat$87$simp$325;
+      write flat$88$simp$328 = 0.0@{Double};
     }
-    read@{Error} flat$93$simp$385 = flat$93$simp$383;
-    read@{Double} flat$93$simp$386 = flat$93$simp$384;
-    write flat$88$simp$373 = flat$93$simp$385;
-    write flat$88$simp$374 = flat$93$simp$386;
+    read@{Error} flat$88$simp$329 = flat$88$simp$327;
+    read@{Double} flat$88$simp$330 = flat$88$simp$328;
+    write flat$83$simp$317 = flat$88$simp$329;
+    write flat$83$simp$318 = flat$88$simp$330;
   } else {
-    write flat$88$simp$373 = flat$87$simp$371;
-    write flat$88$simp$374 = 0.0@{Double};
+    write flat$83$simp$317 = flat$82$simp$315;
+    write flat$83$simp$318 = 0.0@{Double};
   }
-  read@{Error} flat$88$simp$387 = flat$88$simp$373;
-  read@{Double} flat$88$simp$388 = flat$88$simp$374;
-  output@{(Sum Error Double)} repl (flat$88$simp$387@{Error},
-               flat$88$simp$388@{Double});
+  read@{Error} flat$83$simp$331 = flat$83$simp$317;
+  read@{Double} flat$83$simp$332 = flat$83$simp$318;
+  output@{(Sum Error Double)} repl (flat$83$simp$331@{Error},
+               flat$83$simp$332@{Double});
 }
 
 - C:
@@ -686,52 +622,52 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_1;
+    itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_389;
-    istring_t       *new_conv_0_simp_390;
-    iint_t          *new_conv_0_simp_391;
-    itime_t         *new_conv_0_simp_392;
+    ierror_t        *new_conv_0_simp_333;
+    istring_t       *new_conv_0_simp_334;
+    iint_t          *new_conv_0_simp_335;
+    itime_t         *new_conv_0_simp_336;
 
     /* outputs */
     ierror_t         repl_ix_0;
     idouble_t        repl_ix_1;
 
     /* resumables */
-    ibool_t          has_acc_conv_56_simp_93;
-    iint_t           res_acc_conv_56_simp_93;
-    ibool_t          has_acc_conv_56_simp_92;
-    ierror_t         res_acc_conv_56_simp_92;
-    ibool_t          has_acc_conv_55_simp_100;
-    ierror_t         res_acc_conv_55_simp_100;
-    ibool_t          has_acc_conv_55_simp_101;
-    iint_t           res_acc_conv_55_simp_101;
-    ibool_t          has_acc_s_reify_6_conv_10_simp_107;
-    idouble_t        res_acc_s_reify_6_conv_10_simp_107;
-    ibool_t          has_acc_s_reify_6_conv_10_simp_106;
-    ierror_t         res_acc_s_reify_6_conv_10_simp_106;
-    ibool_t          has_acc_s_reify_6_conv_10_simp_108;
-    idouble_t        res_acc_s_reify_6_conv_10_simp_108;
-    ibool_t          has_acc_a_conv_61_simp_80;
-    idouble_t        res_acc_a_conv_61_simp_80;
-    ibool_t          has_acc_a_conv_61_simp_81;
-    idouble_t        res_acc_a_conv_61_simp_81;
-    ibool_t          has_acc_conv_60_simp_83;
-    idouble_t        res_acc_conv_60_simp_83;
-    ibool_t          has_acc_conv_60_simp_82;
-    ierror_t         res_acc_conv_60_simp_82;
-    ibool_t          has_acc_a_conv_61_simp_79;
-    idouble_t        res_acc_a_conv_61_simp_79;
-    ibool_t          has_acc_a_conv_61_simp_78;
-    ierror_t         res_acc_a_conv_61_simp_78;
-    ibool_t          has_acc_conv_9_simp_109;
-    ierror_t         res_acc_conv_9_simp_109;
-    ibool_t          has_acc_conv_9_simp_110;
-    idouble_t        res_acc_conv_9_simp_110;
-    ibool_t          has_acc_conv_5_simp_118;
-    idouble_t        res_acc_conv_5_simp_118;
-    ibool_t          has_acc_conv_5_simp_117;
-    ierror_t         res_acc_conv_5_simp_117;
+    ibool_t          has_acc_conv_58_simp_80;
+    ierror_t         res_acc_conv_58_simp_80;
+    ibool_t          has_acc_conv_58_simp_81;
+    iint_t           res_acc_conv_58_simp_81;
+    ibool_t          has_acc_conv_57_simp_88;
+    ierror_t         res_acc_conv_57_simp_88;
+    ibool_t          has_acc_conv_57_simp_89;
+    iint_t           res_acc_conv_57_simp_89;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_95;
+    idouble_t        res_acc_s_reify_6_conv_12_simp_95;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_94;
+    ierror_t         res_acc_s_reify_6_conv_12_simp_94;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_96;
+    idouble_t        res_acc_s_reify_6_conv_12_simp_96;
+    ibool_t          has_acc_conv_62_simp_70;
+    ierror_t         res_acc_conv_62_simp_70;
+    ibool_t          has_acc_conv_62_simp_71;
+    idouble_t        res_acc_conv_62_simp_71;
+    ibool_t          has_acc_a_conv_63_simp_66;
+    ierror_t         res_acc_a_conv_63_simp_66;
+    ibool_t          has_acc_a_conv_63_simp_67;
+    idouble_t        res_acc_a_conv_63_simp_67;
+    ibool_t          has_acc_a_conv_63_simp_68;
+    idouble_t        res_acc_a_conv_63_simp_68;
+    ibool_t          has_acc_a_conv_63_simp_69;
+    idouble_t        res_acc_a_conv_63_simp_69;
+    ibool_t          has_acc_conv_11_simp_97;
+    ierror_t         res_acc_conv_11_simp_97;
+    ibool_t          has_acc_conv_11_simp_98;
+    idouble_t        res_acc_conv_11_simp_98;
+    ibool_t          has_acc_conv_7_simp_106;
+    idouble_t        res_acc_conv_7_simp_106;
+    ibool_t          has_acc_conv_7_simp_105;
+    ierror_t         res_acc_conv_7_simp_105;
 } iprogram_0_t;
 
 iint_t size_of_state_iprogram_0 ()
@@ -742,974 +678,883 @@ iint_t size_of_state_iprogram_0 ()
 #line 1 "compute function #0 - repl"
 void iprogram_0(iprogram_0_t *s)
 {
-    ierror_t         flat_57_simp_326;
-    idouble_t        flat_57_simp_327;
-    ierror_t         flat_57_simp_328;
-    idouble_t        flat_57_simp_329;
-    ierror_t         flat_56_simp_324;
-    idouble_t        flat_56_simp_325;
-    ierror_t         flat_1_simp_131;
-    idouble_t        flat_1_simp_134;
-    idouble_t        flat_1_simp_132;
-    ierror_t         flat_1_simp_133;
-    iint_t           flat_0_simp_130;
-    idouble_t        flat_56_simp_319;
-    ierror_t         flat_56_simp_318;
-    ierror_t         flat_21_simp_217;
-    ierror_t         flat_21_simp_214;
-    idouble_t        flat_21_simp_216;
-    idouble_t        flat_21_simp_215;
-    idouble_t        flat_21_simp_218;
-    idouble_t        flat_21_simp_219;
-    ierror_t         flat_20_simp_212;
-    idouble_t        flat_20_simp_211;
-    ierror_t         flat_20_simp_210;
-    idouble_t        flat_20_simp_213;
-    iint_t           acc_conv_56_simp_93;
-    ierror_t         acc_conv_56_simp_92;
-    istring_t        flat_30_simp_241;
-    ierror_t         flat_30_simp_240;
-    ierror_t         flat_31_simp_244;
-    ibool_t          flat_31_simp_243;
-    ierror_t         flat_31_simp_242;
-    ibool_t          flat_31_simp_245;
-    ierror_t         flat_33_simp_252;
-    iint_t           flat_33_simp_253;
-    ierror_t         flat_33_simp_254;
-    iint_t           flat_33_simp_255;
-    ierror_t         flat_41_simp_316;
-    idouble_t        flat_41_simp_317;
-    ierror_t         flat_40_simp_314;
-    idouble_t        flat_40_simp_315;
-    ierror_t         flat_40_simp_312;
-    idouble_t        flat_40_simp_313;
-    idouble_t        flat_35_simp_359;
-    ierror_t         flat_35_simp_358;
-    ierror_t         flat_34_simp_278;
-    idouble_t        flat_34_simp_279;
-    idouble_t        flat_34_simp_277;
-    ierror_t         flat_34_simp_276;
-    idouble_t        flat_4_simp_166;
-    ierror_t         flat_4_simp_163;
-    ierror_t         flat_4_simp_165;
-    idouble_t        flat_4_simp_164;
-    ierror_t         flat_5_simp_167;
-    ierror_t         flat_5_simp_169;
-    iint_t           flat_5_simp_168;
-    idouble_t        flat_43_simp_338;
-    ierror_t         flat_43_simp_339;
-    ierror_t         flat_43_simp_336;
-    idouble_t        flat_43_simp_337;
-    ierror_t         flat_41_simp_330;
-    idouble_t        flat_41_simp_331;
-    ierror_t         flat_42_simp_332;
-    idouble_t        flat_42_simp_333;
-    ierror_t         flat_42_simp_334;
-    idouble_t        flat_42_simp_335;
-    iint_t           flat_5_simp_170;
-    ierror_t         flat_6_simp_171;
-    idouble_t        flat_6_simp_172;
-    ierror_t         flat_6_simp_173;
-    idouble_t        flat_6_simp_174;
-    idouble_t        elem_conv_5_simp_136;
-    ierror_t         elem_conv_5_simp_135;
-    ierror_t         flat_2_simp_141;
-    idouble_t        flat_2_simp_144;
-    idouble_t        flat_2_simp_142;
-    ierror_t         flat_2_simp_143;
-    iint_t           flat_3_simp_148;
-    ierror_t         flat_3_simp_145;
-    ierror_t         flat_3_simp_147;
-    iint_t           flat_3_simp_146;
-    idouble_t        flat_39_simp_309;
-    ierror_t         flat_39_simp_308;
-    idouble_t        flat_35_simp_301;
-    idouble_t        flat_35_simp_302;
-    idouble_t        flat_35_simp_303;
-    ierror_t         flat_35_simp_300;
-    ierror_t         flat_38_simp_304;
-    idouble_t        flat_38_simp_307;
-    idouble_t        flat_38_simp_305;
-    ierror_t         flat_38_simp_306;
-    idouble_t        conv_9_simp_186;
-    ierror_t         conv_9_simp_185;
-    ierror_t         flat_30_simp_238;
-    istring_t        flat_30_simp_239;
-    iint_t           flat_0_simp_128;
-    ierror_t         flat_0_simp_129;
-    ierror_t         flat_0_simp_127;
-    idouble_t        flat_35_simp_360;
-    idouble_t        flat_35_simp_361;
-    ierror_t         acc_conv_55_simp_100;
-    iint_t           acc_conv_55_simp_101;
-    ierror_t         flat_92_simp_379;
-    idouble_t        flat_91_simp_376;
-    ierror_t         flat_91_simp_375;
-    ierror_t         flat_91_simp_377;
-    idouble_t        flat_91_simp_378;
-    idouble_t        flat_8_simp_237;
-    idouble_t        flat_8_simp_236;
-    ierror_t         flat_8_simp_235;
-    ierror_t         flat_15_simp_199;
-    idouble_t        flat_19_simp_209;
-    idouble_t        flat_19_simp_207;
-    ierror_t         flat_19_simp_206;
-    ierror_t         flat_19_simp_208;
-    idouble_t        flat_18_simp_205;
-    ierror_t         flat_18_simp_204;
-    ierror_t         flat_18_simp_202;
-    idouble_t        flat_18_simp_203;
-    idouble_t        flat_15_simp_200;
-    idouble_t        flat_15_simp_201;
-    idouble_t        flat_62_simp_321;
-    ierror_t         flat_62_simp_320;
-    idouble_t        flat_62_simp_323;
-    ierror_t         flat_62_simp_322;
-    idouble_t        flat_7_simp_184;
-    ierror_t         flat_7_simp_181;
-    ierror_t         flat_7_simp_183;
-    idouble_t        flat_7_simp_182;
-    idouble_t        acc_s_reify_6_conv_10_simp_107;
-    ierror_t         acc_s_reify_6_conv_10_simp_106;
-    idouble_t        acc_s_reify_6_conv_10_simp_108;
-    idouble_t        flat_8_simp_198;
-    ierror_t         flat_8_simp_196;
-    idouble_t        flat_8_simp_197;
-    idouble_t        acc_a_conv_61_simp_80;
-    idouble_t        acc_a_conv_61_simp_81;
-    idouble_t        acc_conv_60_simp_83;
-    ierror_t         acc_conv_60_simp_82;
-    idouble_t        flat_15_simp_221;
-    ierror_t         flat_15_simp_220;
-    idouble_t        flat_15_simp_222;
-    idouble_t        flat_11_simp_225;
-    idouble_t        flat_11_simp_224;
-    ierror_t         flat_11_simp_223;
-    idouble_t        flat_12_simp_227;
-    ierror_t         flat_12_simp_226;
-    ierror_t         flat_12_simp_229;
-    idouble_t        flat_12_simp_228;
-    ierror_t         conv_5_simp_175;
-    idouble_t        conv_5_simp_176;
-    idouble_t        acc_a_conv_61_simp_79;
-    ierror_t         acc_a_conv_61_simp_78;
-    ierror_t         flat_88_simp_387;
-    idouble_t        flat_88_simp_388;
-    ierror_t         flat_11_simp_232;
-    idouble_t        flat_11_simp_233;
-    idouble_t        flat_11_simp_234;
-    idouble_t        flat_12_simp_230;
-    idouble_t        flat_12_simp_231;
-    ierror_t         conv_55_simp_256;
-    iint_t           conv_55_simp_257;
-    idouble_t        s_reify_6_conv_10_simp_367;
-    ierror_t         s_reify_6_conv_10_simp_366;
-    idouble_t        flat_92_simp_382;
-    idouble_t        flat_92_simp_380;
-    ierror_t         flat_92_simp_381;
-    idouble_t        flat_93_simp_384;
-    ierror_t         flat_93_simp_385;
-    ierror_t         flat_93_simp_383;
-    idouble_t        flat_93_simp_386;
-    idouble_t        flat_88_simp_374;
-    ierror_t         flat_88_simp_373;
-    idouble_t        flat_87_simp_372;
-    ierror_t         flat_87_simp_371;
-    idouble_t        flat_87_simp_370;
-    ierror_t         elem_conv_55_simp_149;
-    ierror_t         elem_conv_56_simp_155;
-    iint_t           elem_conv_56_simp_156;
-    iint_t           elem_conv_55_simp_150;
-    ierror_t         flat_87_simp_369;
-    ierror_t         s_reify_6_conv_10_simp_193;
-    idouble_t        s_reify_6_conv_10_simp_195;
-    idouble_t        s_reify_6_conv_10_simp_194;
-    ierror_t         conv_56_simp_268;
-    iint_t           conv_56_simp_269;
-    idouble_t        a_conv_61_simp_365;
-    ierror_t         a_conv_61_simp_362;
-    idouble_t        a_conv_61_simp_363;
-    idouble_t        flat_47_simp_352;
-    idouble_t        flat_47_simp_351;
-    idouble_t        flat_47_simp_353;
-    ierror_t         flat_47_simp_350;
-    idouble_t        flat_44_simp_357;
-    ierror_t         flat_44_simp_354;
-    idouble_t        flat_44_simp_355;
-    idouble_t        flat_44_simp_356;
-    idouble_t        flat_39_simp_311;
-    ierror_t         flat_39_simp_310;
-    ierror_t         flat_47_simp_346;
-    idouble_t        flat_47_simp_347;
-    idouble_t        flat_47_simp_348;
-    idouble_t        flat_47_simp_349;
-    idouble_t        flat_44_simp_344;
-    idouble_t        flat_44_simp_343;
-    ierror_t         flat_44_simp_342;
-    idouble_t        flat_44_simp_345;
-    idouble_t        flat_43_simp_341;
-    idouble_t        flat_43_simp_340;
-    ierror_t         acc_conv_9_simp_109;
-    idouble_t        acc_conv_9_simp_110;
-    idouble_t        acc_conv_5_simp_118;
-    ierror_t         acc_conv_5_simp_117;
-    ibool_t          flat_32;
-    idouble_t        a_conv_61_simp_297;
-    idouble_t        a_conv_61_simp_299;
-    idouble_t        a_conv_61_simp_298;
-    ierror_t         a_conv_61_simp_296;
-    idouble_t        conv_60_simp_287;
-    ierror_t         conv_60_simp_286;
+    idouble_t        flat_39_simp_289;
+    idouble_t        flat_39_simp_288;
+    idouble_t        flat_39_simp_287;
+    ierror_t         flat_39_simp_286;
+    idouble_t        flat_38_simp_285;
+    idouble_t        flat_38_simp_281;
+    idouble_t        flat_38_simp_284;
+    idouble_t        flat_38_simp_282;
+    ierror_t         flat_38_simp_280;
+    ierror_t         flat_38_simp_283;
+    idouble_t        flat_16_simp_162;
+    idouble_t        flat_16_simp_163;
+    idouble_t        flat_16_simp_160;
+    ierror_t         flat_16_simp_161;
+    ierror_t         flat_10_simp_164;
+    idouble_t        flat_10_simp_165;
+    idouble_t        flat_10_simp_166;
+    ierror_t         flat_1_simp_117;
+    ierror_t         flat_1_simp_115;
+    idouble_t        flat_1_simp_116;
+    idouble_t        flat_1_simp_118;
+    ierror_t         flat_0_simp_113;
+    iint_t           flat_0_simp_114;
+    ierror_t         flat_0_simp_111;
+    iint_t           flat_0_simp_112;
+    ierror_t         flat_39_simp_298;
+    idouble_t        flat_39_simp_299;
+    ierror_t         acc_conv_58_simp_80;
+    iint_t           acc_conv_58_simp_81;
+    ierror_t         acc_conv_57_simp_88;
+    iint_t           acc_conv_57_simp_89;
+    ierror_t         flat_29_simp_222;
+    idouble_t        flat_29_simp_223;
+    ierror_t         flat_29_simp_220;
+    idouble_t        flat_29_simp_221;
+    idouble_t        flat_30_simp_245;
+    idouble_t        flat_30_simp_246;
+    ierror_t         flat_30_simp_244;
+    idouble_t        flat_30_simp_247;
+    idouble_t        flat_33_simp_249;
+    ierror_t         flat_33_simp_248;
+    idouble_t        flat_14_simp_153;
+    ierror_t         flat_14_simp_150;
+    ierror_t         flat_14_simp_152;
+    idouble_t        flat_14_simp_151;
+    ierror_t         flat_15_simp_156;
+    idouble_t        flat_15_simp_155;
+    ierror_t         flat_15_simp_154;
+    idouble_t        flat_15_simp_157;
+    ierror_t         flat_16_simp_158;
+    idouble_t        flat_16_simp_159;
+    idouble_t        flat_13_simp_149;
+    ierror_t         flat_13_simp_148;
+    ierror_t         flat_13_simp_146;
+    idouble_t        flat_13_simp_147;
+    idouble_t        flat_10_simp_144;
+    idouble_t        flat_10_simp_145;
+    ierror_t         flat_10_simp_143;
+    idouble_t        flat_35_simp_257;
+    ierror_t         flat_35_simp_258;
+    idouble_t        flat_35_simp_259;
+    ierror_t         flat_35_simp_256;
+    ierror_t         flat_33_simp_250;
+    idouble_t        flat_33_simp_251;
+    idouble_t        flat_34_simp_255;
+    idouble_t        flat_34_simp_253;
+    ierror_t         flat_34_simp_254;
+    ierror_t         flat_34_simp_252;
+    istring_t        flat_25_simp_183;
+    ierror_t         flat_25_simp_182;
+    istring_t        flat_25_simp_185;
+    ierror_t         flat_25_simp_184;
+    ibool_t          flat_26_simp_187;
+    ierror_t         flat_26_simp_186;
+    ibool_t          flat_26_simp_189;
+    ierror_t         flat_26_simp_188;
+    idouble_t        flat_6_simp_169;
+    idouble_t        flat_6_simp_168;
+    ierror_t         flat_6_simp_167;
+    ierror_t         flat_37_simp_278;
+    idouble_t        flat_37_simp_279;
+    ierror_t         flat_37_simp_276;
+    idouble_t        flat_37_simp_277;
+    idouble_t        flat_36_simp_275;
+    ierror_t         flat_36_simp_274;
+    ierror_t         flat_3_simp_179;
+    ierror_t         flat_36_simp_260;
+    idouble_t        flat_36_simp_261;
+    idouble_t        flat_7_simp_174;
+    idouble_t        flat_7_simp_175;
+    idouble_t        flat_7_simp_172;
+    ierror_t         flat_7_simp_173;
+    ierror_t         flat_7_simp_170;
+    idouble_t        flat_7_simp_171;
+    ierror_t         flat_6_simp_176;
+    idouble_t        flat_6_simp_177;
+    idouble_t        flat_6_simp_178;
+    ierror_t         flat_3_simp_140;
+    idouble_t        flat_3_simp_142;
+    idouble_t        flat_3_simp_141;
+    idouble_t        flat_30_simp_304;
+    idouble_t        flat_30_simp_305;
+    idouble_t        flat_30_simp_303;
+    ierror_t         flat_30_simp_302;
+    idouble_t        flat_39_simp_301;
+    idouble_t        flat_39_simp_300;
+    idouble_t        acc_s_reify_6_conv_12_simp_95;
+    ierror_t         acc_s_reify_6_conv_12_simp_94;
+    idouble_t        acc_s_reify_6_conv_12_simp_96;
+    ierror_t         flat_28_simp_196;
+    iint_t           flat_28_simp_197;
+    ierror_t         flat_28_simp_198;
+    iint_t           flat_28_simp_199;
+    idouble_t        flat_2_simp_126;
+    ierror_t         flat_2_simp_125;
+    ierror_t         flat_2_simp_127;
+    idouble_t        flat_2_simp_128;
+    ierror_t         conv_11_simp_129;
+    ierror_t         flat_83_simp_331;
+    idouble_t        flat_83_simp_332;
+    idouble_t        flat_88_simp_330;
+    ierror_t         flat_82_simp_315;
+    idouble_t        flat_82_simp_314;
+    idouble_t        flat_82_simp_316;
+    ierror_t         flat_82_simp_313;
+    idouble_t        flat_83_simp_318;
+    ierror_t         flat_83_simp_317;
+    ierror_t         flat_86_simp_319;
+    ierror_t         conv_7_simp_119;
+    idouble_t        flat_87_simp_326;
+    ierror_t         flat_87_simp_323;
+    idouble_t        flat_87_simp_324;
+    ierror_t         flat_87_simp_325;
+    idouble_t        flat_86_simp_320;
+    ierror_t         flat_86_simp_321;
+    idouble_t        flat_86_simp_322;
+    idouble_t        flat_88_simp_328;
+    ierror_t         flat_88_simp_329;
+    ierror_t         flat_88_simp_327;
+    idouble_t        conv_7_simp_120;
+    idouble_t        flat_3_simp_181;
+    idouble_t        flat_3_simp_180;
+    idouble_t        conv_11_simp_130;
+    ierror_t         acc_conv_62_simp_70;
+    idouble_t        acc_conv_62_simp_71;
+    idouble_t        s_reify_6_conv_12_simp_311;
+    ierror_t         s_reify_6_conv_12_simp_310;
+    ierror_t         acc_a_conv_63_simp_66;
+    idouble_t        acc_a_conv_63_simp_67;
+    idouble_t        acc_a_conv_63_simp_68;
+    idouble_t        acc_a_conv_63_simp_69;
+    ierror_t         acc_conv_11_simp_97;
+    idouble_t        acc_conv_11_simp_98;
+    ierror_t         conv_58_simp_212;
+    iint_t           conv_58_simp_213;
+    iint_t           conv_57_simp_201;
+    ierror_t         conv_57_simp_200;
+    idouble_t        conv_62_simp_231;
+    ierror_t         conv_62_simp_230;
+    idouble_t        a_conv_63_simp_307;
+    ierror_t         a_conv_63_simp_306;
+    idouble_t        a_conv_63_simp_309;
+    idouble_t        s_reify_6_conv_12_simp_139;
+    idouble_t        s_reify_6_conv_12_simp_138;
+    ierror_t         s_reify_6_conv_12_simp_137;
+    idouble_t        flat_42_simp_293;
+    idouble_t        flat_42_simp_292;
+    idouble_t        flat_42_simp_291;
+    ierror_t         flat_42_simp_290;
+    idouble_t        flat_42_simp_297;
+    idouble_t        flat_42_simp_296;
+    idouble_t        flat_42_simp_295;
+    ierror_t         flat_42_simp_294;
+    ierror_t         flat_57_simp_264;
+    ierror_t         flat_57_simp_266;
+    idouble_t        flat_57_simp_265;
+    idouble_t        flat_57_simp_267;
+    ierror_t         flat_51_simp_262;
+    ierror_t         flat_51_simp_268;
+    idouble_t        flat_51_simp_269;
+    idouble_t        flat_51_simp_263;
+    idouble_t        flat_52_simp_271;
+    ierror_t         flat_52_simp_272;
+    idouble_t        flat_52_simp_273;
+    ierror_t         flat_52_simp_270;
+    idouble_t        acc_conv_7_simp_106;
+    ierror_t         acc_conv_7_simp_105;
+    ibool_t          flat_27;
+    idouble_t        a_conv_63_simp_242;
+    ierror_t         a_conv_63_simp_240;
+    idouble_t        a_conv_63_simp_243;
+    idouble_t        a_conv_63_simp_241;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_1                   = s->conv_1;
+    itime_t          conv_3                   = s->conv_3;
 
-    acc_a_conv_61_simp_78                     = ierror_not_an_error;                  /* init */
-    acc_a_conv_61_simp_79                     = 0.0;                                  /* init */
-    acc_a_conv_61_simp_80                     = 0.0;                                  /* init */
-    acc_a_conv_61_simp_81                     = 0.0;                                  /* init */
-    acc_conv_60_simp_82                       = ierror_not_an_error;                  /* init */
-    acc_conv_60_simp_83                       = 0.0;                                  /* init */
-    acc_conv_56_simp_92                       = ierror_not_an_error;                  /* init */
-    acc_conv_56_simp_93                       = 0;                                    /* init */
-    acc_conv_55_simp_100                      = ierror_not_an_error;                  /* init */
-    acc_conv_55_simp_101                      = 0;                                    /* init */
-    acc_s_reify_6_conv_10_simp_106            = ierror_not_an_error;                  /* init */
-    acc_s_reify_6_conv_10_simp_107            = 0.0;                                  /* init */
-    acc_s_reify_6_conv_10_simp_108            = 0.0;                                  /* init */
-    acc_conv_9_simp_109                       = ierror_not_an_error;                  /* init */
-    acc_conv_9_simp_110                       = 0.0;                                  /* init */
-    acc_conv_5_simp_117                       = ierror_not_an_error;                  /* init */
-    acc_conv_5_simp_118                       = 0.0;                                  /* init */
-    flat_0_simp_127                           = ierror_not_an_error;                  /* init */
-    flat_0_simp_128                           = 0;                                    /* init */
-    flat_0_simp_127                           = ierror_not_an_error;                  /* write */
-    flat_0_simp_128                           = 0;                                    /* write */
-    flat_0_simp_129                           = flat_0_simp_127;                      /* read */
-    flat_0_simp_130                           = flat_0_simp_128;                      /* read */
-    flat_1_simp_131                           = ierror_not_an_error;                  /* init */
-    flat_1_simp_132                           = 0.0;                                  /* init */
+    acc_a_conv_63_simp_66                     = ierror_not_an_error;                  /* init */
+    acc_a_conv_63_simp_67                     = 0.0;                                  /* init */
+    acc_a_conv_63_simp_68                     = 0.0;                                  /* init */
+    acc_a_conv_63_simp_69                     = 0.0;                                  /* init */
+    acc_conv_62_simp_70                       = ierror_not_an_error;                  /* init */
+    acc_conv_62_simp_71                       = 0.0;                                  /* init */
+    acc_conv_58_simp_80                       = ierror_not_an_error;                  /* init */
+    acc_conv_58_simp_81                       = 0;                                    /* init */
+    acc_conv_57_simp_88                       = ierror_not_an_error;                  /* init */
+    acc_conv_57_simp_89                       = 0;                                    /* init */
+    acc_s_reify_6_conv_12_simp_94             = ierror_not_an_error;                  /* init */
+    acc_s_reify_6_conv_12_simp_95             = 0.0;                                  /* init */
+    acc_s_reify_6_conv_12_simp_96             = 0.0;                                  /* init */
+    acc_conv_11_simp_97                       = ierror_not_an_error;                  /* init */
+    acc_conv_11_simp_98                       = 0.0;                                  /* init */
+    acc_conv_7_simp_105                       = ierror_not_an_error;                  /* init */
+    acc_conv_7_simp_106                       = 0.0;                                  /* init */
+    acc_s_reify_6_conv_12_simp_94             = ierror_fold1_no_value;                /* write */
+    acc_s_reify_6_conv_12_simp_95             = 0.0;                                  /* write */
+    acc_s_reify_6_conv_12_simp_96             = 0.0;                                  /* write */
+    acc_a_conv_63_simp_66                     = ierror_not_an_error;                  /* write */
+    acc_a_conv_63_simp_67                     = 0.0;                                  /* write */
+    acc_a_conv_63_simp_68                     = 0.0;                                  /* write */
+    acc_a_conv_63_simp_69                     = 0.0;                                  /* write */
     
-    if (ierror_eq (flat_0_simp_129, ierror_not_an_error)) {
-        flat_1_simp_131                       = ierror_not_an_error;                  /* write */
-        flat_1_simp_132                       = iint_extend (flat_0_simp_130);        /* write */
-    } else {
-        flat_1_simp_131                       = flat_0_simp_129;                      /* write */
-        flat_1_simp_132                       = 0.0;                                  /* write */
+    if (s->has_acc_a_conv_63_simp_66) {
+        acc_a_conv_63_simp_66                 = s->res_acc_a_conv_63_simp_66;         /* load */
     }
     
-    flat_1_simp_133                           = flat_1_simp_131;                      /* read */
-    flat_1_simp_134                           = flat_1_simp_132;                      /* read */
-    acc_conv_5_simp_117                       = flat_1_simp_133;                      /* write */
-    acc_conv_5_simp_118                       = flat_1_simp_134;                      /* write */
-    elem_conv_5_simp_135                      = acc_conv_5_simp_117;                  /* read */
-    elem_conv_5_simp_136                      = acc_conv_5_simp_118;                  /* read */
-    flat_2_simp_141                           = ierror_not_an_error;                  /* init */
-    flat_2_simp_142                           = 0.0;                                  /* init */
-    
-    if (ierror_eq (elem_conv_5_simp_135, ierror_not_an_error)) {
-        flat_2_simp_141                       = ierror_not_an_error;                  /* write */
-        flat_2_simp_142                       = elem_conv_5_simp_136;                 /* write */
-    } else {
-        flat_2_simp_141                       = elem_conv_5_simp_135;                 /* write */
-        flat_2_simp_142                       = 0.0;                                  /* write */
+    if (s->has_acc_a_conv_63_simp_67) {
+        acc_a_conv_63_simp_67                 = s->res_acc_a_conv_63_simp_67;         /* load */
     }
     
-    flat_2_simp_143                           = flat_2_simp_141;                      /* read */
-    flat_2_simp_144                           = flat_2_simp_142;                      /* read */
-    acc_conv_9_simp_109                       = flat_2_simp_143;                      /* write */
-    acc_conv_9_simp_110                       = flat_2_simp_144;                      /* write */
-    acc_s_reify_6_conv_10_simp_106            = ierror_fold1_no_value;                /* write */
-    acc_s_reify_6_conv_10_simp_107            = 0.0;                                  /* write */
-    acc_s_reify_6_conv_10_simp_108            = 0.0;                                  /* write */
-    flat_3_simp_145                           = ierror_not_an_error;                  /* init */
-    flat_3_simp_146                           = 0;                                    /* init */
-    flat_3_simp_145                           = ierror_not_an_error;                  /* write */
-    flat_3_simp_146                           = 0;                                    /* write */
-    flat_3_simp_147                           = flat_3_simp_145;                      /* read */
-    flat_3_simp_148                           = flat_3_simp_146;                      /* read */
-    acc_conv_55_simp_100                      = flat_3_simp_147;                      /* write */
-    acc_conv_55_simp_101                      = flat_3_simp_148;                      /* write */
-    elem_conv_55_simp_149                     = acc_conv_55_simp_100;                 /* read */
-    elem_conv_55_simp_150                     = acc_conv_55_simp_101;                 /* read */
-    acc_conv_56_simp_92                       = elem_conv_55_simp_149;                /* write */
-    acc_conv_56_simp_93                       = elem_conv_55_simp_150;                /* write */
-    elem_conv_56_simp_155                     = acc_conv_56_simp_92;                  /* read */
-    elem_conv_56_simp_156                     = acc_conv_56_simp_93;                  /* read */
-    flat_4_simp_163                           = ierror_not_an_error;                  /* init */
-    flat_4_simp_164                           = 0.0;                                  /* init */
-    
-    if (ierror_eq (elem_conv_56_simp_155, ierror_not_an_error)) {
-        flat_4_simp_163                       = ierror_not_an_error;                  /* write */
-        flat_4_simp_164                       = iint_extend (elem_conv_56_simp_156);  /* write */
-    } else {
-        flat_4_simp_163                       = elem_conv_56_simp_155;                /* write */
-        flat_4_simp_164                       = 0.0;                                  /* write */
+    if (s->has_acc_a_conv_63_simp_68) {
+        acc_a_conv_63_simp_68                 = s->res_acc_a_conv_63_simp_68;         /* load */
     }
     
-    flat_4_simp_165                           = flat_4_simp_163;                      /* read */
-    flat_4_simp_166                           = flat_4_simp_164;                      /* read */
-    acc_conv_60_simp_82                       = flat_4_simp_165;                      /* write */
-    acc_conv_60_simp_83                       = flat_4_simp_166;                      /* write */
-    acc_a_conv_61_simp_78                     = ierror_not_an_error;                  /* write */
-    acc_a_conv_61_simp_79                     = 0.0;                                  /* write */
-    acc_a_conv_61_simp_80                     = 0.0;                                  /* write */
-    acc_a_conv_61_simp_81                     = 0.0;                                  /* write */
-    
-    if (s->has_acc_a_conv_61_simp_78) {
-        acc_a_conv_61_simp_78                 = s->res_acc_a_conv_61_simp_78;         /* load */
+    if (s->has_acc_a_conv_63_simp_69) {
+        acc_a_conv_63_simp_69                 = s->res_acc_a_conv_63_simp_69;         /* load */
     }
     
-    if (s->has_acc_a_conv_61_simp_79) {
-        acc_a_conv_61_simp_79                 = s->res_acc_a_conv_61_simp_79;         /* load */
+    if (s->has_acc_conv_62_simp_70) {
+        acc_conv_62_simp_70                   = s->res_acc_conv_62_simp_70;           /* load */
     }
     
-    if (s->has_acc_a_conv_61_simp_80) {
-        acc_a_conv_61_simp_80                 = s->res_acc_a_conv_61_simp_80;         /* load */
+    if (s->has_acc_conv_62_simp_71) {
+        acc_conv_62_simp_71                   = s->res_acc_conv_62_simp_71;           /* load */
     }
     
-    if (s->has_acc_a_conv_61_simp_81) {
-        acc_a_conv_61_simp_81                 = s->res_acc_a_conv_61_simp_81;         /* load */
+    if (s->has_acc_conv_58_simp_80) {
+        acc_conv_58_simp_80                   = s->res_acc_conv_58_simp_80;           /* load */
     }
     
-    if (s->has_acc_conv_60_simp_82) {
-        acc_conv_60_simp_82                   = s->res_acc_conv_60_simp_82;           /* load */
+    if (s->has_acc_conv_58_simp_81) {
+        acc_conv_58_simp_81                   = s->res_acc_conv_58_simp_81;           /* load */
     }
     
-    if (s->has_acc_conv_60_simp_83) {
-        acc_conv_60_simp_83                   = s->res_acc_conv_60_simp_83;           /* load */
+    if (s->has_acc_conv_57_simp_88) {
+        acc_conv_57_simp_88                   = s->res_acc_conv_57_simp_88;           /* load */
     }
     
-    if (s->has_acc_conv_56_simp_92) {
-        acc_conv_56_simp_92                   = s->res_acc_conv_56_simp_92;           /* load */
+    if (s->has_acc_conv_57_simp_89) {
+        acc_conv_57_simp_89                   = s->res_acc_conv_57_simp_89;           /* load */
     }
     
-    if (s->has_acc_conv_56_simp_93) {
-        acc_conv_56_simp_93                   = s->res_acc_conv_56_simp_93;           /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_94) {
+        acc_s_reify_6_conv_12_simp_94         = s->res_acc_s_reify_6_conv_12_simp_94; /* load */
     }
     
-    if (s->has_acc_conv_55_simp_100) {
-        acc_conv_55_simp_100                  = s->res_acc_conv_55_simp_100;          /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_95) {
+        acc_s_reify_6_conv_12_simp_95         = s->res_acc_s_reify_6_conv_12_simp_95; /* load */
     }
     
-    if (s->has_acc_conv_55_simp_101) {
-        acc_conv_55_simp_101                  = s->res_acc_conv_55_simp_101;          /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_96) {
+        acc_s_reify_6_conv_12_simp_96         = s->res_acc_s_reify_6_conv_12_simp_96; /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_10_simp_106) {
-        acc_s_reify_6_conv_10_simp_106        = s->res_acc_s_reify_6_conv_10_simp_106; /* load */
+    if (s->has_acc_conv_11_simp_97) {
+        acc_conv_11_simp_97                   = s->res_acc_conv_11_simp_97;           /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_10_simp_107) {
-        acc_s_reify_6_conv_10_simp_107        = s->res_acc_s_reify_6_conv_10_simp_107; /* load */
+    if (s->has_acc_conv_11_simp_98) {
+        acc_conv_11_simp_98                   = s->res_acc_conv_11_simp_98;           /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_10_simp_108) {
-        acc_s_reify_6_conv_10_simp_108        = s->res_acc_s_reify_6_conv_10_simp_108; /* load */
+    if (s->has_acc_conv_7_simp_105) {
+        acc_conv_7_simp_105                   = s->res_acc_conv_7_simp_105;           /* load */
     }
     
-    if (s->has_acc_conv_9_simp_109) {
-        acc_conv_9_simp_109                   = s->res_acc_conv_9_simp_109;           /* load */
-    }
-    
-    if (s->has_acc_conv_9_simp_110) {
-        acc_conv_9_simp_110                   = s->res_acc_conv_9_simp_110;           /* load */
-    }
-    
-    if (s->has_acc_conv_5_simp_117) {
-        acc_conv_5_simp_117                   = s->res_acc_conv_5_simp_117;           /* load */
-    }
-    
-    if (s->has_acc_conv_5_simp_118) {
-        acc_conv_5_simp_118                   = s->res_acc_conv_5_simp_118;           /* load */
+    if (s->has_acc_conv_7_simp_106) {
+        acc_conv_7_simp_106                   = s->res_acc_conv_7_simp_106;           /* load */
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_389 = s->new_conv_0_simp_389;
-    const istring_t *const new_conv_0_simp_390 = s->new_conv_0_simp_390;
-    const iint_t    *const new_conv_0_simp_391 = s->new_conv_0_simp_391;
-    const itime_t   *const new_conv_0_simp_392 = s->new_conv_0_simp_392;
+    const ierror_t  *const new_conv_0_simp_333 = s->new_conv_0_simp_333;
+    const istring_t *const new_conv_0_simp_334 = s->new_conv_0_simp_334;
+    const iint_t    *const new_conv_0_simp_335 = s->new_conv_0_simp_335;
+    const itime_t   *const new_conv_0_simp_336 = s->new_conv_0_simp_336;
     
     for (iint_t i = 0; i < new_count; i++) {
-        ierror_t         conv_0_simp_389      = new_conv_0_simp_389[i];
-        istring_t        conv_0_simp_390      = new_conv_0_simp_390[i];
-        iint_t           conv_0_simp_391      = new_conv_0_simp_391[i];
-        itime_t          conv_0_simp_392      = new_conv_0_simp_392[i];
-        flat_5_simp_167                       = ierror_not_an_error;                  /* init */
-        flat_5_simp_168                       = 0;                                    /* init */
+        iint_t           conv_1               = i;
+        itime_t          conv_2               = new_conv_0_simp_336[i];
+        ierror_t         conv_0_simp_333      = new_conv_0_simp_333[i];
+        istring_t        conv_0_simp_334      = new_conv_0_simp_334[i];
+        iint_t           conv_0_simp_335      = new_conv_0_simp_335[i];
+        itime_t          conv_0_simp_336      = new_conv_0_simp_336[i];
+        flat_0_simp_111                       = ierror_not_an_error;                  /* init */
+        flat_0_simp_112                       = 0;                                    /* init */
         
-        if (ierror_eq (conv_0_simp_389, ierror_not_an_error)) {
-            flat_5_simp_167                   = ierror_not_an_error;                  /* write */
-            flat_5_simp_168                   = conv_0_simp_391;                      /* write */
+        if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
+            flat_0_simp_111                   = ierror_not_an_error;                  /* write */
+            flat_0_simp_112                   = conv_0_simp_335;                      /* write */
         } else {
-            flat_5_simp_167                   = conv_0_simp_389;                      /* write */
-            flat_5_simp_168                   = 0;                                    /* write */
+            flat_0_simp_111                   = conv_0_simp_333;                      /* write */
+            flat_0_simp_112                   = 0;                                    /* write */
         }
         
-        flat_5_simp_169                       = flat_5_simp_167;                      /* read */
-        flat_5_simp_170                       = flat_5_simp_168;                      /* read */
-        flat_6_simp_171                       = ierror_not_an_error;                  /* init */
-        flat_6_simp_172                       = 0.0;                                  /* init */
+        flat_0_simp_113                       = flat_0_simp_111;                      /* read */
+        flat_0_simp_114                       = flat_0_simp_112;                      /* read */
+        flat_1_simp_115                       = ierror_not_an_error;                  /* init */
+        flat_1_simp_116                       = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_5_simp_169, ierror_not_an_error)) {
-            flat_6_simp_171                   = ierror_not_an_error;                  /* write */
-            flat_6_simp_172                   = iint_extend (flat_5_simp_170);        /* write */
+        if (ierror_eq (flat_0_simp_113, ierror_not_an_error)) {
+            flat_1_simp_115                   = ierror_not_an_error;                  /* write */
+            flat_1_simp_116                   = iint_extend (flat_0_simp_114);        /* write */
         } else {
-            flat_6_simp_171                   = flat_5_simp_169;                      /* write */
-            flat_6_simp_172                   = 0.0;                                  /* write */
+            flat_1_simp_115                   = flat_0_simp_113;                      /* write */
+            flat_1_simp_116                   = 0.0;                                  /* write */
         }
         
-        flat_6_simp_173                       = flat_6_simp_171;                      /* read */
-        flat_6_simp_174                       = flat_6_simp_172;                      /* read */
-        acc_conv_5_simp_117                   = flat_6_simp_173;                      /* write */
-        acc_conv_5_simp_118                   = flat_6_simp_174;                      /* write */
-        conv_5_simp_175                       = acc_conv_5_simp_117;                  /* read */
-        conv_5_simp_176                       = acc_conv_5_simp_118;                  /* read */
-        flat_7_simp_181                       = ierror_not_an_error;                  /* init */
-        flat_7_simp_182                       = 0.0;                                  /* init */
+        flat_1_simp_117                       = flat_1_simp_115;                      /* read */
+        flat_1_simp_118                       = flat_1_simp_116;                      /* read */
+        acc_conv_7_simp_105                   = flat_1_simp_117;                      /* write */
+        acc_conv_7_simp_106                   = flat_1_simp_118;                      /* write */
+        conv_7_simp_119                       = acc_conv_7_simp_105;                  /* read */
+        conv_7_simp_120                       = acc_conv_7_simp_106;                  /* read */
+        flat_2_simp_125                       = ierror_not_an_error;                  /* init */
+        flat_2_simp_126                       = 0.0;                                  /* init */
         
-        if (ierror_eq (conv_5_simp_175, ierror_not_an_error)) {
-            flat_7_simp_181                   = ierror_not_an_error;                  /* write */
-            flat_7_simp_182                   = conv_5_simp_176;                      /* write */
+        if (ierror_eq (conv_7_simp_119, ierror_not_an_error)) {
+            flat_2_simp_125                   = ierror_not_an_error;                  /* write */
+            flat_2_simp_126                   = conv_7_simp_120;                      /* write */
         } else {
-            flat_7_simp_181                   = conv_5_simp_175;                      /* write */
-            flat_7_simp_182                   = 0.0;                                  /* write */
+            flat_2_simp_125                   = conv_7_simp_119;                      /* write */
+            flat_2_simp_126                   = 0.0;                                  /* write */
         }
         
-        flat_7_simp_183                       = flat_7_simp_181;                      /* read */
-        flat_7_simp_184                       = flat_7_simp_182;                      /* read */
-        acc_conv_9_simp_109                   = flat_7_simp_183;                      /* write */
-        acc_conv_9_simp_110                   = flat_7_simp_184;                      /* write */
-        conv_9_simp_185                       = acc_conv_9_simp_109;                  /* read */
-        conv_9_simp_186                       = acc_conv_9_simp_110;                  /* read */
-        s_reify_6_conv_10_simp_193            = acc_s_reify_6_conv_10_simp_106;       /* read */
-        s_reify_6_conv_10_simp_194            = acc_s_reify_6_conv_10_simp_107;       /* read */
-        s_reify_6_conv_10_simp_195            = acc_s_reify_6_conv_10_simp_108;       /* read */
-        flat_8_simp_196                       = ierror_not_an_error;                  /* init */
-        flat_8_simp_197                       = 0.0;                                  /* init */
-        flat_8_simp_198                       = 0.0;                                  /* init */
+        flat_2_simp_127                       = flat_2_simp_125;                      /* read */
+        flat_2_simp_128                       = flat_2_simp_126;                      /* read */
+        acc_conv_11_simp_97                   = flat_2_simp_127;                      /* write */
+        acc_conv_11_simp_98                   = flat_2_simp_128;                      /* write */
+        conv_11_simp_129                      = acc_conv_11_simp_97;                  /* read */
+        conv_11_simp_130                      = acc_conv_11_simp_98;                  /* read */
+        s_reify_6_conv_12_simp_137            = acc_s_reify_6_conv_12_simp_94;        /* read */
+        s_reify_6_conv_12_simp_138            = acc_s_reify_6_conv_12_simp_95;        /* read */
+        s_reify_6_conv_12_simp_139            = acc_s_reify_6_conv_12_simp_96;        /* read */
+        flat_3_simp_140                       = ierror_not_an_error;                  /* init */
+        flat_3_simp_141                       = 0.0;                                  /* init */
+        flat_3_simp_142                       = 0.0;                                  /* init */
         
-        if (ierror_eq (s_reify_6_conv_10_simp_193, ierror_not_an_error)) {
-            flat_15_simp_199                  = ierror_not_an_error;                  /* init */
-            flat_15_simp_200                  = 0.0;                                  /* init */
-            flat_15_simp_201                  = 0.0;                                  /* init */
+        if (ierror_eq (s_reify_6_conv_12_simp_137, ierror_not_an_error)) {
+            flat_10_simp_143                  = ierror_not_an_error;                  /* init */
+            flat_10_simp_144                  = 0.0;                                  /* init */
+            flat_10_simp_145                  = 0.0;                                  /* init */
             
-            if (ierror_eq (s_reify_6_conv_10_simp_193, ierror_not_an_error)) {
-                flat_18_simp_202              = ierror_not_an_error;                  /* init */
-                flat_18_simp_203              = 0.0;                                  /* init */
+            if (ierror_eq (s_reify_6_conv_12_simp_137, ierror_not_an_error)) {
+                flat_13_simp_146              = ierror_not_an_error;                  /* init */
+                flat_13_simp_147              = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_9_simp_185, ierror_not_an_error)) {
-                    flat_18_simp_202          = ierror_not_an_error;                  /* write */
-                    flat_18_simp_203          = idouble_sub (conv_9_simp_186, s_reify_6_conv_10_simp_194); /* write */
+                if (ierror_eq (conv_11_simp_129, ierror_not_an_error)) {
+                    flat_13_simp_146          = ierror_not_an_error;                  /* write */
+                    flat_13_simp_147          = idouble_sub (conv_11_simp_130, s_reify_6_conv_12_simp_138); /* write */
                 } else {
-                    flat_18_simp_202          = conv_9_simp_185;                      /* write */
-                    flat_18_simp_203          = 0.0;                                  /* write */
+                    flat_13_simp_146          = conv_11_simp_129;                     /* write */
+                    flat_13_simp_147          = 0.0;                                  /* write */
                 }
                 
-                flat_18_simp_204              = flat_18_simp_202;                     /* read */
-                flat_18_simp_205              = flat_18_simp_203;                     /* read */
-                flat_19_simp_206              = ierror_not_an_error;                  /* init */
-                flat_19_simp_207              = 0.0;                                  /* init */
+                flat_13_simp_148              = flat_13_simp_146;                     /* read */
+                flat_13_simp_149              = flat_13_simp_147;                     /* read */
+                flat_14_simp_150              = ierror_not_an_error;                  /* init */
+                flat_14_simp_151              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_18_simp_204, ierror_not_an_error)) {
-                    idouble_t        simp_729 = idouble_add (s_reify_6_conv_10_simp_195, 1.0); /* let */
-                    flat_19_simp_206          = ierror_not_an_error;                  /* write */
-                    flat_19_simp_207          = idouble_div (flat_18_simp_205, simp_729); /* write */
+                if (ierror_eq (flat_13_simp_148, ierror_not_an_error)) {
+                    idouble_t        simp_457 = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* let */
+                    flat_14_simp_150          = ierror_not_an_error;                  /* write */
+                    flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_457); /* write */
                 } else {
-                    flat_19_simp_206          = flat_18_simp_204;                     /* write */
-                    flat_19_simp_207          = 0.0;                                  /* write */
+                    flat_14_simp_150          = flat_13_simp_148;                     /* write */
+                    flat_14_simp_151          = 0.0;                                  /* write */
                 }
                 
-                flat_19_simp_208              = flat_19_simp_206;                     /* read */
-                flat_19_simp_209              = flat_19_simp_207;                     /* read */
-                flat_20_simp_210              = ierror_not_an_error;                  /* init */
-                flat_20_simp_211              = 0.0;                                  /* init */
+                flat_14_simp_152              = flat_14_simp_150;                     /* read */
+                flat_14_simp_153              = flat_14_simp_151;                     /* read */
+                flat_15_simp_154              = ierror_not_an_error;                  /* init */
+                flat_15_simp_155              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_19_simp_208, ierror_not_an_error)) {
-                    flat_20_simp_210          = ierror_not_an_error;                  /* write */
-                    flat_20_simp_211          = idouble_add (s_reify_6_conv_10_simp_194, flat_19_simp_209); /* write */
+                if (ierror_eq (flat_14_simp_152, ierror_not_an_error)) {
+                    flat_15_simp_154          = ierror_not_an_error;                  /* write */
+                    flat_15_simp_155          = idouble_add (s_reify_6_conv_12_simp_138, flat_14_simp_153); /* write */
                 } else {
-                    flat_20_simp_210          = flat_19_simp_208;                     /* write */
-                    flat_20_simp_211          = 0.0;                                  /* write */
+                    flat_15_simp_154          = flat_14_simp_152;                     /* write */
+                    flat_15_simp_155          = 0.0;                                  /* write */
                 }
                 
-                flat_20_simp_212              = flat_20_simp_210;                     /* read */
-                flat_20_simp_213              = flat_20_simp_211;                     /* read */
-                flat_21_simp_214              = ierror_not_an_error;                  /* init */
-                flat_21_simp_215              = 0.0;                                  /* init */
-                flat_21_simp_216              = 0.0;                                  /* init */
+                flat_15_simp_156              = flat_15_simp_154;                     /* read */
+                flat_15_simp_157              = flat_15_simp_155;                     /* read */
+                flat_16_simp_158              = ierror_not_an_error;                  /* init */
+                flat_16_simp_159              = 0.0;                                  /* init */
+                flat_16_simp_160              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_20_simp_212, ierror_not_an_error)) {
-                    flat_21_simp_214          = ierror_not_an_error;                  /* write */
-                    flat_21_simp_215          = flat_20_simp_213;                     /* write */
-                    flat_21_simp_216          = idouble_add (s_reify_6_conv_10_simp_195, 1.0); /* write */
+                if (ierror_eq (flat_15_simp_156, ierror_not_an_error)) {
+                    flat_16_simp_158          = ierror_not_an_error;                  /* write */
+                    flat_16_simp_159          = flat_15_simp_157;                     /* write */
+                    flat_16_simp_160          = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* write */
                 } else {
-                    flat_21_simp_214          = flat_20_simp_212;                     /* write */
-                    flat_21_simp_215          = 0.0;                                  /* write */
-                    flat_21_simp_216          = 0.0;                                  /* write */
+                    flat_16_simp_158          = flat_15_simp_156;                     /* write */
+                    flat_16_simp_159          = 0.0;                                  /* write */
+                    flat_16_simp_160          = 0.0;                                  /* write */
                 }
                 
-                flat_21_simp_217              = flat_21_simp_214;                     /* read */
-                flat_21_simp_218              = flat_21_simp_215;                     /* read */
-                flat_21_simp_219              = flat_21_simp_216;                     /* read */
-                flat_15_simp_199              = flat_21_simp_217;                     /* write */
-                flat_15_simp_200              = flat_21_simp_218;                     /* write */
-                flat_15_simp_201              = flat_21_simp_219;                     /* write */
+                flat_16_simp_161              = flat_16_simp_158;                     /* read */
+                flat_16_simp_162              = flat_16_simp_159;                     /* read */
+                flat_16_simp_163              = flat_16_simp_160;                     /* read */
+                flat_10_simp_143              = flat_16_simp_161;                     /* write */
+                flat_10_simp_144              = flat_16_simp_162;                     /* write */
+                flat_10_simp_145              = flat_16_simp_163;                     /* write */
             } else {
-                flat_15_simp_199              = s_reify_6_conv_10_simp_193;           /* write */
-                flat_15_simp_200              = 0.0;                                  /* write */
-                flat_15_simp_201              = 0.0;                                  /* write */
+                flat_10_simp_143              = s_reify_6_conv_12_simp_137;           /* write */
+                flat_10_simp_144              = 0.0;                                  /* write */
+                flat_10_simp_145              = 0.0;                                  /* write */
             }
             
-            flat_15_simp_220                  = flat_15_simp_199;                     /* read */
-            flat_15_simp_221                  = flat_15_simp_200;                     /* read */
-            flat_15_simp_222                  = flat_15_simp_201;                     /* read */
-            flat_8_simp_196                   = flat_15_simp_220;                     /* write */
-            flat_8_simp_197                   = flat_15_simp_221;                     /* write */
-            flat_8_simp_198                   = flat_15_simp_222;                     /* write */
+            flat_10_simp_164                  = flat_10_simp_143;                     /* read */
+            flat_10_simp_165                  = flat_10_simp_144;                     /* read */
+            flat_10_simp_166                  = flat_10_simp_145;                     /* read */
+            flat_3_simp_140                   = flat_10_simp_164;                     /* write */
+            flat_3_simp_141                   = flat_10_simp_165;                     /* write */
+            flat_3_simp_142                   = flat_10_simp_166;                     /* write */
         } else {
-            flat_11_simp_223                  = ierror_not_an_error;                  /* init */
-            flat_11_simp_224                  = 0.0;                                  /* init */
-            flat_11_simp_225                  = 0.0;                                  /* init */
+            flat_6_simp_167                   = ierror_not_an_error;                  /* init */
+            flat_6_simp_168                   = 0.0;                                  /* init */
+            flat_6_simp_169                   = 0.0;                                  /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, s_reify_6_conv_10_simp_193)) {
-                flat_12_simp_226              = ierror_not_an_error;                  /* init */
-                flat_12_simp_227              = 0.0;                                  /* init */
-                flat_12_simp_228              = 0.0;                                  /* init */
+            if (ierror_eq (ierror_fold1_no_value, s_reify_6_conv_12_simp_137)) {
+                flat_7_simp_170               = ierror_not_an_error;                  /* init */
+                flat_7_simp_171               = 0.0;                                  /* init */
+                flat_7_simp_172               = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_9_simp_185, ierror_not_an_error)) {
-                    flat_12_simp_226          = ierror_not_an_error;                  /* write */
-                    flat_12_simp_227          = conv_9_simp_186;                      /* write */
-                    flat_12_simp_228          = 1.0;                                  /* write */
+                if (ierror_eq (conv_11_simp_129, ierror_not_an_error)) {
+                    flat_7_simp_170           = ierror_not_an_error;                  /* write */
+                    flat_7_simp_171           = conv_11_simp_130;                     /* write */
+                    flat_7_simp_172           = 1.0;                                  /* write */
                 } else {
-                    flat_12_simp_226          = conv_9_simp_185;                      /* write */
-                    flat_12_simp_227          = 0.0;                                  /* write */
-                    flat_12_simp_228          = 0.0;                                  /* write */
+                    flat_7_simp_170           = conv_11_simp_129;                     /* write */
+                    flat_7_simp_171           = 0.0;                                  /* write */
+                    flat_7_simp_172           = 0.0;                                  /* write */
                 }
                 
-                flat_12_simp_229              = flat_12_simp_226;                     /* read */
-                flat_12_simp_230              = flat_12_simp_227;                     /* read */
-                flat_12_simp_231              = flat_12_simp_228;                     /* read */
-                flat_11_simp_223              = flat_12_simp_229;                     /* write */
-                flat_11_simp_224              = flat_12_simp_230;                     /* write */
-                flat_11_simp_225              = flat_12_simp_231;                     /* write */
+                flat_7_simp_173               = flat_7_simp_170;                      /* read */
+                flat_7_simp_174               = flat_7_simp_171;                      /* read */
+                flat_7_simp_175               = flat_7_simp_172;                      /* read */
+                flat_6_simp_167               = flat_7_simp_173;                      /* write */
+                flat_6_simp_168               = flat_7_simp_174;                      /* write */
+                flat_6_simp_169               = flat_7_simp_175;                      /* write */
             } else {
-                flat_11_simp_223              = s_reify_6_conv_10_simp_193;           /* write */
-                flat_11_simp_224              = 0.0;                                  /* write */
-                flat_11_simp_225              = 0.0;                                  /* write */
+                flat_6_simp_167               = s_reify_6_conv_12_simp_137;           /* write */
+                flat_6_simp_168               = 0.0;                                  /* write */
+                flat_6_simp_169               = 0.0;                                  /* write */
             }
             
-            flat_11_simp_232                  = flat_11_simp_223;                     /* read */
-            flat_11_simp_233                  = flat_11_simp_224;                     /* read */
-            flat_11_simp_234                  = flat_11_simp_225;                     /* read */
-            flat_8_simp_196                   = flat_11_simp_232;                     /* write */
-            flat_8_simp_197                   = flat_11_simp_233;                     /* write */
-            flat_8_simp_198                   = flat_11_simp_234;                     /* write */
+            flat_6_simp_176                   = flat_6_simp_167;                      /* read */
+            flat_6_simp_177                   = flat_6_simp_168;                      /* read */
+            flat_6_simp_178                   = flat_6_simp_169;                      /* read */
+            flat_3_simp_140                   = flat_6_simp_176;                      /* write */
+            flat_3_simp_141                   = flat_6_simp_177;                      /* write */
+            flat_3_simp_142                   = flat_6_simp_178;                      /* write */
         }
         
-        flat_8_simp_235                       = flat_8_simp_196;                      /* read */
-        flat_8_simp_236                       = flat_8_simp_197;                      /* read */
-        flat_8_simp_237                       = flat_8_simp_198;                      /* read */
-        acc_s_reify_6_conv_10_simp_106        = flat_8_simp_235;                      /* write */
-        acc_s_reify_6_conv_10_simp_107        = flat_8_simp_236;                      /* write */
-        acc_s_reify_6_conv_10_simp_108        = flat_8_simp_237;                      /* write */
-        flat_30_simp_238                      = ierror_not_an_error;                  /* init */
-        flat_30_simp_239                      = "";                                   /* init */
+        flat_3_simp_179                       = flat_3_simp_140;                      /* read */
+        flat_3_simp_180                       = flat_3_simp_141;                      /* read */
+        flat_3_simp_181                       = flat_3_simp_142;                      /* read */
+        acc_s_reify_6_conv_12_simp_94         = flat_3_simp_179;                      /* write */
+        acc_s_reify_6_conv_12_simp_95         = flat_3_simp_180;                      /* write */
+        acc_s_reify_6_conv_12_simp_96         = flat_3_simp_181;                      /* write */
+        flat_25_simp_182                      = ierror_not_an_error;                  /* init */
+        flat_25_simp_183                      = "";                                   /* init */
         
-        if (ierror_eq (conv_0_simp_389, ierror_not_an_error)) {
-            flat_30_simp_238                  = ierror_not_an_error;                  /* write */
-            flat_30_simp_239                  = conv_0_simp_390;                      /* write */
+        if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
+            flat_25_simp_182                  = ierror_not_an_error;                  /* write */
+            flat_25_simp_183                  = conv_0_simp_334;                      /* write */
         } else {
-            flat_30_simp_238                  = conv_0_simp_389;                      /* write */
-            flat_30_simp_239                  = "";                                   /* write */
+            flat_25_simp_182                  = conv_0_simp_333;                      /* write */
+            flat_25_simp_183                  = "";                                   /* write */
         }
         
-        flat_30_simp_240                      = flat_30_simp_238;                     /* read */
-        flat_30_simp_241                      = flat_30_simp_239;                     /* read */
-        flat_31_simp_242                      = ierror_not_an_error;                  /* init */
-        flat_31_simp_243                      = ifalse;                               /* init */
+        flat_25_simp_184                      = flat_25_simp_182;                     /* read */
+        flat_25_simp_185                      = flat_25_simp_183;                     /* read */
+        flat_26_simp_186                      = ierror_not_an_error;                  /* init */
+        flat_26_simp_187                      = ifalse;                               /* init */
         
-        if (ierror_eq (flat_30_simp_240, ierror_not_an_error)) {
-            flat_31_simp_242                  = ierror_not_an_error;                  /* write */
-            flat_31_simp_243                  = istring_eq (flat_30_simp_241, "torso"); /* write */
+        if (ierror_eq (flat_25_simp_184, ierror_not_an_error)) {
+            flat_26_simp_186                  = ierror_not_an_error;                  /* write */
+            flat_26_simp_187                  = istring_eq (flat_25_simp_185, "torso"); /* write */
         } else {
-            flat_31_simp_242                  = flat_30_simp_240;                     /* write */
-            flat_31_simp_243                  = ifalse;                               /* write */
+            flat_26_simp_186                  = flat_25_simp_184;                     /* write */
+            flat_26_simp_187                  = ifalse;                               /* write */
         }
         
-        flat_31_simp_244                      = flat_31_simp_242;                     /* read */
-        flat_31_simp_245                      = flat_31_simp_243;                     /* read */
-        flat_32                               = ifalse;                               /* init */
+        flat_26_simp_188                      = flat_26_simp_186;                     /* read */
+        flat_26_simp_189                      = flat_26_simp_187;                     /* read */
+        flat_27                               = ifalse;                               /* init */
         
-        if (ierror_eq (flat_31_simp_244, ierror_not_an_error)) {
-            flat_32                           = flat_31_simp_245;                     /* write */
+        if (ierror_eq (flat_26_simp_188, ierror_not_an_error)) {
+            flat_27                           = flat_26_simp_189;                     /* write */
         } else {
-            flat_32                           = itrue;                                /* write */
+            flat_27                           = itrue;                                /* write */
         }
         
-        flat_32                               = flat_32;                              /* read */
+        flat_27                               = flat_27;                              /* read */
         
-        if (flat_32) {
-            flat_33_simp_252                  = ierror_not_an_error;                  /* init */
-            flat_33_simp_253                  = 0;                                    /* init */
+        if (flat_27) {
+            flat_28_simp_196                  = ierror_not_an_error;                  /* init */
+            flat_28_simp_197                  = 0;                                    /* init */
             
-            if (ierror_eq (conv_0_simp_389, ierror_not_an_error)) {
-                flat_33_simp_252              = ierror_not_an_error;                  /* write */
-                flat_33_simp_253              = conv_0_simp_391;                      /* write */
+            if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
+                flat_28_simp_196              = ierror_not_an_error;                  /* write */
+                flat_28_simp_197              = conv_0_simp_335;                      /* write */
             } else {
-                flat_33_simp_252              = conv_0_simp_389;                      /* write */
-                flat_33_simp_253              = 0;                                    /* write */
+                flat_28_simp_196              = conv_0_simp_333;                      /* write */
+                flat_28_simp_197              = 0;                                    /* write */
             }
             
-            flat_33_simp_254                  = flat_33_simp_252;                     /* read */
-            flat_33_simp_255                  = flat_33_simp_253;                     /* read */
-            acc_conv_55_simp_100              = flat_33_simp_254;                     /* write */
-            acc_conv_55_simp_101              = flat_33_simp_255;                     /* write */
-            conv_55_simp_256                  = acc_conv_55_simp_100;                 /* read */
-            conv_55_simp_257                  = acc_conv_55_simp_101;                 /* read */
-            acc_conv_56_simp_92               = conv_55_simp_256;                     /* write */
-            acc_conv_56_simp_93               = conv_55_simp_257;                     /* write */
-            conv_56_simp_268                  = acc_conv_56_simp_92;                  /* read */
-            conv_56_simp_269                  = acc_conv_56_simp_93;                  /* read */
-            flat_34_simp_276                  = ierror_not_an_error;                  /* init */
-            flat_34_simp_277                  = 0.0;                                  /* init */
+            flat_28_simp_198                  = flat_28_simp_196;                     /* read */
+            flat_28_simp_199                  = flat_28_simp_197;                     /* read */
+            acc_conv_57_simp_88               = flat_28_simp_198;                     /* write */
+            acc_conv_57_simp_89               = flat_28_simp_199;                     /* write */
+            conv_57_simp_200                  = acc_conv_57_simp_88;                  /* read */
+            conv_57_simp_201                  = acc_conv_57_simp_89;                  /* read */
+            acc_conv_58_simp_80               = conv_57_simp_200;                     /* write */
+            acc_conv_58_simp_81               = conv_57_simp_201;                     /* write */
+            conv_58_simp_212                  = acc_conv_58_simp_80;                  /* read */
+            conv_58_simp_213                  = acc_conv_58_simp_81;                  /* read */
+            flat_29_simp_220                  = ierror_not_an_error;                  /* init */
+            flat_29_simp_221                  = 0.0;                                  /* init */
             
-            if (ierror_eq (conv_56_simp_268, ierror_not_an_error)) {
-                flat_34_simp_276              = ierror_not_an_error;                  /* write */
-                flat_34_simp_277              = iint_extend (conv_56_simp_269);       /* write */
+            if (ierror_eq (conv_58_simp_212, ierror_not_an_error)) {
+                flat_29_simp_220              = ierror_not_an_error;                  /* write */
+                flat_29_simp_221              = iint_extend (conv_58_simp_213);       /* write */
             } else {
-                flat_34_simp_276              = conv_56_simp_268;                     /* write */
-                flat_34_simp_277              = 0.0;                                  /* write */
+                flat_29_simp_220              = conv_58_simp_212;                     /* write */
+                flat_29_simp_221              = 0.0;                                  /* write */
             }
             
-            flat_34_simp_278                  = flat_34_simp_276;                     /* read */
-            flat_34_simp_279                  = flat_34_simp_277;                     /* read */
-            acc_conv_60_simp_82               = flat_34_simp_278;                     /* write */
-            acc_conv_60_simp_83               = flat_34_simp_279;                     /* write */
-            conv_60_simp_286                  = acc_conv_60_simp_82;                  /* read */
-            conv_60_simp_287                  = acc_conv_60_simp_83;                  /* read */
-            a_conv_61_simp_296                = acc_a_conv_61_simp_78;                /* read */
-            a_conv_61_simp_297                = acc_a_conv_61_simp_79;                /* read */
-            a_conv_61_simp_298                = acc_a_conv_61_simp_80;                /* read */
-            a_conv_61_simp_299                = acc_a_conv_61_simp_81;                /* read */
-            flat_35_simp_300                  = ierror_not_an_error;                  /* init */
-            flat_35_simp_301                  = 0.0;                                  /* init */
-            flat_35_simp_302                  = 0.0;                                  /* init */
-            flat_35_simp_303                  = 0.0;                                  /* init */
+            flat_29_simp_222                  = flat_29_simp_220;                     /* read */
+            flat_29_simp_223                  = flat_29_simp_221;                     /* read */
+            acc_conv_62_simp_70               = flat_29_simp_222;                     /* write */
+            acc_conv_62_simp_71               = flat_29_simp_223;                     /* write */
+            conv_62_simp_230                  = acc_conv_62_simp_70;                  /* read */
+            conv_62_simp_231                  = acc_conv_62_simp_71;                  /* read */
+            a_conv_63_simp_240                = acc_a_conv_63_simp_66;                /* read */
+            a_conv_63_simp_241                = acc_a_conv_63_simp_67;                /* read */
+            a_conv_63_simp_242                = acc_a_conv_63_simp_68;                /* read */
+            a_conv_63_simp_243                = acc_a_conv_63_simp_69;                /* read */
+            flat_30_simp_244                  = ierror_not_an_error;                  /* init */
+            flat_30_simp_245                  = 0.0;                                  /* init */
+            flat_30_simp_246                  = 0.0;                                  /* init */
+            flat_30_simp_247                  = 0.0;                                  /* init */
             
-            if (ierror_eq (a_conv_61_simp_296, ierror_not_an_error)) {
-                idouble_t        nn_conv_68   = idouble_add (a_conv_61_simp_297, 1.0); /* let */
-                flat_38_simp_304              = ierror_not_an_error;                  /* init */
-                flat_38_simp_305              = 0.0;                                  /* init */
+            if (ierror_eq (a_conv_63_simp_240, ierror_not_an_error)) {
+                idouble_t        nn_conv_70   = idouble_add (a_conv_63_simp_241, 1.0); /* let */
+                flat_33_simp_248              = ierror_not_an_error;                  /* init */
+                flat_33_simp_249              = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_60_simp_286, ierror_not_an_error)) {
-                    flat_38_simp_304          = ierror_not_an_error;                  /* write */
-                    flat_38_simp_305          = idouble_sub (conv_60_simp_287, a_conv_61_simp_298); /* write */
+                if (ierror_eq (conv_62_simp_230, ierror_not_an_error)) {
+                    flat_33_simp_248          = ierror_not_an_error;                  /* write */
+                    flat_33_simp_249          = idouble_sub (conv_62_simp_231, a_conv_63_simp_242); /* write */
                 } else {
-                    flat_38_simp_304          = conv_60_simp_286;                     /* write */
-                    flat_38_simp_305          = 0.0;                                  /* write */
+                    flat_33_simp_248          = conv_62_simp_230;                     /* write */
+                    flat_33_simp_249          = 0.0;                                  /* write */
                 }
                 
-                flat_38_simp_306              = flat_38_simp_304;                     /* read */
-                flat_38_simp_307              = flat_38_simp_305;                     /* read */
-                flat_39_simp_308              = ierror_not_an_error;                  /* init */
-                flat_39_simp_309              = 0.0;                                  /* init */
+                flat_33_simp_250              = flat_33_simp_248;                     /* read */
+                flat_33_simp_251              = flat_33_simp_249;                     /* read */
+                flat_34_simp_252              = ierror_not_an_error;                  /* init */
+                flat_34_simp_253              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_38_simp_306, ierror_not_an_error)) {
-                    flat_39_simp_308          = ierror_not_an_error;                  /* write */
-                    flat_39_simp_309          = idouble_div (flat_38_simp_307, nn_conv_68); /* write */
+                if (ierror_eq (flat_33_simp_250, ierror_not_an_error)) {
+                    flat_34_simp_252          = ierror_not_an_error;                  /* write */
+                    flat_34_simp_253          = idouble_div (flat_33_simp_251, nn_conv_70); /* write */
                 } else {
-                    flat_39_simp_308          = flat_38_simp_306;                     /* write */
-                    flat_39_simp_309          = 0.0;                                  /* write */
+                    flat_34_simp_252          = flat_33_simp_250;                     /* write */
+                    flat_34_simp_253          = 0.0;                                  /* write */
                 }
                 
-                flat_39_simp_310              = flat_39_simp_308;                     /* read */
-                flat_39_simp_311              = flat_39_simp_309;                     /* read */
-                flat_40_simp_312              = ierror_not_an_error;                  /* init */
-                flat_40_simp_313              = 0.0;                                  /* init */
+                flat_34_simp_254              = flat_34_simp_252;                     /* read */
+                flat_34_simp_255              = flat_34_simp_253;                     /* read */
+                flat_35_simp_256              = ierror_not_an_error;                  /* init */
+                flat_35_simp_257              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_39_simp_310, ierror_not_an_error)) {
-                    flat_40_simp_312          = ierror_not_an_error;                  /* write */
-                    flat_40_simp_313          = idouble_add (a_conv_61_simp_298, flat_39_simp_311); /* write */
+                if (ierror_eq (flat_34_simp_254, ierror_not_an_error)) {
+                    flat_35_simp_256          = ierror_not_an_error;                  /* write */
+                    flat_35_simp_257          = idouble_add (a_conv_63_simp_242, flat_34_simp_255); /* write */
                 } else {
-                    flat_40_simp_312          = flat_39_simp_310;                     /* write */
-                    flat_40_simp_313          = 0.0;                                  /* write */
+                    flat_35_simp_256          = flat_34_simp_254;                     /* write */
+                    flat_35_simp_257          = 0.0;                                  /* write */
                 }
                 
-                flat_40_simp_314              = flat_40_simp_312;                     /* read */
-                flat_40_simp_315              = flat_40_simp_313;                     /* read */
-                flat_41_simp_316              = ierror_not_an_error;                  /* init */
-                flat_41_simp_317              = 0.0;                                  /* init */
+                flat_35_simp_258              = flat_35_simp_256;                     /* read */
+                flat_35_simp_259              = flat_35_simp_257;                     /* read */
+                flat_36_simp_260              = ierror_not_an_error;                  /* init */
+                flat_36_simp_261              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_38_simp_306, ierror_not_an_error)) {
-                    flat_56_simp_318          = ierror_not_an_error;                  /* init */
-                    flat_56_simp_319          = 0.0;                                  /* init */
+                if (ierror_eq (flat_33_simp_250, ierror_not_an_error)) {
+                    flat_51_simp_262          = ierror_not_an_error;                  /* init */
+                    flat_51_simp_263          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (conv_60_simp_286, ierror_not_an_error)) {
-                        flat_62_simp_320      = ierror_not_an_error;                  /* init */
-                        flat_62_simp_321      = 0.0;                                  /* init */
+                    if (ierror_eq (conv_62_simp_230, ierror_not_an_error)) {
+                        flat_57_simp_264      = ierror_not_an_error;                  /* init */
+                        flat_57_simp_265      = 0.0;                                  /* init */
                         
-                        if (ierror_eq (flat_40_simp_314, ierror_not_an_error)) {
-                            flat_62_simp_320  = ierror_not_an_error;                  /* write */
-                            flat_62_simp_321  = idouble_sub (conv_60_simp_287, flat_40_simp_315); /* write */
+                        if (ierror_eq (flat_35_simp_258, ierror_not_an_error)) {
+                            flat_57_simp_264  = ierror_not_an_error;                  /* write */
+                            flat_57_simp_265  = idouble_sub (conv_62_simp_231, flat_35_simp_259); /* write */
                         } else {
-                            flat_62_simp_320  = flat_40_simp_314;                     /* write */
-                            flat_62_simp_321  = 0.0;                                  /* write */
+                            flat_57_simp_264  = flat_35_simp_258;                     /* write */
+                            flat_57_simp_265  = 0.0;                                  /* write */
                         }
                         
-                        flat_62_simp_322      = flat_62_simp_320;                     /* read */
-                        flat_62_simp_323      = flat_62_simp_321;                     /* read */
-                        flat_56_simp_318      = flat_62_simp_322;                     /* write */
-                        flat_56_simp_319      = flat_62_simp_323;                     /* write */
+                        flat_57_simp_266      = flat_57_simp_264;                     /* read */
+                        flat_57_simp_267      = flat_57_simp_265;                     /* read */
+                        flat_51_simp_262      = flat_57_simp_266;                     /* write */
+                        flat_51_simp_263      = flat_57_simp_267;                     /* write */
                     } else {
-                        flat_56_simp_318      = conv_60_simp_286;                     /* write */
-                        flat_56_simp_319      = 0.0;                                  /* write */
+                        flat_51_simp_262      = conv_62_simp_230;                     /* write */
+                        flat_51_simp_263      = 0.0;                                  /* write */
                     }
                     
-                    flat_56_simp_324          = flat_56_simp_318;                     /* read */
-                    flat_56_simp_325          = flat_56_simp_319;                     /* read */
-                    flat_57_simp_326          = ierror_not_an_error;                  /* init */
-                    flat_57_simp_327          = 0.0;                                  /* init */
+                    flat_51_simp_268          = flat_51_simp_262;                     /* read */
+                    flat_51_simp_269          = flat_51_simp_263;                     /* read */
+                    flat_52_simp_270          = ierror_not_an_error;                  /* init */
+                    flat_52_simp_271          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_56_simp_324, ierror_not_an_error)) {
-                        flat_57_simp_326      = ierror_not_an_error;                  /* write */
-                        flat_57_simp_327      = idouble_mul (flat_38_simp_307, flat_56_simp_325); /* write */
+                    if (ierror_eq (flat_51_simp_268, ierror_not_an_error)) {
+                        flat_52_simp_270      = ierror_not_an_error;                  /* write */
+                        flat_52_simp_271      = idouble_mul (flat_33_simp_251, flat_51_simp_269); /* write */
                     } else {
-                        flat_57_simp_326      = flat_56_simp_324;                     /* write */
-                        flat_57_simp_327      = 0.0;                                  /* write */
+                        flat_52_simp_270      = flat_51_simp_268;                     /* write */
+                        flat_52_simp_271      = 0.0;                                  /* write */
                     }
                     
-                    flat_57_simp_328          = flat_57_simp_326;                     /* read */
-                    flat_57_simp_329          = flat_57_simp_327;                     /* read */
-                    flat_41_simp_316          = flat_57_simp_328;                     /* write */
-                    flat_41_simp_317          = flat_57_simp_329;                     /* write */
+                    flat_52_simp_272          = flat_52_simp_270;                     /* read */
+                    flat_52_simp_273          = flat_52_simp_271;                     /* read */
+                    flat_36_simp_260          = flat_52_simp_272;                     /* write */
+                    flat_36_simp_261          = flat_52_simp_273;                     /* write */
                 } else {
-                    flat_41_simp_316          = flat_38_simp_306;                     /* write */
-                    flat_41_simp_317          = 0.0;                                  /* write */
+                    flat_36_simp_260          = flat_33_simp_250;                     /* write */
+                    flat_36_simp_261          = 0.0;                                  /* write */
                 }
                 
-                flat_41_simp_330              = flat_41_simp_316;                     /* read */
-                flat_41_simp_331              = flat_41_simp_317;                     /* read */
-                flat_42_simp_332              = ierror_not_an_error;                  /* init */
-                flat_42_simp_333              = 0.0;                                  /* init */
+                flat_36_simp_274              = flat_36_simp_260;                     /* read */
+                flat_36_simp_275              = flat_36_simp_261;                     /* read */
+                flat_37_simp_276              = ierror_not_an_error;                  /* init */
+                flat_37_simp_277              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_41_simp_330, ierror_not_an_error)) {
-                    flat_42_simp_332          = ierror_not_an_error;                  /* write */
-                    flat_42_simp_333          = idouble_add (a_conv_61_simp_299, flat_41_simp_331); /* write */
+                if (ierror_eq (flat_36_simp_274, ierror_not_an_error)) {
+                    flat_37_simp_276          = ierror_not_an_error;                  /* write */
+                    flat_37_simp_277          = idouble_add (a_conv_63_simp_243, flat_36_simp_275); /* write */
                 } else {
-                    flat_42_simp_332          = flat_41_simp_330;                     /* write */
-                    flat_42_simp_333          = 0.0;                                  /* write */
+                    flat_37_simp_276          = flat_36_simp_274;                     /* write */
+                    flat_37_simp_277          = 0.0;                                  /* write */
                 }
                 
-                flat_42_simp_334              = flat_42_simp_332;                     /* read */
-                flat_42_simp_335              = flat_42_simp_333;                     /* read */
-                flat_43_simp_336              = ierror_not_an_error;                  /* init */
-                flat_43_simp_337              = 0.0;                                  /* init */
-                flat_43_simp_338              = 0.0;                                  /* init */
+                flat_37_simp_278              = flat_37_simp_276;                     /* read */
+                flat_37_simp_279              = flat_37_simp_277;                     /* read */
+                flat_38_simp_280              = ierror_not_an_error;                  /* init */
+                flat_38_simp_281              = 0.0;                                  /* init */
+                flat_38_simp_282              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_40_simp_314, ierror_not_an_error)) {
-                    flat_43_simp_336          = ierror_not_an_error;                  /* write */
-                    flat_43_simp_337          = idouble_add (a_conv_61_simp_297, 1.0); /* write */
-                    flat_43_simp_338          = flat_40_simp_315;                     /* write */
+                if (ierror_eq (flat_35_simp_258, ierror_not_an_error)) {
+                    flat_38_simp_280          = ierror_not_an_error;                  /* write */
+                    flat_38_simp_281          = idouble_add (a_conv_63_simp_241, 1.0); /* write */
+                    flat_38_simp_282          = flat_35_simp_259;                     /* write */
                 } else {
-                    flat_43_simp_336          = flat_40_simp_314;                     /* write */
-                    flat_43_simp_337          = 0.0;                                  /* write */
-                    flat_43_simp_338          = 0.0;                                  /* write */
+                    flat_38_simp_280          = flat_35_simp_258;                     /* write */
+                    flat_38_simp_281          = 0.0;                                  /* write */
+                    flat_38_simp_282          = 0.0;                                  /* write */
                 }
                 
-                flat_43_simp_339              = flat_43_simp_336;                     /* read */
-                flat_43_simp_340              = flat_43_simp_337;                     /* read */
-                flat_43_simp_341              = flat_43_simp_338;                     /* read */
-                flat_44_simp_342              = ierror_not_an_error;                  /* init */
-                flat_44_simp_343              = 0.0;                                  /* init */
-                flat_44_simp_344              = 0.0;                                  /* init */
-                flat_44_simp_345              = 0.0;                                  /* init */
+                flat_38_simp_283              = flat_38_simp_280;                     /* read */
+                flat_38_simp_284              = flat_38_simp_281;                     /* read */
+                flat_38_simp_285              = flat_38_simp_282;                     /* read */
+                flat_39_simp_286              = ierror_not_an_error;                  /* init */
+                flat_39_simp_287              = 0.0;                                  /* init */
+                flat_39_simp_288              = 0.0;                                  /* init */
+                flat_39_simp_289              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_43_simp_339, ierror_not_an_error)) {
-                    flat_47_simp_346          = ierror_not_an_error;                  /* init */
-                    flat_47_simp_347          = 0.0;                                  /* init */
-                    flat_47_simp_348          = 0.0;                                  /* init */
-                    flat_47_simp_349          = 0.0;                                  /* init */
+                if (ierror_eq (flat_38_simp_283, ierror_not_an_error)) {
+                    flat_42_simp_290          = ierror_not_an_error;                  /* init */
+                    flat_42_simp_291          = 0.0;                                  /* init */
+                    flat_42_simp_292          = 0.0;                                  /* init */
+                    flat_42_simp_293          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_42_simp_334, ierror_not_an_error)) {
-                        flat_47_simp_346      = ierror_not_an_error;                  /* write */
-                        flat_47_simp_347      = flat_43_simp_340;                     /* write */
-                        flat_47_simp_348      = flat_43_simp_341;                     /* write */
-                        flat_47_simp_349      = flat_42_simp_335;                     /* write */
+                    if (ierror_eq (flat_37_simp_278, ierror_not_an_error)) {
+                        flat_42_simp_290      = ierror_not_an_error;                  /* write */
+                        flat_42_simp_291      = flat_38_simp_284;                     /* write */
+                        flat_42_simp_292      = flat_38_simp_285;                     /* write */
+                        flat_42_simp_293      = flat_37_simp_279;                     /* write */
                     } else {
-                        flat_47_simp_346      = flat_42_simp_334;                     /* write */
-                        flat_47_simp_347      = 0.0;                                  /* write */
-                        flat_47_simp_348      = 0.0;                                  /* write */
-                        flat_47_simp_349      = 0.0;                                  /* write */
+                        flat_42_simp_290      = flat_37_simp_278;                     /* write */
+                        flat_42_simp_291      = 0.0;                                  /* write */
+                        flat_42_simp_292      = 0.0;                                  /* write */
+                        flat_42_simp_293      = 0.0;                                  /* write */
                     }
                     
-                    flat_47_simp_350          = flat_47_simp_346;                     /* read */
-                    flat_47_simp_351          = flat_47_simp_347;                     /* read */
-                    flat_47_simp_352          = flat_47_simp_348;                     /* read */
-                    flat_47_simp_353          = flat_47_simp_349;                     /* read */
-                    flat_44_simp_342          = flat_47_simp_350;                     /* write */
-                    flat_44_simp_343          = flat_47_simp_351;                     /* write */
-                    flat_44_simp_344          = flat_47_simp_352;                     /* write */
-                    flat_44_simp_345          = flat_47_simp_353;                     /* write */
+                    flat_42_simp_294          = flat_42_simp_290;                     /* read */
+                    flat_42_simp_295          = flat_42_simp_291;                     /* read */
+                    flat_42_simp_296          = flat_42_simp_292;                     /* read */
+                    flat_42_simp_297          = flat_42_simp_293;                     /* read */
+                    flat_39_simp_286          = flat_42_simp_294;                     /* write */
+                    flat_39_simp_287          = flat_42_simp_295;                     /* write */
+                    flat_39_simp_288          = flat_42_simp_296;                     /* write */
+                    flat_39_simp_289          = flat_42_simp_297;                     /* write */
                 } else {
-                    flat_44_simp_342          = flat_43_simp_339;                     /* write */
-                    flat_44_simp_343          = 0.0;                                  /* write */
-                    flat_44_simp_344          = 0.0;                                  /* write */
-                    flat_44_simp_345          = 0.0;                                  /* write */
+                    flat_39_simp_286          = flat_38_simp_283;                     /* write */
+                    flat_39_simp_287          = 0.0;                                  /* write */
+                    flat_39_simp_288          = 0.0;                                  /* write */
+                    flat_39_simp_289          = 0.0;                                  /* write */
                 }
                 
-                flat_44_simp_354              = flat_44_simp_342;                     /* read */
-                flat_44_simp_355              = flat_44_simp_343;                     /* read */
-                flat_44_simp_356              = flat_44_simp_344;                     /* read */
-                flat_44_simp_357              = flat_44_simp_345;                     /* read */
-                flat_35_simp_300              = flat_44_simp_354;                     /* write */
-                flat_35_simp_301              = flat_44_simp_355;                     /* write */
-                flat_35_simp_302              = flat_44_simp_356;                     /* write */
-                flat_35_simp_303              = flat_44_simp_357;                     /* write */
+                flat_39_simp_298              = flat_39_simp_286;                     /* read */
+                flat_39_simp_299              = flat_39_simp_287;                     /* read */
+                flat_39_simp_300              = flat_39_simp_288;                     /* read */
+                flat_39_simp_301              = flat_39_simp_289;                     /* read */
+                flat_30_simp_244              = flat_39_simp_298;                     /* write */
+                flat_30_simp_245              = flat_39_simp_299;                     /* write */
+                flat_30_simp_246              = flat_39_simp_300;                     /* write */
+                flat_30_simp_247              = flat_39_simp_301;                     /* write */
             } else {
-                flat_35_simp_300              = a_conv_61_simp_296;                   /* write */
-                flat_35_simp_301              = 0.0;                                  /* write */
-                flat_35_simp_302              = 0.0;                                  /* write */
-                flat_35_simp_303              = 0.0;                                  /* write */
+                flat_30_simp_244              = a_conv_63_simp_240;                   /* write */
+                flat_30_simp_245              = 0.0;                                  /* write */
+                flat_30_simp_246              = 0.0;                                  /* write */
+                flat_30_simp_247              = 0.0;                                  /* write */
             }
             
-            flat_35_simp_358                  = flat_35_simp_300;                     /* read */
-            flat_35_simp_359                  = flat_35_simp_301;                     /* read */
-            flat_35_simp_360                  = flat_35_simp_302;                     /* read */
-            flat_35_simp_361                  = flat_35_simp_303;                     /* read */
-            acc_a_conv_61_simp_78             = flat_35_simp_358;                     /* write */
-            acc_a_conv_61_simp_79             = flat_35_simp_359;                     /* write */
-            acc_a_conv_61_simp_80             = flat_35_simp_360;                     /* write */
-            acc_a_conv_61_simp_81             = flat_35_simp_361;                     /* write */
+            flat_30_simp_302                  = flat_30_simp_244;                     /* read */
+            flat_30_simp_303                  = flat_30_simp_245;                     /* read */
+            flat_30_simp_304                  = flat_30_simp_246;                     /* read */
+            flat_30_simp_305                  = flat_30_simp_247;                     /* read */
+            acc_a_conv_63_simp_66             = flat_30_simp_302;                     /* write */
+            acc_a_conv_63_simp_67             = flat_30_simp_303;                     /* write */
+            acc_a_conv_63_simp_68             = flat_30_simp_304;                     /* write */
+            acc_a_conv_63_simp_69             = flat_30_simp_305;                     /* write */
         }
         
     }
     
-    s->has_acc_a_conv_61_simp_78              = itrue;                                /* save */
-    s->res_acc_a_conv_61_simp_78              = acc_a_conv_61_simp_78;                /* save */
+    s->has_acc_a_conv_63_simp_66              = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_66              = acc_a_conv_63_simp_66;                /* save */
     
-    s->has_acc_a_conv_61_simp_79              = itrue;                                /* save */
-    s->res_acc_a_conv_61_simp_79              = acc_a_conv_61_simp_79;                /* save */
+    s->has_acc_a_conv_63_simp_67              = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_67              = acc_a_conv_63_simp_67;                /* save */
     
-    s->has_acc_a_conv_61_simp_80              = itrue;                                /* save */
-    s->res_acc_a_conv_61_simp_80              = acc_a_conv_61_simp_80;                /* save */
+    s->has_acc_a_conv_63_simp_68              = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_68              = acc_a_conv_63_simp_68;                /* save */
     
-    s->has_acc_a_conv_61_simp_81              = itrue;                                /* save */
-    s->res_acc_a_conv_61_simp_81              = acc_a_conv_61_simp_81;                /* save */
+    s->has_acc_a_conv_63_simp_69              = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_69              = acc_a_conv_63_simp_69;                /* save */
     
-    s->has_acc_conv_60_simp_82                = itrue;                                /* save */
-    s->res_acc_conv_60_simp_82                = acc_conv_60_simp_82;                  /* save */
+    s->has_acc_conv_62_simp_70                = itrue;                                /* save */
+    s->res_acc_conv_62_simp_70                = acc_conv_62_simp_70;                  /* save */
     
-    s->has_acc_conv_60_simp_83                = itrue;                                /* save */
-    s->res_acc_conv_60_simp_83                = acc_conv_60_simp_83;                  /* save */
+    s->has_acc_conv_62_simp_71                = itrue;                                /* save */
+    s->res_acc_conv_62_simp_71                = acc_conv_62_simp_71;                  /* save */
     
-    s->has_acc_conv_56_simp_92                = itrue;                                /* save */
-    s->res_acc_conv_56_simp_92                = acc_conv_56_simp_92;                  /* save */
+    s->has_acc_conv_58_simp_80                = itrue;                                /* save */
+    s->res_acc_conv_58_simp_80                = acc_conv_58_simp_80;                  /* save */
     
-    s->has_acc_conv_56_simp_93                = itrue;                                /* save */
-    s->res_acc_conv_56_simp_93                = acc_conv_56_simp_93;                  /* save */
+    s->has_acc_conv_58_simp_81                = itrue;                                /* save */
+    s->res_acc_conv_58_simp_81                = acc_conv_58_simp_81;                  /* save */
     
-    s->has_acc_conv_55_simp_100               = itrue;                                /* save */
-    s->res_acc_conv_55_simp_100               = acc_conv_55_simp_100;                 /* save */
+    s->has_acc_conv_57_simp_88                = itrue;                                /* save */
+    s->res_acc_conv_57_simp_88                = acc_conv_57_simp_88;                  /* save */
     
-    s->has_acc_conv_55_simp_101               = itrue;                                /* save */
-    s->res_acc_conv_55_simp_101               = acc_conv_55_simp_101;                 /* save */
+    s->has_acc_conv_57_simp_89                = itrue;                                /* save */
+    s->res_acc_conv_57_simp_89                = acc_conv_57_simp_89;                  /* save */
     
-    s->has_acc_s_reify_6_conv_10_simp_106     = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_10_simp_106     = acc_s_reify_6_conv_10_simp_106;       /* save */
+    s->has_acc_s_reify_6_conv_12_simp_94      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_94      = acc_s_reify_6_conv_12_simp_94;        /* save */
     
-    s->has_acc_s_reify_6_conv_10_simp_107     = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_10_simp_107     = acc_s_reify_6_conv_10_simp_107;       /* save */
+    s->has_acc_s_reify_6_conv_12_simp_95      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_95      = acc_s_reify_6_conv_12_simp_95;        /* save */
     
-    s->has_acc_s_reify_6_conv_10_simp_108     = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_10_simp_108     = acc_s_reify_6_conv_10_simp_108;       /* save */
+    s->has_acc_s_reify_6_conv_12_simp_96      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_96      = acc_s_reify_6_conv_12_simp_96;        /* save */
     
-    s->has_acc_conv_9_simp_109                = itrue;                                /* save */
-    s->res_acc_conv_9_simp_109                = acc_conv_9_simp_109;                  /* save */
+    s->has_acc_conv_11_simp_97                = itrue;                                /* save */
+    s->res_acc_conv_11_simp_97                = acc_conv_11_simp_97;                  /* save */
     
-    s->has_acc_conv_9_simp_110                = itrue;                                /* save */
-    s->res_acc_conv_9_simp_110                = acc_conv_9_simp_110;                  /* save */
+    s->has_acc_conv_11_simp_98                = itrue;                                /* save */
+    s->res_acc_conv_11_simp_98                = acc_conv_11_simp_98;                  /* save */
     
-    s->has_acc_conv_5_simp_117                = itrue;                                /* save */
-    s->res_acc_conv_5_simp_117                = acc_conv_5_simp_117;                  /* save */
+    s->has_acc_conv_7_simp_105                = itrue;                                /* save */
+    s->res_acc_conv_7_simp_105                = acc_conv_7_simp_105;                  /* save */
     
-    s->has_acc_conv_5_simp_118                = itrue;                                /* save */
-    s->res_acc_conv_5_simp_118                = acc_conv_5_simp_118;                  /* save */
+    s->has_acc_conv_7_simp_106                = itrue;                                /* save */
+    s->res_acc_conv_7_simp_106                = acc_conv_7_simp_106;                  /* save */
     
-    a_conv_61_simp_362                        = acc_a_conv_61_simp_78;                /* read */
-    a_conv_61_simp_363                        = acc_a_conv_61_simp_79;                /* read */
-    a_conv_61_simp_365                        = acc_a_conv_61_simp_81;                /* read */
-    s_reify_6_conv_10_simp_366                = acc_s_reify_6_conv_10_simp_106;       /* read */
-    s_reify_6_conv_10_simp_367                = acc_s_reify_6_conv_10_simp_107;       /* read */
-    flat_87_simp_369                          = ierror_not_an_error;                  /* init */
-    flat_87_simp_370                          = 0.0;                                  /* init */
+    a_conv_63_simp_306                        = acc_a_conv_63_simp_66;                /* read */
+    a_conv_63_simp_307                        = acc_a_conv_63_simp_67;                /* read */
+    a_conv_63_simp_309                        = acc_a_conv_63_simp_69;                /* read */
+    s_reify_6_conv_12_simp_310                = acc_s_reify_6_conv_12_simp_94;        /* read */
+    s_reify_6_conv_12_simp_311                = acc_s_reify_6_conv_12_simp_95;        /* read */
+    flat_82_simp_313                          = ierror_not_an_error;                  /* init */
+    flat_82_simp_314                          = 0.0;                                  /* init */
     
-    if (ierror_eq (s_reify_6_conv_10_simp_366, ierror_not_an_error)) {
-        flat_87_simp_369                      = ierror_not_an_error;                  /* write */
-        flat_87_simp_370                      = s_reify_6_conv_10_simp_367;           /* write */
+    if (ierror_eq (s_reify_6_conv_12_simp_310, ierror_not_an_error)) {
+        flat_82_simp_313                      = ierror_not_an_error;                  /* write */
+        flat_82_simp_314                      = s_reify_6_conv_12_simp_311;           /* write */
     } else {
-        flat_87_simp_369                      = s_reify_6_conv_10_simp_366;           /* write */
-        flat_87_simp_370                      = 0.0;                                  /* write */
+        flat_82_simp_313                      = s_reify_6_conv_12_simp_310;           /* write */
+        flat_82_simp_314                      = 0.0;                                  /* write */
     }
     
-    flat_87_simp_371                          = flat_87_simp_369;                     /* read */
-    flat_87_simp_372                          = flat_87_simp_370;                     /* read */
-    flat_88_simp_373                          = ierror_not_an_error;                  /* init */
-    flat_88_simp_374                          = 0.0;                                  /* init */
+    flat_82_simp_315                          = flat_82_simp_313;                     /* read */
+    flat_82_simp_316                          = flat_82_simp_314;                     /* read */
+    flat_83_simp_317                          = ierror_not_an_error;                  /* init */
+    flat_83_simp_318                          = 0.0;                                  /* init */
     
-    if (ierror_eq (flat_87_simp_371, ierror_not_an_error)) {
-        flat_91_simp_375                      = ierror_not_an_error;                  /* init */
-        flat_91_simp_376                      = 0.0;                                  /* init */
+    if (ierror_eq (flat_82_simp_315, ierror_not_an_error)) {
+        flat_86_simp_319                      = ierror_not_an_error;                  /* init */
+        flat_86_simp_320                      = 0.0;                                  /* init */
         
-        if (ierror_eq (a_conv_61_simp_362, ierror_not_an_error)) {
-            idouble_t        conv_116         = idouble_sub (a_conv_61_simp_363, 1.0); /* let */
-            idouble_t        simp_1786        = idouble_div (a_conv_61_simp_365, conv_116); /* let */
-            flat_91_simp_375                  = ierror_not_an_error;                  /* write */
-            flat_91_simp_376                  = simp_1786;                            /* write */
+        if (ierror_eq (a_conv_63_simp_306, ierror_not_an_error)) {
+            idouble_t        conv_118         = idouble_sub (a_conv_63_simp_307, 1.0); /* let */
+            idouble_t        simp_1408        = idouble_div (a_conv_63_simp_309, conv_118); /* let */
+            flat_86_simp_319                  = ierror_not_an_error;                  /* write */
+            flat_86_simp_320                  = simp_1408;                            /* write */
         } else {
-            flat_91_simp_375                  = a_conv_61_simp_362;                   /* write */
-            flat_91_simp_376                  = 0.0;                                  /* write */
+            flat_86_simp_319                  = a_conv_63_simp_306;                   /* write */
+            flat_86_simp_320                  = 0.0;                                  /* write */
         }
         
-        flat_91_simp_377                      = flat_91_simp_375;                     /* read */
-        flat_91_simp_378                      = flat_91_simp_376;                     /* read */
-        flat_92_simp_379                      = ierror_not_an_error;                  /* init */
-        flat_92_simp_380                      = 0.0;                                  /* init */
+        flat_86_simp_321                      = flat_86_simp_319;                     /* read */
+        flat_86_simp_322                      = flat_86_simp_320;                     /* read */
+        flat_87_simp_323                      = ierror_not_an_error;                  /* init */
+        flat_87_simp_324                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_91_simp_377, ierror_not_an_error)) {
-            flat_92_simp_379                  = ierror_not_an_error;                  /* write */
-            flat_92_simp_380                  = idouble_sqrt (flat_91_simp_378);      /* write */
+        if (ierror_eq (flat_86_simp_321, ierror_not_an_error)) {
+            flat_87_simp_323                  = ierror_not_an_error;                  /* write */
+            flat_87_simp_324                  = idouble_sqrt (flat_86_simp_322);      /* write */
         } else {
-            flat_92_simp_379                  = flat_91_simp_377;                     /* write */
-            flat_92_simp_380                  = 0.0;                                  /* write */
+            flat_87_simp_323                  = flat_86_simp_321;                     /* write */
+            flat_87_simp_324                  = 0.0;                                  /* write */
         }
         
-        flat_92_simp_381                      = flat_92_simp_379;                     /* read */
-        flat_92_simp_382                      = flat_92_simp_380;                     /* read */
-        flat_93_simp_383                      = ierror_not_an_error;                  /* init */
-        flat_93_simp_384                      = 0.0;                                  /* init */
+        flat_87_simp_325                      = flat_87_simp_323;                     /* read */
+        flat_87_simp_326                      = flat_87_simp_324;                     /* read */
+        flat_88_simp_327                      = ierror_not_an_error;                  /* init */
+        flat_88_simp_328                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_92_simp_381, ierror_not_an_error)) {
-            flat_93_simp_383                  = ierror_not_an_error;                  /* write */
-            flat_93_simp_384                  = idouble_mul (flat_87_simp_372, flat_92_simp_382); /* write */
+        if (ierror_eq (flat_87_simp_325, ierror_not_an_error)) {
+            flat_88_simp_327                  = ierror_not_an_error;                  /* write */
+            flat_88_simp_328                  = idouble_mul (flat_82_simp_316, flat_87_simp_326); /* write */
         } else {
-            flat_93_simp_383                  = flat_92_simp_381;                     /* write */
-            flat_93_simp_384                  = 0.0;                                  /* write */
+            flat_88_simp_327                  = flat_87_simp_325;                     /* write */
+            flat_88_simp_328                  = 0.0;                                  /* write */
         }
         
-        flat_93_simp_385                      = flat_93_simp_383;                     /* read */
-        flat_93_simp_386                      = flat_93_simp_384;                     /* read */
-        flat_88_simp_373                      = flat_93_simp_385;                     /* write */
-        flat_88_simp_374                      = flat_93_simp_386;                     /* write */
+        flat_88_simp_329                      = flat_88_simp_327;                     /* read */
+        flat_88_simp_330                      = flat_88_simp_328;                     /* read */
+        flat_83_simp_317                      = flat_88_simp_329;                     /* write */
+        flat_83_simp_318                      = flat_88_simp_330;                     /* write */
     } else {
-        flat_88_simp_373                      = flat_87_simp_371;                     /* write */
-        flat_88_simp_374                      = 0.0;                                  /* write */
+        flat_83_simp_317                      = flat_82_simp_315;                     /* write */
+        flat_83_simp_318                      = 0.0;                                  /* write */
     }
     
-    flat_88_simp_387                          = flat_88_simp_373;                     /* read */
-    flat_88_simp_388                          = flat_88_simp_374;                     /* read */
-    s->repl_ix_0                              = flat_88_simp_387;                     /* output */
-    s->repl_ix_1                              = flat_88_simp_388;                     /* output */
+    flat_83_simp_331                          = flat_83_simp_317;                     /* read */
+    flat_83_simp_332                          = flat_83_simp_318;                     /* read */
+    s->repl_ix_0                              = flat_83_simp_331;                     /* output */
+    s->repl_ix_1                              = flat_83_simp_332;                     /* output */
 }
 
 - C evaluation:
@@ -1720,72 +1565,73 @@ void iprogram_0(iprogram_0_t *s)
 
 > > -- Times
 > - Flattened:
-conv$1 = TIME
+conv$3 = TIME
 {
-  init acc$s$reify$2$conv$3$simp$7@{Error} = ExceptNotAnError@{Error};
-  init acc$s$reify$2$conv$3$simp$8@{Time} = 1858-11-17@{Time};
-  init acc$conv$2$simp$9@{Time} = 1858-11-17@{Time};
-  write acc$conv$2$simp$9 = 1878-11-12@{Time};
-  write acc$s$reify$2$conv$3$simp$7 = ExceptFold1NoValue@{Error};
-  write acc$s$reify$2$conv$3$simp$8 = 1858-11-17@{Time};
-  load_resumable@{Error} acc$s$reify$2$conv$3$simp$7;
-  load_resumable@{Time} acc$s$reify$2$conv$3$simp$8;
-  load_resumable@{Time} acc$conv$2$simp$9;
-  for_facts (conv$0$simp$32@{Error},
-             conv$0$simp$33@{Int},
-             conv$0$simp$34@{Time}) in new {
-    let anf$5 = Time_daysDifference#
-                (1980-01-06@{Time}) conv$0$simp$34;
-    let anf$6 = negate#@{Int} anf$5;
-    write acc$conv$2$simp$9 = Time_minusDays#
-                              (2000-01-01@{Time}) anf$6;
-    read@{Time} conv$2$simp$16 = acc$conv$2$simp$9;
-    read@{Error} s$reify$2$conv$3$simp$20 = acc$s$reify$2$conv$3$simp$7;
-    read@{Time} s$reify$2$conv$3$simp$21 = acc$s$reify$2$conv$3$simp$8;
-    init flat$0$simp$22@{Error} = ExceptNotAnError@{Error};
-    init flat$0$simp$23@{Time} = 1858-11-17@{Time};
-    if (eq#@{Error} s$reify$2$conv$3$simp$20
+  init acc$s$reify$2$conv$5$simp$4@{Error} = ExceptNotAnError@{Error};
+  init acc$s$reify$2$conv$5$simp$5@{Time} = 1858-11-17@{Time};
+  init acc$conv$4$simp$6@{Time} = 1858-11-17@{Time};
+  write acc$s$reify$2$conv$5$simp$4 = ExceptFold1NoValue@{Error};
+  write acc$s$reify$2$conv$5$simp$5 = 1858-11-17@{Time};
+  load_resumable@{Error} acc$s$reify$2$conv$5$simp$4;
+  load_resumable@{Time} acc$s$reify$2$conv$5$simp$5;
+  load_resumable@{Time} acc$conv$4$simp$6;
+  for_facts (conv$2@{Time},
+             conv$1@{FactIdentifier},
+             conv$0$simp$26@{Error},
+             conv$0$simp$27@{Int},
+             conv$0$simp$28@{Time}) in new {
+    let anf$1 = Time_daysDifference#
+                (1980-01-06@{Time}) conv$0$simp$28;
+    let anf$2 = negate#@{Int} anf$1;
+    write acc$conv$4$simp$6 = Time_minusDays#
+                              (2000-01-01@{Time}) anf$2;
+    read@{Time} conv$4$simp$10 = acc$conv$4$simp$6;
+    read@{Error} s$reify$2$conv$5$simp$14 = acc$s$reify$2$conv$5$simp$4;
+    read@{Time} s$reify$2$conv$5$simp$15 = acc$s$reify$2$conv$5$simp$5;
+    init flat$0$simp$16@{Error} = ExceptNotAnError@{Error};
+    init flat$0$simp$17@{Time} = 1858-11-17@{Time};
+    if (eq#@{Error} s$reify$2$conv$5$simp$14
         (ExceptNotAnError@{Error})) {
       init flat$4@{Time} = 1858-11-17@{Time};
-      if (gt#@{Time} conv$2$simp$16
-          s$reify$2$conv$3$simp$21) {
-        write flat$4 = conv$2$simp$16;
+      if (gt#@{Time} conv$4$simp$10
+          s$reify$2$conv$5$simp$15) {
+        write flat$4 = conv$4$simp$10;
       } 
        else {
-        write flat$4 = s$reify$2$conv$3$simp$21;
+        write flat$4 = s$reify$2$conv$5$simp$15;
       } 
       
       read@{Time} flat$4 = flat$4;
-      write flat$0$simp$22 = ExceptNotAnError@{Error};
-      write flat$0$simp$23 = flat$4;
+      write flat$0$simp$16 = ExceptNotAnError@{Error};
+      write flat$0$simp$17 = flat$4;
     } else {
-      init flat$3$simp$24@{Error} = ExceptNotAnError@{Error};
-      init flat$3$simp$25@{Time} = 1858-11-17@{Time};
+      init flat$3$simp$18@{Error} = ExceptNotAnError@{Error};
+      init flat$3$simp$19@{Time} = 1858-11-17@{Time};
       if (eq#@{Error} (ExceptFold1NoValue@{Error})
-          s$reify$2$conv$3$simp$20) {
-        write flat$3$simp$24 = ExceptNotAnError@{Error};
-        write flat$3$simp$25 = conv$2$simp$16;
+          s$reify$2$conv$5$simp$14) {
+        write flat$3$simp$18 = ExceptNotAnError@{Error};
+        write flat$3$simp$19 = conv$4$simp$10;
       } else {
-        write flat$3$simp$24 = s$reify$2$conv$3$simp$20;
-        write flat$3$simp$25 = 1858-11-17@{Time};
+        write flat$3$simp$18 = s$reify$2$conv$5$simp$14;
+        write flat$3$simp$19 = 1858-11-17@{Time};
       }
-      read@{Error} flat$3$simp$26 = flat$3$simp$24;
-      read@{Time} flat$3$simp$27 = flat$3$simp$25;
-      write flat$0$simp$22 = flat$3$simp$26;
-      write flat$0$simp$23 = flat$3$simp$27;
+      read@{Error} flat$3$simp$20 = flat$3$simp$18;
+      read@{Time} flat$3$simp$21 = flat$3$simp$19;
+      write flat$0$simp$16 = flat$3$simp$20;
+      write flat$0$simp$17 = flat$3$simp$21;
     }
-    read@{Error} flat$0$simp$28 = flat$0$simp$22;
-    read@{Time} flat$0$simp$29 = flat$0$simp$23;
-    write acc$s$reify$2$conv$3$simp$7 = flat$0$simp$28;
-    write acc$s$reify$2$conv$3$simp$8 = flat$0$simp$29;
+    read@{Error} flat$0$simp$22 = flat$0$simp$16;
+    read@{Time} flat$0$simp$23 = flat$0$simp$17;
+    write acc$s$reify$2$conv$5$simp$4 = flat$0$simp$22;
+    write acc$s$reify$2$conv$5$simp$5 = flat$0$simp$23;
   }
-  save_resumable@{Error} acc$s$reify$2$conv$3$simp$7;
-  save_resumable@{Time} acc$s$reify$2$conv$3$simp$8;
-  save_resumable@{Time} acc$conv$2$simp$9;
-  read@{Error} s$reify$2$conv$3$simp$30 = acc$s$reify$2$conv$3$simp$7;
-  read@{Time} s$reify$2$conv$3$simp$31 = acc$s$reify$2$conv$3$simp$8;
-  output@{(Sum Error Time)} repl (s$reify$2$conv$3$simp$30@{Error},
-               s$reify$2$conv$3$simp$31@{Time});
+  save_resumable@{Error} acc$s$reify$2$conv$5$simp$4;
+  save_resumable@{Time} acc$s$reify$2$conv$5$simp$5;
+  save_resumable@{Time} acc$conv$4$simp$6;
+  read@{Error} s$reify$2$conv$5$simp$24 = acc$s$reify$2$conv$5$simp$4;
+  read@{Time} s$reify$2$conv$5$simp$25 = acc$s$reify$2$conv$5$simp$5;
+  output@{(Sum Error Time)} repl (s$reify$2$conv$5$simp$24@{Error},
+               s$reify$2$conv$5$simp$25@{Time});
 }
 
 - C:
@@ -1795,23 +1641,23 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_1;
+    itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_32;
-    iint_t          *new_conv_0_simp_33;
-    itime_t         *new_conv_0_simp_34;
+    ierror_t        *new_conv_0_simp_26;
+    iint_t          *new_conv_0_simp_27;
+    itime_t         *new_conv_0_simp_28;
 
     /* outputs */
     ierror_t         repl_ix_0;
     itime_t          repl_ix_1;
 
     /* resumables */
-    ibool_t          has_acc_s_reify_2_conv_3_simp_8;
-    itime_t          res_acc_s_reify_2_conv_3_simp_8;
-    ibool_t          has_acc_s_reify_2_conv_3_simp_7;
-    ierror_t         res_acc_s_reify_2_conv_3_simp_7;
-    ibool_t          has_acc_conv_2_simp_9;
-    itime_t          res_acc_conv_2_simp_9;
+    ibool_t          has_acc_s_reify_2_conv_5_simp_5;
+    itime_t          res_acc_s_reify_2_conv_5_simp_5;
+    ibool_t          has_acc_s_reify_2_conv_5_simp_4;
+    ierror_t         res_acc_s_reify_2_conv_5_simp_4;
+    ibool_t          has_acc_conv_4_simp_6;
+    itime_t          res_acc_conv_4_simp_6;
 } iprogram_0_t;
 
 iint_t size_of_state_iprogram_0 ()
@@ -1823,112 +1669,113 @@ iint_t size_of_state_iprogram_0 ()
 void iprogram_0(iprogram_0_t *s)
 {
     itime_t          flat_4;
-    itime_t          acc_s_reify_2_conv_3_simp_8;
-    ierror_t         acc_s_reify_2_conv_3_simp_7;
-    ierror_t         s_reify_2_conv_3_simp_20;
-    itime_t          s_reify_2_conv_3_simp_21;
-    itime_t          s_reify_2_conv_3_simp_31;
-    ierror_t         s_reify_2_conv_3_simp_30;
-    itime_t          flat_0_simp_29;
-    ierror_t         flat_0_simp_28;
+    itime_t          acc_s_reify_2_conv_5_simp_5;
+    ierror_t         acc_s_reify_2_conv_5_simp_4;
+    ierror_t         s_reify_2_conv_5_simp_24;
+    itime_t          s_reify_2_conv_5_simp_25;
+    itime_t          s_reify_2_conv_5_simp_15;
+    ierror_t         s_reify_2_conv_5_simp_14;
     itime_t          flat_0_simp_23;
     ierror_t         flat_0_simp_22;
-    ierror_t         flat_3_simp_26;
-    itime_t          flat_3_simp_27;
-    ierror_t         flat_3_simp_24;
-    itime_t          flat_3_simp_25;
-    itime_t          acc_conv_2_simp_9;
-    itime_t          conv_2_simp_16;
+    ierror_t         flat_3_simp_20;
+    itime_t          flat_3_simp_21;
+    itime_t          flat_3_simp_19;
+    ierror_t         flat_3_simp_18;
+    itime_t          flat_0_simp_17;
+    ierror_t         flat_0_simp_16;
+    itime_t          acc_conv_4_simp_6;
+    itime_t          conv_4_simp_10;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_1                   = s->conv_1;
+    itime_t          conv_3                   = s->conv_3;
 
-    acc_s_reify_2_conv_3_simp_7               = ierror_not_an_error;                  /* init */
-    acc_s_reify_2_conv_3_simp_8               = 0x7420b1100000000;                    /* init */
-    acc_conv_2_simp_9                         = 0x7420b1100000000;                    /* init */
-    acc_conv_2_simp_9                         = 0x7560b0c00000000;                    /* write */
-    acc_s_reify_2_conv_3_simp_7               = ierror_fold1_no_value;                /* write */
-    acc_s_reify_2_conv_3_simp_8               = 0x7420b1100000000;                    /* write */
+    acc_s_reify_2_conv_5_simp_4               = ierror_not_an_error;                  /* init */
+    acc_s_reify_2_conv_5_simp_5               = 0x7420b1100000000;                    /* init */
+    acc_conv_4_simp_6                         = 0x7420b1100000000;                    /* init */
+    acc_s_reify_2_conv_5_simp_4               = ierror_fold1_no_value;                /* write */
+    acc_s_reify_2_conv_5_simp_5               = 0x7420b1100000000;                    /* write */
     
-    if (s->has_acc_s_reify_2_conv_3_simp_7) {
-        acc_s_reify_2_conv_3_simp_7           = s->res_acc_s_reify_2_conv_3_simp_7;   /* load */
+    if (s->has_acc_s_reify_2_conv_5_simp_4) {
+        acc_s_reify_2_conv_5_simp_4           = s->res_acc_s_reify_2_conv_5_simp_4;   /* load */
     }
     
-    if (s->has_acc_s_reify_2_conv_3_simp_8) {
-        acc_s_reify_2_conv_3_simp_8           = s->res_acc_s_reify_2_conv_3_simp_8;   /* load */
+    if (s->has_acc_s_reify_2_conv_5_simp_5) {
+        acc_s_reify_2_conv_5_simp_5           = s->res_acc_s_reify_2_conv_5_simp_5;   /* load */
     }
     
-    if (s->has_acc_conv_2_simp_9) {
-        acc_conv_2_simp_9                     = s->res_acc_conv_2_simp_9;             /* load */
+    if (s->has_acc_conv_4_simp_6) {
+        acc_conv_4_simp_6                     = s->res_acc_conv_4_simp_6;             /* load */
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_32 = s->new_conv_0_simp_32;
-    const iint_t    *const new_conv_0_simp_33 = s->new_conv_0_simp_33;
-    const itime_t   *const new_conv_0_simp_34 = s->new_conv_0_simp_34;
+    const ierror_t  *const new_conv_0_simp_26 = s->new_conv_0_simp_26;
+    const iint_t    *const new_conv_0_simp_27 = s->new_conv_0_simp_27;
+    const itime_t   *const new_conv_0_simp_28 = s->new_conv_0_simp_28;
     
     for (iint_t i = 0; i < new_count; i++) {
-        ierror_t         conv_0_simp_32       = new_conv_0_simp_32[i];
-        iint_t           conv_0_simp_33       = new_conv_0_simp_33[i];
-        itime_t          conv_0_simp_34       = new_conv_0_simp_34[i];
-        iint_t           anf_5                = itime_days_diff (0x7bc010600000000, conv_0_simp_34); /* let */
-        iint_t           anf_6                = iint_neg (anf_5);                     /* let */
-        acc_conv_2_simp_9                     = itime_minus_days (0x7d0010100000000, anf_6); /* write */
-        conv_2_simp_16                        = acc_conv_2_simp_9;                    /* read */
-        s_reify_2_conv_3_simp_20              = acc_s_reify_2_conv_3_simp_7;          /* read */
-        s_reify_2_conv_3_simp_21              = acc_s_reify_2_conv_3_simp_8;          /* read */
-        flat_0_simp_22                        = ierror_not_an_error;                  /* init */
-        flat_0_simp_23                        = 0x7420b1100000000;                    /* init */
+        iint_t           conv_1               = i;
+        itime_t          conv_2               = new_conv_0_simp_28[i];
+        ierror_t         conv_0_simp_26       = new_conv_0_simp_26[i];
+        iint_t           conv_0_simp_27       = new_conv_0_simp_27[i];
+        itime_t          conv_0_simp_28       = new_conv_0_simp_28[i];
+        iint_t           anf_1                = itime_days_diff (0x7bc010600000000, conv_0_simp_28); /* let */
+        iint_t           anf_2                = iint_neg (anf_1);                     /* let */
+        acc_conv_4_simp_6                     = itime_minus_days (0x7d0010100000000, anf_2); /* write */
+        conv_4_simp_10                        = acc_conv_4_simp_6;                    /* read */
+        s_reify_2_conv_5_simp_14              = acc_s_reify_2_conv_5_simp_4;          /* read */
+        s_reify_2_conv_5_simp_15              = acc_s_reify_2_conv_5_simp_5;          /* read */
+        flat_0_simp_16                        = ierror_not_an_error;                  /* init */
+        flat_0_simp_17                        = 0x7420b1100000000;                    /* init */
         
-        if (ierror_eq (s_reify_2_conv_3_simp_20, ierror_not_an_error)) {
+        if (ierror_eq (s_reify_2_conv_5_simp_14, ierror_not_an_error)) {
             flat_4                            = 0x7420b1100000000;                    /* init */
             
-            if (itime_gt (conv_2_simp_16, s_reify_2_conv_3_simp_21)) {
-                flat_4                        = conv_2_simp_16;                       /* write */
+            if (itime_gt (conv_4_simp_10, s_reify_2_conv_5_simp_15)) {
+                flat_4                        = conv_4_simp_10;                       /* write */
             } else {
-                flat_4                        = s_reify_2_conv_3_simp_21;             /* write */
+                flat_4                        = s_reify_2_conv_5_simp_15;             /* write */
             }
             
             flat_4                            = flat_4;                               /* read */
-            flat_0_simp_22                    = ierror_not_an_error;                  /* write */
-            flat_0_simp_23                    = flat_4;                               /* write */
+            flat_0_simp_16                    = ierror_not_an_error;                  /* write */
+            flat_0_simp_17                    = flat_4;                               /* write */
         } else {
-            flat_3_simp_24                    = ierror_not_an_error;                  /* init */
-            flat_3_simp_25                    = 0x7420b1100000000;                    /* init */
+            flat_3_simp_18                    = ierror_not_an_error;                  /* init */
+            flat_3_simp_19                    = 0x7420b1100000000;                    /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, s_reify_2_conv_3_simp_20)) {
-                flat_3_simp_24                = ierror_not_an_error;                  /* write */
-                flat_3_simp_25                = conv_2_simp_16;                       /* write */
+            if (ierror_eq (ierror_fold1_no_value, s_reify_2_conv_5_simp_14)) {
+                flat_3_simp_18                = ierror_not_an_error;                  /* write */
+                flat_3_simp_19                = conv_4_simp_10;                       /* write */
             } else {
-                flat_3_simp_24                = s_reify_2_conv_3_simp_20;             /* write */
-                flat_3_simp_25                = 0x7420b1100000000;                    /* write */
+                flat_3_simp_18                = s_reify_2_conv_5_simp_14;             /* write */
+                flat_3_simp_19                = 0x7420b1100000000;                    /* write */
             }
             
-            flat_3_simp_26                    = flat_3_simp_24;                       /* read */
-            flat_3_simp_27                    = flat_3_simp_25;                       /* read */
-            flat_0_simp_22                    = flat_3_simp_26;                       /* write */
-            flat_0_simp_23                    = flat_3_simp_27;                       /* write */
+            flat_3_simp_20                    = flat_3_simp_18;                       /* read */
+            flat_3_simp_21                    = flat_3_simp_19;                       /* read */
+            flat_0_simp_16                    = flat_3_simp_20;                       /* write */
+            flat_0_simp_17                    = flat_3_simp_21;                       /* write */
         }
         
-        flat_0_simp_28                        = flat_0_simp_22;                       /* read */
-        flat_0_simp_29                        = flat_0_simp_23;                       /* read */
-        acc_s_reify_2_conv_3_simp_7           = flat_0_simp_28;                       /* write */
-        acc_s_reify_2_conv_3_simp_8           = flat_0_simp_29;                       /* write */
+        flat_0_simp_22                        = flat_0_simp_16;                       /* read */
+        flat_0_simp_23                        = flat_0_simp_17;                       /* read */
+        acc_s_reify_2_conv_5_simp_4           = flat_0_simp_22;                       /* write */
+        acc_s_reify_2_conv_5_simp_5           = flat_0_simp_23;                       /* write */
     }
     
-    s->has_acc_s_reify_2_conv_3_simp_7        = itrue;                                /* save */
-    s->res_acc_s_reify_2_conv_3_simp_7        = acc_s_reify_2_conv_3_simp_7;          /* save */
+    s->has_acc_s_reify_2_conv_5_simp_4        = itrue;                                /* save */
+    s->res_acc_s_reify_2_conv_5_simp_4        = acc_s_reify_2_conv_5_simp_4;          /* save */
     
-    s->has_acc_s_reify_2_conv_3_simp_8        = itrue;                                /* save */
-    s->res_acc_s_reify_2_conv_3_simp_8        = acc_s_reify_2_conv_3_simp_8;          /* save */
+    s->has_acc_s_reify_2_conv_5_simp_5        = itrue;                                /* save */
+    s->res_acc_s_reify_2_conv_5_simp_5        = acc_s_reify_2_conv_5_simp_5;          /* save */
     
-    s->has_acc_conv_2_simp_9                  = itrue;                                /* save */
-    s->res_acc_conv_2_simp_9                  = acc_conv_2_simp_9;                    /* save */
+    s->has_acc_conv_4_simp_6                  = itrue;                                /* save */
+    s->res_acc_conv_4_simp_6                  = acc_conv_4_simp_6;                    /* save */
     
-    s_reify_2_conv_3_simp_30                  = acc_s_reify_2_conv_3_simp_7;          /* read */
-    s_reify_2_conv_3_simp_31                  = acc_s_reify_2_conv_3_simp_8;          /* read */
-    s->repl_ix_0                              = s_reify_2_conv_3_simp_30;             /* output */
-    s->repl_ix_1                              = s_reify_2_conv_3_simp_31;             /* output */
+    s_reify_2_conv_5_simp_24                  = acc_s_reify_2_conv_5_simp_4;          /* read */
+    s_reify_2_conv_5_simp_25                  = acc_s_reify_2_conv_5_simp_5;          /* read */
+    s->repl_ix_0                              = s_reify_2_conv_5_simp_24;             /* output */
+    s->repl_ix_1                              = s_reify_2_conv_5_simp_25;             /* output */
 }
 
 - C evaluation:

--- a/test/cli/repl/t30.2-array-strings/expected
+++ b/test/cli/repl/t30.2-array-strings/expected
@@ -22,9 +22,9 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 > > ok, loaded dictionary with 2 features and 20 functions
 > ok, loaded test/cli/repl/t30.2-array-strings/data.psv, 5 rows
 > > - C evaluation:
-[(ID00000000,2)
-,(ID00000001,1)
-,(ID00000002,2)]
+[(ID00000000,0)
+,(ID00000001,0)
+,(ID00000002,0)]
 
 - Core evaluation:
 [ID00000000, 2

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -27,7 +27,7 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_1;
+    itime_t          conv_3;
     iint_t           new_count;
     ierror_t        *new_conv_0_simp_23;
     iint_t          *new_conv_0_simp_24;
@@ -39,12 +39,12 @@ typedef struct {
     idouble_t        repl_ix_2;
 
     /* resumables */
-    ibool_t          has_acc_perhaps_conv_2_simp_10;
-    idouble_t        res_acc_perhaps_conv_2_simp_10;
-    ibool_t          has_acc_perhaps_conv_2_simp_8;
-    ibool_t          res_acc_perhaps_conv_2_simp_8;
-    ibool_t          has_acc_perhaps_conv_2_simp_9;
-    iint_t           res_acc_perhaps_conv_2_simp_9;
+    ibool_t          has_acc_perhaps_conv_4_simp_10;
+    idouble_t        res_acc_perhaps_conv_4_simp_10;
+    ibool_t          has_acc_perhaps_conv_4_simp_8;
+    ibool_t          res_acc_perhaps_conv_4_simp_8;
+    ibool_t          has_acc_perhaps_conv_4_simp_9;
+    iint_t           res_acc_perhaps_conv_4_simp_9;
 } iprogram_0_t;
 
 iint_t size_of_state_iprogram_0 ()
@@ -55,39 +55,39 @@ iint_t size_of_state_iprogram_0 ()
 #line 1 "compute function #0 - repl"
 void iprogram_0(iprogram_0_t *s)
 {
-    idouble_t        acc_perhaps_conv_2_simp_10;
-    ibool_t          acc_perhaps_conv_2_simp_8;
-    iint_t           acc_perhaps_conv_2_simp_9;
+    idouble_t        acc_perhaps_conv_4_simp_10;
+    ibool_t          acc_perhaps_conv_4_simp_8;
+    iint_t           acc_perhaps_conv_4_simp_9;
     ibool_t          flat_0_simp_14;
     ibool_t          flat_0_simp_17;
     iint_t           flat_0_simp_15;
     iint_t           flat_0_simp_18;
     idouble_t        flat_0_simp_19;
     idouble_t        flat_0_simp_16;
-    iint_t           perhaps_conv_2_simp_12;
-    idouble_t        perhaps_conv_2_simp_13;
-    ibool_t          perhaps_conv_2_simp_11;
-    idouble_t        perhaps_conv_2_simp_22;
-    iint_t           perhaps_conv_2_simp_21;
-    ibool_t          perhaps_conv_2_simp_20;
+    idouble_t        perhaps_conv_4_simp_13;
+    ibool_t          perhaps_conv_4_simp_11;
+    iint_t           perhaps_conv_4_simp_12;
+    idouble_t        perhaps_conv_4_simp_22;
+    iint_t           perhaps_conv_4_simp_21;
+    ibool_t          perhaps_conv_4_simp_20;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_1                   = s->conv_1;
+    itime_t          conv_3                   = s->conv_3;
 
-    acc_perhaps_conv_2_simp_8                 = ifalse;                               /* init */
-    acc_perhaps_conv_2_simp_9                 = 0;                                    /* init */
-    acc_perhaps_conv_2_simp_10                = 0.0;                                  /* init */
+    acc_perhaps_conv_4_simp_8                 = ifalse;                               /* init */
+    acc_perhaps_conv_4_simp_9                 = 0;                                    /* init */
+    acc_perhaps_conv_4_simp_10                = 0.0;                                  /* init */
     
-    if (s->has_acc_perhaps_conv_2_simp_8) {
-        acc_perhaps_conv_2_simp_8             = s->res_acc_perhaps_conv_2_simp_8;     /* load */
+    if (s->has_acc_perhaps_conv_4_simp_8) {
+        acc_perhaps_conv_4_simp_8             = s->res_acc_perhaps_conv_4_simp_8;     /* load */
     }
     
-    if (s->has_acc_perhaps_conv_2_simp_9) {
-        acc_perhaps_conv_2_simp_9             = s->res_acc_perhaps_conv_2_simp_9;     /* load */
+    if (s->has_acc_perhaps_conv_4_simp_9) {
+        acc_perhaps_conv_4_simp_9             = s->res_acc_perhaps_conv_4_simp_9;     /* load */
     }
     
-    if (s->has_acc_perhaps_conv_2_simp_10) {
-        acc_perhaps_conv_2_simp_10            = s->res_acc_perhaps_conv_2_simp_10;    /* load */
+    if (s->has_acc_perhaps_conv_4_simp_10) {
+        acc_perhaps_conv_4_simp_10            = s->res_acc_perhaps_conv_4_simp_10;    /* load */
     }
     
     const iint_t     new_count                = s->new_count;
@@ -96,23 +96,25 @@ void iprogram_0(iprogram_0_t *s)
     const itime_t   *const new_conv_0_simp_25 = s->new_conv_0_simp_25;
     
     for (iint_t i = 0; i < new_count; i++) {
+        iint_t           conv_1               = i;
+        itime_t          conv_2               = new_conv_0_simp_25[i];
         ierror_t         conv_0_simp_23       = new_conv_0_simp_23[i];
         iint_t           conv_0_simp_24       = new_conv_0_simp_24[i];
         itime_t          conv_0_simp_25       = new_conv_0_simp_25[i];
-        perhaps_conv_2_simp_11                = acc_perhaps_conv_2_simp_8;            /* read */
-        perhaps_conv_2_simp_12                = acc_perhaps_conv_2_simp_9;            /* read */
-        perhaps_conv_2_simp_13                = acc_perhaps_conv_2_simp_10;           /* read */
+        perhaps_conv_4_simp_11                = acc_perhaps_conv_4_simp_8;            /* read */
+        perhaps_conv_4_simp_12                = acc_perhaps_conv_4_simp_9;            /* read */
+        perhaps_conv_4_simp_13                = acc_perhaps_conv_4_simp_10;           /* read */
         flat_0_simp_14                        = ifalse;                               /* init */
         flat_0_simp_15                        = 0;                                    /* init */
         flat_0_simp_16                        = 0.0;                                  /* init */
         
-        if (perhaps_conv_2_simp_11) {
-            iint_t           simp_31          = idouble_trunc (perhaps_conv_2_simp_13); /* let */
+        if (perhaps_conv_4_simp_11) {
+            iint_t           simp_31          = idouble_trunc (perhaps_conv_4_simp_13); /* let */
             flat_0_simp_14                    = ifalse;                               /* write */
             flat_0_simp_15                    = iint_add (simp_31, 1);                /* write */
             flat_0_simp_16                    = 0.0;                                  /* write */
         } else {
-            idouble_t        simp_45          = iint_extend (perhaps_conv_2_simp_12); /* let */
+            idouble_t        simp_45          = iint_extend (perhaps_conv_4_simp_12); /* let */
             flat_0_simp_14                    = itrue;                                /* write */
             flat_0_simp_15                    = 0;                                    /* write */
             flat_0_simp_16                    = idouble_add (simp_45, 1.0);           /* write */
@@ -121,26 +123,26 @@ void iprogram_0(iprogram_0_t *s)
         flat_0_simp_17                        = flat_0_simp_14;                       /* read */
         flat_0_simp_18                        = flat_0_simp_15;                       /* read */
         flat_0_simp_19                        = flat_0_simp_16;                       /* read */
-        acc_perhaps_conv_2_simp_8             = flat_0_simp_17;                       /* write */
-        acc_perhaps_conv_2_simp_9             = flat_0_simp_18;                       /* write */
-        acc_perhaps_conv_2_simp_10            = flat_0_simp_19;                       /* write */
+        acc_perhaps_conv_4_simp_8             = flat_0_simp_17;                       /* write */
+        acc_perhaps_conv_4_simp_9             = flat_0_simp_18;                       /* write */
+        acc_perhaps_conv_4_simp_10            = flat_0_simp_19;                       /* write */
     }
     
-    s->has_acc_perhaps_conv_2_simp_8          = itrue;                                /* save */
-    s->res_acc_perhaps_conv_2_simp_8          = acc_perhaps_conv_2_simp_8;            /* save */
+    s->has_acc_perhaps_conv_4_simp_8          = itrue;                                /* save */
+    s->res_acc_perhaps_conv_4_simp_8          = acc_perhaps_conv_4_simp_8;            /* save */
     
-    s->has_acc_perhaps_conv_2_simp_9          = itrue;                                /* save */
-    s->res_acc_perhaps_conv_2_simp_9          = acc_perhaps_conv_2_simp_9;            /* save */
+    s->has_acc_perhaps_conv_4_simp_9          = itrue;                                /* save */
+    s->res_acc_perhaps_conv_4_simp_9          = acc_perhaps_conv_4_simp_9;            /* save */
     
-    s->has_acc_perhaps_conv_2_simp_10         = itrue;                                /* save */
-    s->res_acc_perhaps_conv_2_simp_10         = acc_perhaps_conv_2_simp_10;           /* save */
+    s->has_acc_perhaps_conv_4_simp_10         = itrue;                                /* save */
+    s->res_acc_perhaps_conv_4_simp_10         = acc_perhaps_conv_4_simp_10;           /* save */
     
-    perhaps_conv_2_simp_20                    = acc_perhaps_conv_2_simp_8;            /* read */
-    perhaps_conv_2_simp_21                    = acc_perhaps_conv_2_simp_9;            /* read */
-    perhaps_conv_2_simp_22                    = acc_perhaps_conv_2_simp_10;           /* read */
-    s->repl_ix_0                              = perhaps_conv_2_simp_20;               /* output */
-    s->repl_ix_1                              = perhaps_conv_2_simp_21;               /* output */
-    s->repl_ix_2                              = perhaps_conv_2_simp_22;               /* output */
+    perhaps_conv_4_simp_20                    = acc_perhaps_conv_4_simp_8;            /* read */
+    perhaps_conv_4_simp_21                    = acc_perhaps_conv_4_simp_9;            /* read */
+    perhaps_conv_4_simp_22                    = acc_perhaps_conv_4_simp_10;           /* read */
+    s->repl_ix_0                              = perhaps_conv_4_simp_20;               /* output */
+    s->repl_ix_1                              = perhaps_conv_4_simp_21;               /* output */
+    s->repl_ix_2                              = perhaps_conv_4_simp_22;               /* output */
 }
 
 - C evaluation:


### PR DESCRIPTION
I have added a new "FactIdentifierT" type that is really just a time. Latest push in Core takes a fact identifier and stores it in the buffer. The Core program also binds the current fact identifier, the current fact time, and the actual value (which is still the pair of date and time)

TODO still:
1. Core evaluation to read out the fact identifiers
2. Conversion to Avalanche should preserve the new fact identifier bindings