### PR TITLE
Fix bug in distinct: make Option_fold explicitly delay the 'none' cas…

### DIFF
--- a/src/Icicle/Avalanche/Statement/Flatten.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten.hs
@@ -498,8 +498,9 @@ flatX a_fresh xx stm
       acc  <- fresh
       stm' <- stm (xVar acc)
       tmp  <- fresh
+      let vunit = xValue UnitT VUnit
       ssome <- flatX' (xsome `xApp` (xVar tmp)) $ (return . Write acc)
-      snone <- flatX' xnone $ (return . Write acc)
+      snone <- flatX' (xnone `xApp` vunit)  $ (return . Write acc)
       let if_   = If (fpIsSome ta `xApp` opt') (Let tmp (fpOptionGet ta `xApp` opt') ssome) snone
           -- After if, read back result from accumulator and then go do the rest of the statements
           read_ = Read acc acc valT stm'

--- a/src/Icicle/Core/Eval/Exp.hs
+++ b/src/Icicle/Core/Eval/Exp.hs
@@ -45,7 +45,7 @@ evalPrim p vs
       | [s, _, VBase (VSome v)] <- vs
       -> applies' s [VBase v]
       | [_, n, VBase (VNone)] <- vs
-      -> return n
+      -> applies' n [VBase VUnit]
       | otherwise
       -> primError
 

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -80,7 +80,7 @@ typeOfPrim p
     PrimFold (PrimFoldArray a) ret
      -> FunT [FunT [funOfVal ret, funOfVal a] ret, funOfVal ret, funOfVal (ArrayT a)] ret
     PrimFold (PrimFoldOption a) ret
-     -> FunT [FunT [funOfVal a] ret, funOfVal ret, funOfVal (OptionT a)] ret
+     -> FunT [FunT [funOfVal a] ret, FunT [funOfVal UnitT] ret, funOfVal (OptionT a)] ret
     PrimFold (PrimFoldSum    a b) ret
      -> FunT [FunT [funOfVal a] ret, FunT [funOfVal b] ret, funOfVal (SumT a b)] ret
     PrimFold (PrimFoldMap k v) ret

--- a/src/Icicle/Source/ToCore/Exp.hs
+++ b/src/Icicle/Source/ToCore/Exp.hs
@@ -149,7 +149,7 @@ convertCase x scrut pats scrutT resT
           , Just ([],non)  <- Map.lookup ConNone    m
 
           -> return ((CE.xPrim $ C.PrimFold (C.PrimFoldOption ta) resT)
-                     CE.@~ (CE.xLam n ta som) CE.@~ non
+                     CE.@~ (CE.xLam n ta som) CE.@~ (CE.xLam sn T.UnitT non)
                      CE.@~ scrut)
 
          T.BoolT

--- a/src/Icicle/Source/ToCore/ToCore.hs
+++ b/src/Icicle/Source/ToCore/ToCore.hs
@@ -379,7 +379,7 @@ convertQuery q
             let kons    = CE.xLet n'key e'
                         ( CE.xPrim (C.PrimFold (C.PrimFoldOption T.UnitT) pairt)
                         CE.@~ CE.xLam n'ignore2 T.UnitT (CE.xVar n')
-                        CE.@~ update_step
+                        CE.@~ CE.xLam n'ignore2 T.UnitT update_step
                         CE.@~ check_if_exists )
 
             -- Perform the map fold

--- a/test/cli/repl/t30.2-array-strings/expected
+++ b/test/cli/repl/t30.2-array-strings/expected
@@ -22,9 +22,9 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 > > ok, loaded dictionary with 2 features and 20 functions
 > ok, loaded test/cli/repl/t30.2-array-strings/data.psv, 5 rows
 > > - C evaluation:
-[(ID00000000,0)
-,(ID00000001,0)
-,(ID00000002,0)]
+[(ID00000000,2)
+,(ID00000001,1)
+,(ID00000002,2)]
 
 - Core evaluation:
 [ID00000000, 2


### PR DESCRIPTION
Fix the bug, however we one day need a better analysis on avalanche/flatten to see which map/array operations can be made mutable updates, and which need to copy beforehand.