### PR TITLE
allow multiple dense feeds

### DIFF
--- a/src/Icicle/Sea/Psv.hs
+++ b/src/Icicle/Sea/Psv.hs
@@ -41,12 +41,18 @@ seaOfPsvDriver
   -> PsvOutputConfig
   -> Either SeaError Doc
 seaOfPsvDriver states inputConfig outputConfig = do
+  let outputList  = case inputPsvFormat inputConfig of
+                      PsvInputSparse
+                        -> Nothing
+                      PsvInputDense _ feed
+                        -> Just [feed]
+
   let struct_sea  = seaOfFleetState      states
       alloc_sea   = seaOfAllocFleet      states
       collect_sea = seaOfCollectFleet    states
       config_sea  = seaOfConfigureFleet (inputPsvMode inputConfig) states
   read_sea  <- seaOfReadAnyFact      inputConfig  states
-  write_sea <- seaOfWriteFleetOutput outputConfig states
+  write_sea <- seaOfWriteFleetOutput outputConfig outputList states
   pure $ vsep
     [ struct_sea
     , ""

--- a/src/Icicle/Sea/Psv/Output.hs
+++ b/src/Icicle/Sea/Psv/Output.hs
@@ -16,6 +16,8 @@ import           Icicle.Avalanche.Prim.Flat (meltType)
 import           Icicle.Common.Base (OutputName(..))
 import           Icicle.Common.Type (ValType(..))
 
+import           Icicle.Data (Attribute(..))
+
 import           Icicle.Internal.Pretty
 
 import           Icicle.Sea.Error (SeaError(..))
@@ -42,14 +44,19 @@ data PsvOutputFormat
 
 type MissingValue = Text
 
+type PsvOutputWhiteList = Maybe [Text]
+
 defaultMissingValue :: Text
 defaultMissingValue = "NA"
 
 ------------------------------------------------------------------------
 
-seaOfWriteFleetOutput :: PsvOutputConfig -> [SeaProgramState] -> Either SeaError Doc
-seaOfWriteFleetOutput config states = do
-  write_sea <- traverse (seaOfWriteProgramOutput config) states
+seaOfWriteFleetOutput :: PsvOutputConfig -> PsvOutputWhiteList -> [SeaProgramState] -> Either SeaError Doc
+seaOfWriteFleetOutput config whitelist states = do
+  let states' = case whitelist of
+                  Nothing -> states
+                  Just as -> filter (flip List.elem as . getAttribute . stateAttribute) states
+  write_sea  <- traverse (seaOfWriteProgramOutput config) states'
   let (beforeChord, inChord, afterChord)
          = case outputPsvFormat config of
              PsvOutputDense _

--- a/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/src/Icicle/Storage/Dictionary/Toml.hs
@@ -68,11 +68,12 @@ loadDictionary impPrelude dictionary
 loadDenseDictionary
   :: ImplicitPrelude
   -> FilePath
+  -> Maybe PsvInputDenseFeedName
   -> EitherT DictionaryImportError IO (Dictionary, PsvInputDenseDict)
-loadDenseDictionary impPrelude dictionary
+loadDenseDictionary impPrelude dictionary feed
   = do d    <- loadDictionary impPrelude dictionary
        toml <- parseTOML dictionary
-       dd   <- firstEitherT DictionaryErrorDense $ hoistEither $ denseFeeds d toml
+       dd   <- firstEitherT DictionaryErrorDense $ hoistEither $ denseFeeds d toml feed
        return (d, dd)
 
 loadDictionary'

--- a/test/Icicle/Test/Sea/Psv.hs
+++ b/test/Icicle/Test/Sea/Psv.hs
@@ -111,11 +111,17 @@ prop_sparse_dense_both_compile
            e <- liftIO
               $ runEitherT
               $ runTest wt
-              $ TestOpts ShowInputOnError ShowOutputOnError (S.PsvInputDense d) S.DoNotAllowDupTime
+              $ TestOpts ShowInputOnError
+                         ShowOutputOnError
+                         (S.PsvInputDense d (getAttribute (wtAttribute wt)))
+                         S.DoNotAllowDupTime
            s <- liftIO
               $ runEitherT
               $ runTest wt
-              $ TestOpts ShowInputOnError ShowOutputOnError S.PsvInputSparse S.DoNotAllowDupTime
+              $ TestOpts ShowInputOnError
+                         ShowOutputOnError
+                         S.PsvInputSparse
+                         S.DoNotAllowDupTime
            case (s, e) of
              (Right _, Right _) -> pure (property succeeded)
              (Left err, _)      -> stop
@@ -309,6 +315,7 @@ denseDictionary denseName (StructT (StructType m))
               $ S.PsvInputDenseDict
                   (Map.singleton (getAttribute denseName) fs)
                   (maybe Map.empty (Map.singleton n) missingValue)
+                  n
 denseDictionary _ _ = return Nothing
 
 genMissingValue :: Gen (Maybe Text)


### PR DESCRIPTION
@HuwCampbell 

this lets you specify the dense feed to use. If there are multiple feeds, the user must select one at run time. If there is only one feed it will be automatically used. 

e.g. with dictionary

```
[feed.person]
  columns = ["misery", "state", "injury"]
[feed.thing]
  columns = ["price"]
...
```

run ice on `person`s:

```
./dist/build/Ice/ice snapshot data_person.psv dict.toml 2015-01-01 --input-psv dense:person --output-psv sparse        
marge|mean_misery_by_injury_location|[["foot",8.0],["head",7.0]]
marge|mean_misery_by_state|[["CA",8.0],["UT",7.0]]
marge|newest_misery|5
```

run ice on `thing`s:

```
./dist/build/Ice/ice snapshot data_thing.psv dict.toml 2015-01-01 --input-psv dense:thing --output-psv sparse
milk|foo|2.0
```

run ice with mismatched feed name and input data can give you either an error or garbage output:

```
./dist/build/Ice/ice snapshot data_person.psv dict.toml 2015-01-01 --input-psv dense:thing --output-psv sparse
line 1: marge|8|CA|{"location":"foot","severity":4.3}|1989-12-17
               ^ invalid dense field start

./dist/build/Ice/ice snapshot data_thing.psv dict.toml 2015-01-01 --input-psv dense:person --output-psv sparse                ⏎ ✹ ✭
milk|mean_misery_by_injury_location|[["",2.0]]
milk|mean_misery_by_state|[["",2.0]]
milk|newest_misery|2
```

if there is only one feed you can just say `dense` rather than `dense:FEED`:

```
./dist/build/Ice/ice snapshot data_thing.psv dict_thing.toml 2015-01-01 --input-psv dense --output-psv sparse
```