### PR TITLE
output dense dictionary

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "lib/jetski"]
 	path = lib/jetski
 	url = https://github.com/ambiata/jetski
+[submodule "lib/formation"]
+	path = lib/formation
+	url = https://github.com/ambiata/formation.hs

--- a/data/sea/52-psv.h
+++ b/data/sea/52-psv.h
@@ -266,6 +266,7 @@ static ierror_msg_t INLINE psv_output_char
     return 0;
 }
 
+/* Assuming value_size does not include the null terminator */
 static ierror_msg_t INLINE psv_output_string
     (int fd, char *ps, char *pe, char **pp, const char *value_ptr, size_t value_size)
 {

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -17,6 +17,7 @@ library
                      , ambiata-jetski
                      , ambiata-p
                      , ambiata-x-eithert
+                     , ambiata-formation
                      , aeson                           == 0.8.*
                      , annotated-wl-pprint             == 0.7.*
                      , bifunctors                      == 4.2.*
@@ -165,6 +166,7 @@ library
                        Icicle.Sea.Psv.Base
                        Icicle.Sea.Psv.Input
                        Icicle.Sea.Psv.Output
+                       Icicle.Sea.Psv.Output.Dictionary
 
                        Icicle.Source.Eval
                        Icicle.Source.Query

--- a/src/Icicle/Sea/Eval.hs
+++ b/src/Icicle/Sea/Eval.hs
@@ -25,6 +25,8 @@ module Icicle.Sea.Eval (
   , seaPsvSnapshotFilePath
   , seaPsvSnapshotFd
   , seaRelease
+  , seaOutputDict
+  , defaultMissingValue
 
   , seaEvalAvalanche
 
@@ -74,7 +76,9 @@ import           Icicle.Sea.FromAvalanche.Program (seaOfProgram, nameOfProgram')
 import           Icicle.Sea.FromAvalanche.State (stateOfProgram, nameOfStateSize')
 import           Icicle.Sea.FromAvalanche.Type (seaOfDefinitions)
 import           Icicle.Sea.Preamble (seaPreamble)
-import           Icicle.Sea.Psv (PsvInputConfig(..), PsvOutputConfig(..), PsvMode(..), PsvFormat(..), seaOfPsvDriver)
+import           Icicle.Sea.Psv ( PsvInputConfig(..), PsvOutputConfig(..)
+                                , PsvMode(..), PsvFormat(..)
+                                , seaOfPsvDriver, seaOutputDict, defaultMissingValue)
 
 import           Jetski
 

--- a/src/Icicle/Sea/Psv.hs
+++ b/src/Icicle/Sea/Psv.hs
@@ -7,7 +7,9 @@ module Icicle.Sea.Psv (
   , PsvOutputConfig(..)
   , PsvMode(..)
   , PsvFormat(..)
+  , defaultMissingValue
   , seaOfPsvDriver
+  , seaOutputDict
   ) where
 
 import qualified Data.List as List
@@ -28,7 +30,6 @@ import           Icicle.Sea.Psv.Input
 import           Icicle.Sea.Psv.Output
 
 import           P
-
 
 
 seaOfPsvDriver

--- a/src/Icicle/Sea/Psv/Base.hs
+++ b/src/Icicle/Sea/Psv/Base.hs
@@ -5,6 +5,9 @@
 module Icicle.Sea.Psv.Base (
     PsvMode(..)
   , PsvFormat(..)
+  , MissingValue
+  , defaultMissingValue
+
   , StringWord(..)
   , wordsOfString
   , wordsOfBytes
@@ -33,8 +36,13 @@ data PsvMode
 
 data PsvFormat
   = PsvSparse
-  | PsvDense
+  | PsvDense   MissingValue
   deriving (Eq, Ord, Show)
+
+type MissingValue = Text
+
+defaultMissingValue :: Text
+defaultMissingValue = "NA"
 
 --------------------------------------------------------------------------------
 

--- a/src/Icicle/Sea/Psv/Output.hs
+++ b/src/Icicle/Sea/Psv/Output.hs
@@ -12,6 +12,7 @@ import qualified Data.List as List
 import           Data.Map (Map)
 import qualified Data.Map as Map
 import           Data.Text (Text)
+import qualified Data.Text as T
 
 import           Icicle.Avalanche.Prim.Flat (Prim(..), PrimUnsafe(..))
 import           Icicle.Avalanche.Prim.Flat (meltType)
@@ -180,7 +181,7 @@ seaOfWriteOutputDense struct structIndex outName@(OutputName name) outType argTy
   where
     -- Missing value needs to be unquoted
     bodyMissingValue
-      = outputValue "string" ["\"" <> pretty missingValue <> "\"", "2"]
+      = outputValue "string" ["\"" <> pretty missingValue <> "\"", pretty (T.length missingValue)]
 
     go body
       = pure

--- a/src/Icicle/Sea/Psv/Output/Dictionary.hs
+++ b/src/Icicle/Sea/Psv/Output/Dictionary.hs
@@ -1,0 +1,152 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
+module Icicle.Sea.Psv.Output.Dictionary
+  ( seaOutputDict
+  ) where
+
+import           Control.Monad.IO.Class (MonadIO(..))
+
+import           Data.Aeson
+import           Data.Aeson.Types
+import           Data.ByteString.Lazy (writeFile)
+import           Data.Text (Text)
+import           Data.Map  (Map)
+import qualified Data.List           as List
+import qualified Data.Map            as Map
+import qualified Data.Vector         as Vector
+import           System.IO (IO, FilePath)
+
+import           Icicle.Avalanche.Program (Program)
+import           Icicle.Avalanche.Prim.Flat (Prim)
+import           Icicle.Common.Annot (Annot)
+import           Icicle.Common.Base
+import           Icicle.Common.Type
+import           Icicle.Data (Attribute(..))
+import           Icicle.Sea.FromAvalanche.State
+import           Icicle.Sea.Error (SeaError(..))
+import           Icicle.Internal.Pretty (Pretty)
+
+import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
+
+import           Formation
+
+import           P
+
+
+data GlobalProps
+  = GlobalProps
+  { missingValue :: Text }
+
+instance ToJSON GlobalProps where
+  toJSON props
+    = object [ "missing_value: " .= missingValue props ]
+
+type Output  = Text
+
+formationVersion :: Text
+formationVersion = "1"
+
+encodingVersion :: EncodingVersion
+encodingVersion = EncodingVersion "1"
+
+seaOutputDict
+  :: (Ord n, Pretty n)
+  => FilePath
+  -> Text
+  -> [(Attribute, Program (Annot a) n Prim)]
+  -> EitherT SeaError IO ()
+seaOutputDict filepath tombstone programs
+  = do states  <- hoistEither
+                $ zipWithM (\ix (a, p) -> stateOfProgram ix a p) [0..] programs
+       let dict = encode (seaOutputSchema tombstone states)
+       liftIO $ writeFile filepath dict
+
+seaOutputSchema :: Text -> [SeaProgramState] -> Value
+seaOutputSchema t st
+  = schemaToJson (const encodeAttribute) encodingVersion
+      $ SchemaJsonV1
+      $ outputsToSchema t
+      $ m
+  where
+    m = outputs st
+
+--------------------------------------------------------------------------------
+
+outputsToSchema :: Text -> Map Output ValType -> Schema GlobalProps ValType
+outputsToSchema tombstone attrs
+  = Schema
+      formationVersion
+      encodingVersion
+      (StringEncoding 0)
+      (GlobalProps tombstone)
+      (outputsToAttributeSchema attrs)
+
+outputsToAttributeSchema :: Map Output ValType -> [AttributeSchema ValType]
+outputsToAttributeSchema attrs
+  = let names       = Map.toList attrs
+        go i (k, v) = AttributeSchema k i v
+    in  List.zipWith go [0..] names
+
+outputs :: [SeaProgramState] -> Map Output ValType
+outputs states
+  = let attrs = List.concatMap (fmap (unOutputName . fst) . stateOutputs) states
+        types = List.concatMap (fmap (fst          . snd) . stateOutputs) states
+    in  Map.fromList (List.zip attrs types)
+
+--------------------------------------------------------------------------------
+
+encodeAttributes :: Map Output ValType -> [Value]
+encodeAttributes = fmap encodeAttribute . Map.elems
+
+encodeAttribute :: ValType -> Value
+encodeAttribute = encodeType
+
+-- | Translate an Icicle output type to JSON.
+--
+encodeType :: ValType -> Value
+encodeType ty = case ty of
+  BoolT     -> Bool False
+  TimeT     -> String ""
+  DoubleT   -> Number 0
+  IntT      -> Number 0
+  StringT   -> String ""
+  UnitT     -> emptyObject
+  ErrorT    -> Null
+
+  ArrayT a
+   -> array [encodeType a]
+
+  -- In Sea:
+  -- Map is an array of size-two-arrays.
+  MapT k v
+   -> array [array [encodeType k, encodeType v]]
+
+  -- None becomes missing_value, Some is just the value
+  OptionT a -> encodeType a
+
+  -- Pair is actually a size-two-array
+  PairT a b
+   -> array [encodeType a, encodeType b]
+
+  -- In dense PSV, an error is always missing_value
+  SumT ErrorT v
+    -> encodeType v
+  -- Sum with anything else is not currently supported in C codegen, but is a valid type
+  SumT a b
+    -> array [array [encodeType a, encodeType b]]
+
+  -- Struct is just an array of size-two-arrays (field name and value)
+  StructT s
+    -> array $ encodeStruct s
+
+  BufT _ a
+   -> array [encodeType a]
+
+  where
+    array = Array . Vector.fromList
+
+    encodeStruct
+      = encodeAttributes . Map.mapKeys nameOfStructField . getStructType
+

--- a/src/Icicle/Sea/Psv/Output/Dictionary.hs
+++ b/src/Icicle/Sea/Psv/Output/Dictionary.hs
@@ -6,17 +6,15 @@ module Icicle.Sea.Psv.Output.Dictionary
   ( seaOutputDict
   ) where
 
-import           Control.Monad.IO.Class (MonadIO(..))
 
 import           Data.Aeson
 import           Data.Aeson.Types
-import           Data.ByteString.Lazy (writeFile)
+import           Data.ByteString.Lazy (ByteString)
 import           Data.Text (Text)
 import           Data.Map  (Map)
 import qualified Data.List           as List
 import qualified Data.Map            as Map
 import qualified Data.Vector         as Vector
-import           System.IO (IO, FilePath)
 
 import           Icicle.Avalanche.Program (Program)
 import           Icicle.Avalanche.Prim.Flat (Prim)
@@ -27,8 +25,6 @@ import           Icicle.Data (Attribute(..))
 import           Icicle.Sea.FromAvalanche.State
 import           Icicle.Sea.Error (SeaError(..))
 import           Icicle.Internal.Pretty (Pretty)
-
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither)
 
 import           Formation
 
@@ -53,15 +49,12 @@ encodingVersion = EncodingVersion "1"
 
 seaOutputDict
   :: (Ord n, Pretty n)
-  => FilePath
-  -> Text
+  => Text
   -> [(Attribute, Program (Annot a) n Prim)]
-  -> EitherT SeaError IO ()
-seaOutputDict filepath tombstone programs
-  = do states  <- hoistEither
-                $ zipWithM (\ix (a, p) -> stateOfProgram ix a p) [0..] programs
-       let dict = encode (seaOutputSchema tombstone states)
-       liftIO $ writeFile filepath dict
+  -> Either SeaError ByteString
+seaOutputDict tombstone programs
+  = do states  <- zipWithM (\ix (a, p) -> stateOfProgram ix a p) [0..] programs
+       pure $ encode $ seaOutputSchema tombstone states
 
 seaOutputSchema :: Text -> [SeaProgramState] -> Value
 seaOutputSchema t st


### PR DESCRIPTION
...in formation format

```JSON
{
  "global_properties":{
    "missing_value: ":"NA"
  },
  "entity_id":{
    "encoding":"string",
    "index":0
  },
  "attributes":[
    {
      "name":"expression_count_by_string",
      "encoding":{
        "listof":{
          "pairof":[
            {
              "primitive":"string"
            },
            {
              "primitive":"int"
            }
          ]
        }
      },
      "index":0
    },
    {
      "name":"expression_latest_two",
      "encoding":{
        "listof":{
          "primitive":"string"
        }
      },
      "index":1
    },
    {
      "name":"halibut_cherry_pie",
      "encoding":{
        "pairof":[
          {
            "primitive":"double"
          },
          {
            "primitive":"double"
          }
        ]
      },
      "index":2
    }
  ],
  "version":"1",
  "encoding_version":"1"
}
```

which describes this icicle dense snapshot

```
ID00000003|NA|[["a",1],["d",1]]|["a","d"]
ID00000002|NA|[["c",1]]|["c"]
ID00000001|[113.0,12.0]|[["c",2],["d",1]]|["d","c"]
ID00000000|[13.0,2.0]|[["a",1],["b",1]]|["a","b"]
```

note Icicle has a different format w.r.t to structs than Ivory. `[["a",1],["d",1]]` would be `{"a":1,"d":1}` in Ivory. Perhaps we should use a different `EncodingVersion` to indicate this