### PR TITLE
match user dense field ordering

### DIFF
--- a/src/Icicle/Sea/Error.hs
+++ b/src/Icicle/Sea/Error.hs
@@ -34,6 +34,7 @@ data SeaError
   | SeaUnsupportedOutputType                 ValType
   | SeaOutputTypeMismatch         OutputName ValType    [ValType]
   | SeaStructFieldsMismatch                  StructType [(Text, ValType)]
+  | SeaDenseFieldNotDefined      Text              [Text]
   | SeaDenseFieldsMismatch        [(Text, ValType)] [(Text, ValType)]
   | SeaDenseFeedNotDefined        Text (Map Text [(Text, ValType)])
   | SeaNoFactLoop
@@ -65,6 +66,11 @@ instance Pretty SeaError where
      -> vsep [ "Struct type did not match C struct members:"
              , "  struct type = " <> pretty st
              , "  members     = " <> pretty vs ]
+
+    SeaDenseFieldNotDefined s ss
+     -> vsep [ "Dense field does not exist:"
+             , "  dense field   = " <> pretty s
+             , "  struct fields = " <> pretty ss ]
 
     SeaDenseFieldsMismatch st vs
      -> vsep [ "Dense fields did not match C struct members:"


### PR DESCRIPTION
Undo the savage struct-reordering I did to match user's specified column ordering with the map-ordering that Icicle assumes.

example

```
title = "toy"
namespace = "story"

[fact.stuff]
  encoding = "(foo:int,age:int*,name:string*)"

[feed.stuff]
  missing = "NA"
  columns = ["foo","age", "name"]

[feature.severity]
  expression = "feature stuff ~> filter isSome age ~> mean (getOrElse 0 age)"
```

@jystic 