### PR TITLE
dense psv input

### DIFF
--- a/data/sea/52-psv.h
+++ b/data/sea/52-psv.h
@@ -65,7 +65,8 @@ static ierror_msg_t INLINE psv_write_outputs
   , size_t entity_size
   , ifleet_t *fleet );
 
-static ierror_loc_t INLINE psv_read_fact_sparse
+#if ICICLE_PSV_INPUT_SPARSE
+static ierror_loc_t INLINE psv_read_fact
   ( const char   *attrib_ptr
   , const size_t  attrib_size
   , const char   *value_ptr
@@ -73,14 +74,14 @@ static ierror_loc_t INLINE psv_read_fact_sparse
   , const char   *time_ptr
   , const size_t  time_size
   , ifleet_t     *fleet );
-
-static ierror_loc_t INLINE psv_read_fact_dense
+#else
+static ierror_loc_t INLINE psv_read_fact
   ( const char   *value_ptr
   , const size_t  value_size
   , const char   *time_ptr
   , const size_t  time_size
   , ifleet_t     *fleet );
-
+#endif
 
 /*
 Constants
@@ -151,7 +152,7 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
             goto on_error;
         }
 
-#if ICICLE_PSV_INPUT_DENSE
+#if ICICLE_PSV_INPUT_SPARSE
         const char  *attrib_ptr  = entity_end + 1;
         const char  *attrib_end  = memchr (attrib_ptr, '|', n_ptr - attrib_ptr);
         const size_t attrib_size = attrib_end - attrib_ptr;
@@ -178,7 +179,7 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
         const char  *time_end   = n_ptr;
         const size_t time_size  = time_end - time_ptr;
 
-#if ICICLE_PSV_INPUT_DENSE
+#if ICICLE_PSV_INPUT_SPARSE
         const char  *value_ptr  = attrib_end + 1;
 #else
         const char  *value_ptr  = entity_end + 1;
@@ -227,11 +228,11 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
         }
 
 #if ICICLE_PSV_INPUT_SPARSE
-        error = psv_read_fact_sparse (attrib_ptr, attrib_size, value_ptr, value_size, time_ptr, time_size, s->fleet);
+        error = psv_read_fact(attrib_ptr, attrib_size, value_ptr, value_size, time_ptr, time_size, s->fleet);
         if (error)
             goto on_error;
 #else
-        error = psv_read_fact_dense (value_ptr, value_size, time_ptr, time_size, s->fleet);
+        error = psv_read_fact(value_ptr, value_size, time_ptr, time_size, s->fleet);
         if (error)
           goto on_error;
 #endif

--- a/data/sea/52-psv.h
+++ b/data/sea/52-psv.h
@@ -65,10 +65,17 @@ static ierror_msg_t INLINE psv_write_outputs
   , size_t entity_size
   , ifleet_t *fleet );
 
-static ierror_loc_t INLINE psv_read_fact
+static ierror_loc_t INLINE psv_read_fact_sparse
   ( const char   *attrib_ptr
   , const size_t  attrib_size
   , const char   *value_ptr
+  , const size_t  value_size
+  , const char   *time_ptr
+  , const size_t  time_size
+  , ifleet_t     *fleet );
+
+static ierror_loc_t INLINE psv_read_fact_dense
+  ( const char   *value_ptr
   , const size_t  value_size
   , const char   *time_ptr
   , const size_t  time_size
@@ -144,6 +151,7 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
             goto on_error;
         }
 
+#if ICICLE_PSV_INPUT_DENSE
         const char  *attrib_ptr  = entity_end + 1;
         const char  *attrib_end  = memchr (attrib_ptr, '|', n_ptr - attrib_ptr);
         const size_t attrib_size = attrib_end - attrib_ptr;
@@ -152,6 +160,7 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
             error = ierror_loc_format (attrib_ptr, n_ptr, "missing '|' after attribute");
             goto on_error;
         }
+#endif
 
         const char *time_ptr;
         const char *n11_ptr = n_ptr - 11;
@@ -169,7 +178,12 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
         const char  *time_end   = n_ptr;
         const size_t time_size  = time_end - time_ptr;
 
+#if ICICLE_PSV_INPUT_DENSE
         const char  *value_ptr  = attrib_end + 1;
+#else
+        const char  *value_ptr  = entity_end + 1;
+#endif
+
         const char  *value_end  = time_ptr - 1;
         const size_t value_size = value_end - value_ptr;
 
@@ -212,9 +226,15 @@ static ierror_loc_t psv_read_buffer (psv_state_t *s)
             goto on_error;
         }
 
-        error = psv_read_fact (attrib_ptr, attrib_size, value_ptr, value_size, time_ptr, time_size, s->fleet);
+#if ICICLE_PSV_INPUT_SPARSE
+        error = psv_read_fact_sparse (attrib_ptr, attrib_size, value_ptr, value_size, time_ptr, time_size, s->fleet);
         if (error)
             goto on_error;
+#else
+        error = psv_read_fact_dense (value_ptr, value_size, time_ptr, time_size, s->fleet);
+        if (error)
+          goto on_error;
+#endif
 
         line_ptr = n_ptr + 1;
     }

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -222,6 +222,7 @@ library
                        Icicle.Storage.Dictionary.Toml.Toml
                        Icicle.Storage.Dictionary.Toml.Persist
                        Icicle.Storage.Dictionary.Toml.Prisms
+                       Icicle.Storage.Dictionary.Toml.Dense
                        Icicle.Storage.Dictionary.Toml.TomlDictionary
 
                        Icicle.Storage.Encoding

--- a/src/Icicle/Benchmark.hs
+++ b/src/Icicle/Benchmark.hs
@@ -94,8 +94,8 @@ createBenchmark mode dictionaryPath inputPath outputPath packedChordPath = do
   dictionary <- firstEitherT BenchDictionaryImportError (loadDictionary ImplicitPrelude dictionaryPath)
   avalanche  <- hoistEither (avalancheOfDictionary dictionary)
 
-  let cfg = Psv (PsvInputConfig  mode (tombstonesOfDictionary dictionary))
-                (PsvOutputConfig mode PsvSparse)
+  let cfg = Psv (PsvInputConfig  mode (tombstonesOfDictionary dictionary) PsvInputSparse)
+                (PsvOutputConfig mode PsvOutputSparse)
 
   let avalancheL = Map.toList avalanche
 

--- a/src/Icicle/Data.hs
+++ b/src/Icicle/Data.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DeriveFoldable #-}
 module Icicle.Data (
     Entity (..)
   , Namespace (..)
@@ -74,7 +76,7 @@ data AsAt a =
   AsAt {
       atFact :: a
     , atTime :: Time
-    } deriving (Eq, Show, Functor)
+    } deriving (Eq, Show, Functor, Foldable, Traversable)
 
 --------------------------------------------------------------------------------
 

--- a/src/Icicle/Sea/Error.hs
+++ b/src/Icicle/Sea/Error.hs
@@ -32,6 +32,7 @@ data SeaError
   | SeaUnsupportedOutputType                 ValType
   | SeaOutputTypeMismatch         OutputName ValType    [ValType]
   | SeaStructFieldsMismatch                  StructType [(Text, ValType)]
+  | SeaDenseFieldsMismatch        [(Text, ValType)] [(Text, ValType)]
   | SeaNoFactLoop
   | SeaNoOutputs
   deriving (Eq, Show)
@@ -61,6 +62,11 @@ instance Pretty SeaError where
      -> vsep [ "Struct type did not match C struct members:"
              , "  struct type = " <> pretty st
              , "  members     = " <> pretty vs ]
+
+    SeaDenseFieldsMismatch st vs
+     -> vsep [ "Dense fields did not match C struct members:"
+             , "  dense fields = " <> pretty st
+             , "  members      = " <> pretty vs ]
 
     SeaInputTypeMismatch t ns
      -> vsep [ "Unsupported mapping, cannot map input type to its C struct members"

--- a/src/Icicle/Sea/Error.hs
+++ b/src/Icicle/Sea/Error.hs
@@ -5,6 +5,8 @@ module Icicle.Sea.Error (
     SeaError(..)
   ) where
 
+import           Data.Map  (Map)
+import qualified Data.Map as Map
 import           Data.Text (Text)
 
 import           Icicle.Common.Base (BaseValue, OutputName)
@@ -33,6 +35,7 @@ data SeaError
   | SeaOutputTypeMismatch         OutputName ValType    [ValType]
   | SeaStructFieldsMismatch                  StructType [(Text, ValType)]
   | SeaDenseFieldsMismatch        [(Text, ValType)] [(Text, ValType)]
+  | SeaDenseFeedNotDefined        Text (Map Text [(Text, ValType)])
   | SeaNoFactLoop
   | SeaNoOutputs
   deriving (Eq, Show)
@@ -68,6 +71,11 @@ instance Pretty SeaError where
              , "  dense fields = " <> pretty st
              , "  members      = " <> pretty vs ]
 
+    SeaDenseFeedNotDefined attr fs
+     -> vsep [ "Dense feed not defined in dictionary:"
+             , "  dense feeds = " <> pretty (Map.toList fs)
+             , "  looking for = " <> pretty attr
+             ]
     SeaInputTypeMismatch t ns
      -> vsep [ "Unsupported mapping, cannot map input type to its C struct members"
              , "  input type    = " <> pretty t

--- a/src/Icicle/Sea/Eval.hs
+++ b/src/Icicle/Sea/Eval.hs
@@ -368,7 +368,11 @@ codeOfPrograms psv programs = do
       pure . textOfDoc . vsep $ ["#define ICICLE_NO_PSV 1", seaPreamble, defs] <> progs
     Psv icfg ocfg -> do
       psv_doc <- seaOfPsvDriver states icfg ocfg
-      pure . textOfDoc . vsep $ [seaPreamble, defs] <> progs <> ["", psv_doc]
+      let def  = case inputPsvFormat icfg of
+                   PsvInputSparse -> "#define ICICLE_PSV_INPUT_SPARSE 1"
+                   _              -> ""
+
+      pure . textOfDoc . vsep $ [def, seaPreamble, defs] <> progs <> ["", psv_doc]
 
 textOfDoc :: Doc -> Text
 textOfDoc doc = T.pack (displayS (renderPretty 0.8 80 (pretty doc)) "")

--- a/src/Icicle/Sea/Eval.hs
+++ b/src/Icicle/Sea/Eval.hs
@@ -17,7 +17,9 @@ module Icicle.Sea.Eval (
   , PsvInputConfig(..)
   , PsvOutputConfig(..)
   , PsvMode(..)
-  , PsvFormat(..)
+  , PsvOutputFormat(..)
+  , PsvInputFormat(..)
+  , PsvInputDenseDict(..)
 
   , seaCompile
   , seaCompile'
@@ -74,7 +76,9 @@ import           Icicle.Sea.FromAvalanche.Program (seaOfProgram, nameOfProgram')
 import           Icicle.Sea.FromAvalanche.State (stateOfProgram, nameOfStateSize')
 import           Icicle.Sea.FromAvalanche.Type (seaOfDefinitions)
 import           Icicle.Sea.Preamble (seaPreamble)
-import           Icicle.Sea.Psv (PsvInputConfig(..), PsvOutputConfig(..), PsvMode(..), PsvFormat(..), seaOfPsvDriver)
+import           Icicle.Sea.Psv ( PsvInputConfig(..), PsvOutputConfig(..), PsvMode(..)
+                                , PsvInputFormat(..), PsvOutputFormat (..) , PsvInputDenseDict (..)
+                                , seaOfPsvDriver)
 
 import           Jetski
 

--- a/src/Icicle/Sea/Psv.hs
+++ b/src/Icicle/Sea/Psv.hs
@@ -6,7 +6,9 @@ module Icicle.Sea.Psv (
     PsvInputConfig(..)
   , PsvOutputConfig(..)
   , PsvMode(..)
-  , PsvFormat(..)
+  , PsvOutputFormat(..)
+  , PsvInputFormat(..)
+  , PsvInputDenseDict(..)
   , seaOfPsvDriver
   , defaultMissingValue
   ) where

--- a/src/Icicle/Sea/Psv/Base.hs
+++ b/src/Icicle/Sea/Psv/Base.hs
@@ -4,10 +4,7 @@
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Sea.Psv.Base (
     PsvMode(..)
-  , PsvFormat(..)
   , StringWord(..)
-  , MissingValue
-  , defaultMissingValue
   , wordsOfString
   , wordsOfBytes
   , wordsOfBytes'
@@ -32,16 +29,6 @@ data PsvMode
   = PsvSnapshot Time
   | PsvChords
   deriving (Eq, Ord, Show)
-
-data PsvFormat
-  = PsvSparse
-  | PsvDense MissingValue
-  deriving (Eq, Ord, Show)
-
-type MissingValue = Text
-
-defaultMissingValue :: Text
-defaultMissingValue = "NA"
 
 --------------------------------------------------------------------------------
 

--- a/src/Icicle/Sea/Psv/Output.hs
+++ b/src/Icicle/Sea/Psv/Output.hs
@@ -32,8 +32,18 @@ import           Prelude (String)
 
 data PsvOutputConfig = PsvOutputConfig {
     outputPsvMode   :: PsvMode
-  , outputPsvFormat :: PsvFormat
+  , outputPsvFormat :: PsvOutputFormat
   } deriving (Eq, Ord, Show)
+
+data PsvOutputFormat
+  = PsvOutputSparse
+  | PsvOutputDense MissingValue
+  deriving (Eq, Ord, Show)
+
+type MissingValue = Text
+
+defaultMissingValue :: Text
+defaultMissingValue = "NA"
 
 ------------------------------------------------------------------------
 
@@ -42,9 +52,9 @@ seaOfWriteFleetOutput config states = do
   write_sea <- traverse (seaOfWriteProgramOutput config) states
   let (beforeChord, inChord, afterChord)
          = case outputPsvFormat config of
-             PsvDense _
+             PsvOutputDense _
               -> (outputEntity, outputChord, outputChar '\n')
-             PsvSparse
+             PsvOutputSparse
               -> ("", "", "")
 
   pure $ vsep
@@ -107,9 +117,9 @@ seaOfWriteProgramOutput config state = do
 
   let outputState (name, (ty, tys))
         = case outputPsvFormat config of
-            PsvSparse
+            PsvOutputSparse
               -> seaOfWriteOutputSparse ps 0 name ty tys
-            PsvDense missingValue
+            PsvOutputDense missingValue
               -> seaOfWriteOutputDense  ps 0 name ty tys missingValue
 
   let outputRes   name

--- a/src/Icicle/Storage/Dictionary/Toml/Dense.hs
+++ b/src/Icicle/Storage/Dictionary/Toml/Dense.hs
@@ -1,0 +1,117 @@
+-- | In dense PSV, each feed (e.g. demograpghics) is an attribute (e.g. "person")
+--   In TOML, this is:
+--
+--   @
+--   [feed.demographics]
+--      columns = ["age", "state", "injury"]
+--
+--   [fact.demographics]
+--      encoding = (age:"int",state:"string",injury:(location:"string",severity:"int"))
+--   @
+--
+--   We use this information to tell how to parse each data feed.
+--
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Storage.Dictionary.Toml.Dense
+  ( PsvInputDenseDict (..)
+  , DictionaryDenseError (..)
+  , denseFeeds
+  ) where
+
+import Control.Lens
+
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.Text as Text
+import qualified Data.List as List
+import qualified Data.Map  as Map
+import Data.Map  (Map)
+import Data.Text (Text)
+
+import P
+
+import Icicle.Common.Type (ValType)
+import Icicle.Data
+import Icicle.Encoding
+import Icicle.Dictionary.Data
+import Icicle.Storage.Dictionary.Toml.Types
+import Icicle.Storage.Dictionary.Toml.Prisms
+
+
+data FeedTable
+  = FeedTable
+  { feedName   :: Text
+  , feedFields :: [Text] }
+
+data DenseStructEncoding
+  = DenseStructEncoding
+  { structName :: Text
+  , structFields :: Map Text Encoding }
+
+data DictionaryDenseError
+  = UndefinedFeed Text
+  | InvalidFeedTable Text
+  deriving (Eq, Show)
+
+newtype PsvInputDenseDict
+  = PsvInputDenseDict
+  { denseDict :: Map Text [(Text, ValType)] }
+  deriving (Eq, Ord, Show)
+
+
+denseFeeds :: Dictionary -> Table -> Either DictionaryDenseError PsvInputDenseDict
+denseFeeds dict toml
+  = do ffs    <- denseEncodings toml
+       let ss  = concreteStructs dict
+       ss'    <- orderStructs ss ffs
+       feeds  <- zipWithM go (fmap feedFields ffs) ss'
+       pure $ PsvInputDenseDict $ Map.fromList $ feeds
+  where
+    go fieldNames s
+      = do fields  <- orderFields fieldNames (structFields s)
+           let fs   = fmap (second sourceTypeOfEncoding) fields
+           pure $ (structName s, fs)
+
+orderStructs :: [DenseStructEncoding] -> [FeedTable] -> Either DictionaryDenseError [DenseStructEncoding]
+orderStructs ss ffs
+  = foldM go [] (fmap feedName ffs)
+  where
+    go acc f
+      = case List.find ((== f) . structName) ss of
+          Just s  -> pure $ acc <> [s]
+          Nothing -> Left $ UndefinedFeed f
+
+orderFields :: [Text] -> Map Text Encoding -> Either DictionaryDenseError [(Text, Encoding)]
+orderFields ordering fields
+  = foldM go [] ordering
+  where
+    go acc f
+      = case Map.lookup f fields of
+          Just e  -> pure $ acc <> [(f, e)]
+          Nothing -> Left $ UndefinedFeed f
+
+denseEncodings :: Table -> Either DictionaryDenseError [FeedTable]
+denseEncodings toml = do
+  let feeds = fromMaybe (HashMap.empty)
+            $ join $ traverse ((^? _NTable) . fst) $ (toml ^? key "feed")
+  foldM go [] $ HashMap.toList feeds
+  where
+    go acc (k, (v, _))
+      = case join (fmap (sequence . fmap (^? _VString)) (v ^? _NTValue . _VArray)) of
+          Just fieldNames
+            -> pure $ FeedTable k (fmap (Text.pack . fmap fst) fieldNames) : acc
+          _ -> Left $ InvalidFeedTable k
+
+concreteStructs :: Dictionary -> [DenseStructEncoding]
+concreteStructs dict
+  = fmap mappingOfStructs $ foldr go [] $ dictionaryEntries dict
+  where
+    go (DictionaryEntry a (ConcreteDefinition (StructEncoding st) _)) acc
+      = (a, st) : acc
+    go _ acc
+      = acc
+
+    mappingOfStructs (fname, fs)
+      = DenseStructEncoding (getAttribute fname)
+      $ Map.fromList
+      $ fmap (\(StructField _ a e) -> (getAttribute a,e)) fs

--- a/test/Icicle/Test/Sea/Arbitrary.hs
+++ b/test/Icicle/Test/Sea/Arbitrary.hs
@@ -63,9 +63,13 @@ instance Arbitrary InputType where
 
 instance Arbitrary WellTyped where
   arbitrary = validated 10 $ do
+    (InputType ty) <- arbitrary
+    tryGenWellTypedWith ty
+
+tryGenWellTypedWith :: ValType -> Gen (Maybe WellTyped)
+tryGenWellTypedWith ty = do
     entities       <- List.sort . List.nub . getNonEmpty <$> arbitrary
     attribute      <- arbitrary
-    (InputType ty) <- arbitrary
     (inputs, time) <- first (List.nubBy ((==) `on` atTime)) <$> inputsForType ty
     core           <- programForStreamType ty
     return $ do
@@ -106,6 +110,7 @@ instance Arbitrary WellTyped where
 
       supportedOutput t | isSupportedOutput t = Just t
       supportedOutput _                       = Nothing
+
 
 ------------------------------------------------------------------------
 

--- a/test/Icicle/Test/Sea/Psv.hs
+++ b/test/Icicle/Test/Sea/Psv.hs
@@ -28,6 +28,7 @@ import           Icicle.Internal.Pretty
 
 import           Icicle.Common.Data
 import           Icicle.Common.Base
+import           Icicle.Common.Type
 
 import qualified Icicle.Sea.Eval as S
 
@@ -41,16 +42,17 @@ import           System.IO
 import           System.IO.Temp (createTempDirectory)
 import           System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 
-import           Test.QuickCheck (Args(..), forAllProperties, quickCheckWithResult, stdArgs)
+import           Test.QuickCheck (Args(..), Gen, forAllProperties, quickCheckWithResult
+                                 ,stdArgs, arbitrary)
 import           Test.QuickCheck (Property, (==>), property, counterexample)
 import           Test.QuickCheck.Property (succeeded, failed)
+import           Test.QuickCheck.Monadic
 
 import           X.Control.Monad.Trans.Either (EitherT, runEitherT)
 import           X.Control.Monad.Trans.Either (bracketEitherT', left)
 
-
 prop_psv wt = testIO $ do
-  x <- runEitherT (runTest ShowDataOnError wt)
+  x <- runEitherT (runTest (TestOpts ShowInputOnError ShowOutputOnError S.PsvInputSparse) wt)
   case x of
     Left err -> failWithError wt err
     Right () -> pure (property succeeded)
@@ -60,7 +62,7 @@ prop_entity_out_of_order wt =
   List.length (wtFacts    wt) > 0 ==>
   testIO $ do
     let wt' = wt { wtEntities = List.reverse (wtEntities wt) }
-    x <- runEitherT (runTest ShowDataOnSuccess wt')
+    x <- runEitherT (runTest (TestOpts ShowInputOnSuccess ShowOutputOnSuccess S.PsvInputSparse) wt')
     expectPsvError wt' x
 
 prop_time_out_of_order wt =
@@ -68,8 +70,28 @@ prop_time_out_of_order wt =
   List.length (wtFacts    wt) > 1 ==>
   testIO $ do
     let wt' = wt { wtFacts = List.reverse (wtFacts wt) }
-    x <- runEitherT (runTest ShowDataOnSuccess wt')
+    x <- runEitherT (runTest (TestOpts ShowInputOnSuccess ShowOutputOnSuccess S.PsvInputSparse) wt')
     expectPsvError wt' x
+
+prop_sparse_dense_both_compile
+  = monadicIO
+  $ do wt <- pick genWellTypedWithStruct
+       case denseDictionary (wtAttribute wt) (wtFactType wt) of
+         Nothing -> pure
+                  $ counterexample ("Cannot create dense dictionary for:")
+                  $ counterexample (show (wtFactType wt))
+                  $ failed
+         Just d  -> do
+           e <- liftIO $ runEitherT (runTest (TestOpts ShowInputOnError ShowOutputOnError (S.PsvInputDense d)) wt)
+           s <- liftIO $ runEitherT (runTest (TestOpts ShowInputOnError ShowOutputOnError S.PsvInputSparse) wt)
+           case (s, e) of
+             (Right _, Right _) -> pure (property succeeded)
+             (Left err, _)      -> liftIO
+                                 $ failWithError'
+                                   (counterexample ("==* sparse failed!")) wt err
+             (_, Left err)      -> liftIO
+                                 $ failWithError'
+                                   (counterexample ("==* dense failed!")) wt err
 
 expectPsvError :: WellTyped -> Either S.SeaError () -> IO Property
 expectPsvError wt = \case
@@ -92,9 +114,13 @@ expectPsvError wt = \case
     $ failed
 
 failWithError :: WellTyped -> S.SeaError -> IO Property
-failWithError wt = \case
+failWithError = failWithError' id
+
+failWithError' :: (Property -> Property) -> WellTyped -> S.SeaError -> IO Property
+failWithError' prints wt = \case
   S.SeaJetskiError (J.CompilerError _ src err)
    -> pure
+    $ prints
     $ counterexample (show (pretty src))
     $ counterexample (show (pretty err))
     $ counterexample (show (pretty (wtCore wt)))
@@ -102,26 +128,35 @@ failWithError wt = \case
 
   err
    -> pure
+    $ prints
     $ counterexample (show (pretty err))
     $ counterexample (show (pretty (wtCore wt)))
     $ failed
 
 ------------------------------------------------------------------------
 
-data ShowData = ShowDataOnError | ShowDataOnSuccess
+data ShowInput = ShowInputOnError | ShowInputOnSuccess
   deriving (Eq)
 
-runTest :: ShowData -> WellTyped -> EitherT S.SeaError IO ()
-runTest showData wt = do
+data ShowOutput = ShowOutputOnError | ShowOutputOnSuccess
+  deriving (Eq)
+
+
+data TestOpts = TestOpts ShowInput ShowOutput S.PsvInputFormat
+
+runTest :: TestOpts -> WellTyped -> EitherT S.SeaError IO ()
+runTest (TestOpts showInput showOutput inputFormat) wt = do
   options0 <- S.getCompilerOptions
 
   let options  = options0 <> ["-O0", "-DICICLE_NOINLINE=1"]
       programs = Map.singleton (wtAttribute wt) (wtAvalanche wt)
-      iconfig  = S.PsvInputConfig  (S.PsvSnapshot (wtTime wt))
-                                   (Map.singleton (wtAttribute wt) (Set.singleton tombstone))
-                                   (S.PsvInputSparse)
-      oconfig  = S.PsvOutputConfig (S.PsvSnapshot (wtTime wt))
-                                   (S.PsvOutputSparse)
+      iconfig  = S.PsvInputConfig
+                (S.PsvSnapshot (wtTime wt))
+                (Map.singleton (wtAttribute wt) (Set.singleton tombstone))
+                 inputFormat
+      oconfig  = S.PsvOutputConfig
+                (S.PsvSnapshot (wtTime wt))
+                (S.PsvOutputSparse)
 
   let compile  = S.seaCompile' options (S.Psv iconfig oconfig) programs
       release  = S.seaRelease
@@ -147,14 +182,22 @@ runTest showData wt = do
 
     case result of
       Left err -> do
-        when (showData == ShowDataOnError) $ do
+        when (showInput == ShowInputOnError) $ do
           liftIO (LT.putStrLn "--- input.psv ---")
           liftIO (LT.putStrLn inputPsv)
+        when (showOutput == ShowOutputOnError) $ do
+          outputPsv <- liftIO $ LT.readFile output
+          liftIO (LT.putStrLn "--- output.psv ---")
+          liftIO (LT.putStrLn outputPsv)
         left err
       Right _ -> do
-        when (showData == ShowDataOnSuccess) $ do
+        when (showInput == ShowInputOnSuccess) $ do
           liftIO (LT.putStrLn "--- input.psv ---")
           liftIO (LT.putStrLn inputPsv)
+        when (showOutput == ShowOutputOnSuccess) $ do
+          outputPsv <- liftIO $ LT.readFile output
+          liftIO (LT.putStrLn "--- output.psv ---")
+          liftIO (LT.putStrLn outputPsv)
         pure ()
 
 textOfFacts :: [Entity] -> Attribute -> [AsAt BaseValue] -> LT.Text
@@ -191,6 +234,53 @@ withSystemTempDirectory template action = do
   let acquire = liftIO (getTemporaryDirectory >>= \tmp -> createTempDirectory tmp template)
       release = liftIO . removeDirectoryRecursive
   bracketEitherT' acquire release action
+
+
+-- If the input are structs, we can pretend it's a dense value
+-- We can't treat other values as a single-field dense struct because the
+-- generated programs do not treat them as such.
+
+genWellTypedWithStruct :: Gen WellTyped
+genWellTypedWithStruct = validated 10 $ do
+  st <- arbitrary :: Gen StructType
+  tryGenWellTypedWith (StructT st)
+
+denseTextOfFacts :: [Entity] -> [AsAt BaseValue] -> LT.Text
+denseTextOfFacts entities vs =
+  LT.unlines (fmap (LT.intercalate "|") (denseFieldsOfFacts entities vs))
+
+denseFieldsOfFacts :: [Entity] -> [AsAt BaseValue] -> [[LT.Text]]
+denseFieldsOfFacts entities vs
+  | Just (AsAt v t) <- sequence' vs
+  , Just fs  <- sequence $ fmap (sequence . flip AsAt t . structValues) v
+  =  [ [ LT.fromStrict entity, valueText, timeText ]
+     | Entity entity         <- entities
+     , (valueText, timeText) <- denseTextsOfValues fs ]
+  | otherwise
+  =  [ [ LT.fromStrict entity, valueText, timeText ]
+     | Entity entity         <- entities
+     , (valueText, timeText) <- textsOfValues vs ]
+  where
+    sequence' [] = Nothing
+    sequence' (AsAt x t : xs) = Just $ AsAt (x : fmap atFact xs) t
+    structValues
+      = \case VStruct m -> Just (Map.elems m)
+              _         -> Nothing
+
+denseTextsOfValues :: [AsAt [BaseValue]] -> [(LT.Text, LT.Text)]
+denseTextsOfValues vs =
+  List.zip
+    (fmap (LT.intercalate "|" . fmap textOfValue . atFact) vs)
+    (fmap (textOfTime . atTime) vs)
+
+denseDictionary :: Attribute -> ValType -> Maybe S.PsvInputDenseDict
+denseDictionary denseName (StructT (StructType m))
+  = Just
+  $ S.PsvInputDenseDict
+  $ Map.singleton (getAttribute denseName)
+  $ Map.toList
+  $ Map.mapKeys nameOfStructField m
+denseDictionary _ _ = Nothing
 
 ------------------------------------------------------------------------
 

--- a/test/Icicle/Test/Sea/Psv.hs
+++ b/test/Icicle/Test/Sea/Psv.hs
@@ -119,7 +119,9 @@ runTest showData wt = do
       programs = Map.singleton (wtAttribute wt) (wtAvalanche wt)
       iconfig  = S.PsvInputConfig  (S.PsvSnapshot (wtTime wt))
                                    (Map.singleton (wtAttribute wt) (Set.singleton tombstone))
-      oconfig  = S.PsvOutputConfig (S.PsvSnapshot (wtTime wt)) S.PsvSparse
+                                   (S.PsvInputSparse)
+      oconfig  = S.PsvOutputConfig (S.PsvSnapshot (wtTime wt))
+                                   (S.PsvOutputSparse)
 
   let compile  = S.seaCompile' options (S.Psv iconfig oconfig) programs
       release  = S.seaRelease


### PR DESCRIPTION
Parse dense PSV (snapshots, feeds) as input. e.g. this sample data feed:

```
homer|0|CA|1989-12-17
lisa|5|CA|1989-12-18
lisa|9|UT|1991-12-19
marge|8|CA|1989-12-17
marge|9|UT|1991-12-19
```

This input will be parsed as a single struct `(misery:int,state:string)`. The format is specified in the TOML dictionary:

```
[feed.person]
  columns = ["misery", "state"]

[fact.person]
  encoding = "(misery:int,state:string)"

[feature.mean_misery_by_state]
  expression = "feature person ~> group state ~> mean misery"
```

Sample output:

```
marge|[["CA",8.0],["UT",9.0]]
homer|[["CA",0.0]]
lisa|[["CA",5.0],["UT",9.0]]
```

The current caveat is that we can't have a struct as one of the dense fields, e.g. this is an error:

```
lisa|5|{"location":"head", "serverity":2}|1992-01-01
```

This is because we require structs to have primitive encodings. It should be changed eventually, at least when we are processing dense input.

@markhibberd @HuwCampbell @jystic 
