### PR TITLE
Faster!

### DIFF
--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -41,6 +41,7 @@ simpAvalanche a_fresh p
          >>= nestBlocks   a_fresh
          >>= once . thresher     a_fresh
          >>= transformX return (return . simpEvalX CorePrim.evalPrim CorePrim.typeOfPrim)
+         >>= return .  dead
 
       return $ p { statements = s' }
 

--- a/src/Icicle/Pipeline.hs
+++ b/src/Icicle/Pipeline.hs
@@ -315,7 +315,8 @@ coreAvalanche
   -> AvalProgram () v Core.Prim
 coreAvalanche prog
  = simpAvalanche
- $ AC.programFromCore (AC.namerText id) prog
+ $ snd
+ $ Fresh.runFresh (AC.programFromCore (AC.namerText id) prog) (freshNamer "aval")
 
 simpAvalanche
   :: (Eq v, Hashable v, Show v, IsString v)

--- a/test/Icicle/Test/Avalanche/CheckCommutes.hs
+++ b/test/Icicle/Test/Avalanche/CheckCommutes.hs
@@ -29,7 +29,7 @@ prop_check_commutes t =
  forAll (programForStreamType t)
  $ \p ->
     isRight     (checkProgram p) ==>
-     let conv = Convert.programFromCore namer p in
+     let conv = testFresh "fromCore" $ Convert.programFromCore namer p in
      case Check.checkProgram coreFragment conv of
       Right _
        -> property True

--- a/test/Icicle/Test/Avalanche/EvalCommutes.hs
+++ b/test/Icicle/Test/Avalanche/EvalCommutes.hs
@@ -33,7 +33,7 @@ prop_eval_right t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     isRight $ AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p
+     isRight $ AE.evalProgram XV.evalPrim d vs $ testFresh "fromCore" $ AC.programFromCore namer p
 
 
 -- going to core doesn't affect value
@@ -43,7 +43,7 @@ prop_eval_commutes_value t =
  forAll (inputsForType t)
  $ \(vs,d) -> counterexample (show $ pretty p) $
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ testFresh "fromCore" $ AC.programFromCore namer p, PV.eval d vs p) of
       (Right (_, aval), Right cres)
        ->   aval === PV.value   cres
       (_, Left _)
@@ -62,7 +62,7 @@ zprop_eval_commutes_history t =
  forAll (inputsForType t)
  $ \(vs,d) -> counterexample (show $ pretty p) $
     isRight     (checkProgram p) ==>
-     case (AE.evalProgram XV.evalPrim d vs $ AC.programFromCore namer p, PV.eval d vs p) of
+     case (AE.evalProgram XV.evalPrim d vs $ testFresh "fromCore" $ AC.programFromCore namer p, PV.eval d vs p) of
       (Right (abg, _), Right cres)
        ->  let abg' = sort abg
                cres'= fmap prefixBubbleGum $ sort $ PV.history cres

--- a/test/Icicle/Test/Avalanche/Flatten.hs
+++ b/test/Icicle/Test/Avalanche/Flatten.hs
@@ -13,9 +13,6 @@ import qualified Icicle.Avalanche.Eval      as AE
 import qualified Icicle.Avalanche.Prim.Eval as AE
 import qualified Icicle.Avalanche.Statement.Flatten   as AF
 
-import           Icicle.Common.Base
-import qualified Icicle.Common.Fresh                as Fresh
-
 import           Icicle.Internal.Pretty
 
 import qualified Icicle.Pipeline as P
@@ -42,19 +39,17 @@ prop_flatten_commutes_value t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     P.isRight     (checkProgram p) ==>
-     let p' = AC.programFromCore namer p
+     let p' = testFresh "fromCore" $ AC.programFromCore namer p
 
          eval xp = AE.evalProgram xp d vs
 
-         simp = Fresh.runFreshT
-                        (AF.flatten () $ AP.statements p')
-                        (Fresh.counterNameState (NameBase . Var "anf") 0)
+         simp = testFreshT "anf" (AF.flatten () $ AP.statements p')
      in case simp of
          Left e
           -> counterexample (show e)
            $ counterexample (show $ pretty p')
              False
-         Right (_, s')
+         Right s'
           -> counterexample (show $ pretty p')
            $ counterexample (show $ pretty s')
              (first show (eval XV.evalPrim p') === first show (eval AE.evalPrim p' { AP.statements = s'}))

--- a/test/Icicle/Test/Avalanche/SimpCommutes.hs
+++ b/test/Icicle/Test/Avalanche/SimpCommutes.hs
@@ -14,9 +14,6 @@ import qualified Icicle.Avalanche.FromCore  as AC
 import qualified Icicle.Avalanche.Eval      as AE
 import qualified Icicle.Avalanche.Simp      as AS
 
-import           Icicle.Common.Base
-import qualified Icicle.Common.Fresh                as Fresh
-
 import           Icicle.Internal.Pretty
 
 import           P
@@ -36,12 +33,9 @@ prop_simp_commutes_value t =
  forAll (inputsForType t)
  $ \(vs,d) ->
     isRight     (checkProgram p) ==>
-     let p' = AC.programFromCore namer p
+     let p' = testFresh "fromCore" $ AC.programFromCore namer p
 
-         simp = snd
-              $ Fresh.runFresh
-                        (AS.simpAvalanche () p')
-                        (Fresh.counterNameState (NameBase . Var "anf") 0)
+         simp = testFresh "anf" $ AS.simpAvalanche () p'
          eval = AE.evalProgram XV.evalPrim d vs
      in counterexample (show $ pretty p')
       $ counterexample (show $ pretty simp)

--- a/test/Icicle/Test/Core/Arbitrary.hs
+++ b/test/Icicle/Test/Core/Arbitrary.hs
@@ -15,6 +15,7 @@ import           Icicle.Common.Exp
 import           Icicle.Common.Type
 import           Icicle.Common.Value
 import qualified Icicle.Common.Exp.Prim.Minimal as PM
+import qualified Icicle.Common.Fresh                as Fresh
 
 import qualified Icicle.Core.Exp                as X
 import           Icicle.Core.Exp.Combinators
@@ -36,6 +37,17 @@ import qualified Data.List  as List
 import qualified Data.Map   as Map
 import           Data.Hashable (Hashable)
 
+testFreshT :: Functor m => Text -> Fresh.FreshT Var m a -> m a
+testFreshT desc prog
+ = fmap snd
+ $ Fresh.runFreshT prog
+ $ Fresh.counterNameState (NameBase . Var desc) 0
+
+testFresh :: Text -> Fresh.Fresh Var a -> a
+testFresh desc prog
+ = snd
+ $ Fresh.runFresh prog
+ $ Fresh.counterNameState (NameBase . Var desc) 0
 
 -- | Check if values are equal except for functions/closures
 -- Because closure heaps can differ..

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -7,17 +7,14 @@ ok, avalanche is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Avalanche:
 conv$3 = TIME
-init acc$conv$26@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
-init acc$c$conv$11@{(Sum Error Int)} = Left ExceptNotAnError@{(Sum Error Int)};
 init acc$conv$10@{((Sum Error Int), ((Sum Error Int), Time))} = (Left ExceptNotAnError, (Left ExceptNotAnError, 1858-11-17))@{((Sum Error Int), ((Sum Error Int), Time))};
-write acc$c$conv$11 = Right 0@{(Sum Error Int)};
-
+init acc$c$conv$11@{(Sum Error Int)} = Right 0@{(Sum Error Int)};
+init acc$conv$26@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
 load_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
 load_resumable@{(Sum Error Int)} acc$c$conv$11;
 load_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
-  
   let anf$0 = fst#@{(Sum Error Int), Time} conv$0;
   let anf$1 = Sum_fold#@{(Error,Int)}@{(Sum Error Bool)} 
     (\reify$0$conv$4@{Error} left#@{Error, Bool} reify$0$conv$4) 
@@ -26,24 +23,22 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Tim
     (\reify$2$conv$7@{Error} True@{Bool}) 
     (\reify$3$conv$8@{Bool} reify$3$conv$8) anf$1)
   {
-    let anf$2 = anf$0;
-    write acc$conv$10 = pair#@{(Sum Error Int), ((Sum Error Int), Time)} anf$2 conv$0;
-    read conv$10 = acc$conv$10 [((Sum Error Int), ((Sum Error Int), Time))];
-    read c$conv$11 = acc$c$conv$11 [(Sum Error Int)];
-    let anf$3 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$10;
+    write acc$conv$10 = pair#@{(Sum Error Int), ((Sum Error Int), Time)} anf$0 conv$0;
+    read aval$1 = acc$conv$10 [((Sum Error Int), ((Sum Error Int), Time))];
+    read aval$0 = acc$c$conv$11 [(Sum Error Int)];
+    let anf$3 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} aval$1;
     write acc$c$conv$11 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
       (\reify$6$conv$12@{Error} left#@{Error, Int} reify$6$conv$12) 
       (\reify$7$conv$13@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
         (\reify$8$conv$17@{Error} left#@{Error, Int} reify$8$conv$17) 
         (\reify$9$conv$18@{Int} right#@{Error, Int} reify$9$conv$18) (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
         (\reify$4$conv$14@{Error} left#@{Error, Int} reify$4$conv$14) 
-        (\reify$5$conv$15@{Int} right#@{Error, Int} (add#@{Int} reify$5$conv$15 (1@{Int}))) c$conv$11)) anf$3;
+        (\reify$5$conv$15@{Int} right#@{Error, Int} (add#@{Int} reify$5$conv$15 (1@{Int}))) aval$0)) anf$3;
   }
-  read conv$26 = acc$conv$26 [Buf 3 (Sum Error Int)];
+  read aval$2 = acc$conv$26 [Buf 3 (Sum Error Int)];
   let anf$4 = anf$0;
-  write acc$conv$26 = Latest_push#@{Buf 3 (Sum Error Int)} conv$26 conv$1 anf$4;
+  write acc$conv$26 = Latest_push#@{Buf 3 (Sum Error Int)} aval$2 conv$1 anf$4;
 }
-
 save_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
 save_resumable@{(Sum Error Int)} acc$c$conv$11;
 save_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
@@ -68,18 +63,15 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$31@{(Sum Error (Int
 > - Avalanche:
 conv$3 = TIME
 init acc$conv$4@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
-
 load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
-  
-  read conv$4 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
+  read aval$0 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
   let anf$0 = Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0;
   let anf$1 = snd#@{(Sum Error Int), Time} conv$0;
   write acc$conv$4 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
-    (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 conv$4;
+    (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 aval$0;
 }
-
 save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
 read conv$4 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
 let conv$39 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -7,7 +7,6 @@ ok, avalanche is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Avalanche:
 conv$3 = TIME
-let anf$5 = (Left ExceptNotAnError, 1858-11-17)@{((Sum Error Int), Time)};
 init acc$conv$26@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
 init acc$c$conv$11@{(Sum Error Int)} = Left ExceptNotAnError@{(Sum Error Int)};
 init acc$conv$10@{((Sum Error Int), ((Sum Error Int), Time))} = (Left ExceptNotAnError, (Left ExceptNotAnError, 1858-11-17))@{((Sum Error Int), ((Sum Error Int), Time))};
@@ -68,7 +67,6 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$31@{(Sum Error (Int
 > > -- Something involves the abstract buffer type
 > - Avalanche:
 conv$3 = TIME
-let anf$2 = (Left ExceptNotAnError, 1858-11-17)@{((Sum Error Int), Time)};
 init acc$conv$4@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
 
 load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -152,10 +152,10 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$79@{Error}, conv$
   read conv$4$simp$18 = acc$conv$4$simp$14 [Array Time];
   read conv$4$simp$19 = acc$conv$4$simp$15 [Array (Buf 2 Error)];
   read conv$4$simp$20 = acc$conv$4$simp$16 [Array (Buf 2 Int)];
-  let simp$407 = Buf_make#@{Buf 2 Error} (()@{Unit});
-  let simp$219 = Buf_push#@{Buf 2 Error} simp$407 conv$0$simp$79;
-  let simp$409 = Buf_make#@{Buf 2 Int} (()@{Unit});
-  let simp$221 = Buf_push#@{Buf 2 Int} simp$409 conv$0$simp$80;
+  let simp$391 = Buf_make#@{Buf 2 Error} (()@{Unit});
+  let simp$219 = Buf_push#@{Buf 2 Error} simp$391 conv$0$simp$79;
+  let simp$393 = Buf_make#@{Buf 2 Int} (()@{Unit});
+  let simp$221 = Buf_push#@{Buf 2 Int} simp$393 conv$0$simp$80;
   init flat$1@{Bool} = False@{Bool};
   init flat$2@{Array Time} = conv$4$simp$18;
   init flat$3$simp$22@{Array (Buf 2 Error)} = conv$4$simp$19;

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -7,18 +7,16 @@ ok, flatten is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Flattened:
 conv$3 = TIME
-init acc$conv$26$simp$4@{Buf 3 Error} = Buf []@{Buf 3 Error};
-init acc$conv$26$simp$5@{Buf 3 Int} = Buf []@{Buf 3 Int};
-init acc$c$conv$11$simp$6@{Error} = ExceptNotAnError@{Error};
-init acc$c$conv$11$simp$7@{Int} = 0@{Int};
-init acc$conv$10$simp$8@{Error} = ExceptNotAnError@{Error};
-write acc$c$conv$11$simp$6 = ExceptNotAnError@{Error};
-write acc$c$conv$11$simp$7 = 0@{Int};
-load_resumable@{Buf 3 Error} acc$conv$26$simp$4;
-load_resumable@{Buf 3 Int} acc$conv$26$simp$5;
-load_resumable@{Error} acc$c$conv$11$simp$6;
-load_resumable@{Int} acc$c$conv$11$simp$7;
-load_resumable@{Error} acc$conv$10$simp$8;
+init acc$conv$10$simp$4@{Error} = ExceptNotAnError@{Error};
+init acc$c$conv$11$simp$9@{Error} = ExceptNotAnError@{Error};
+init acc$c$conv$11$simp$10@{Int} = 0@{Int};
+init acc$conv$26$simp$11@{Buf 3 Error} = Buf []@{Buf 3 Error};
+init acc$conv$26$simp$12@{Buf 3 Int} = Buf []@{Buf 3 Int};
+load_resumable@{Buf 3 Error} acc$conv$26$simp$11;
+load_resumable@{Buf 3 Int} acc$conv$26$simp$12;
+load_resumable@{Error} acc$c$conv$11$simp$9;
+load_resumable@{Int} acc$c$conv$11$simp$10;
+load_resumable@{Error} acc$conv$10$simp$4;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$50@{Error}, conv$0$simp$51@{Int}, conv$0$simp$52@{Time}) in new
 {
   init flat$0$simp$13@{Error} = ExceptNotAnError@{Error};
@@ -47,24 +45,24 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$50@{Error}, conv$
   read flat$1 = flat$1 [Bool];
   if (flat$1)
   {
-    write acc$conv$10$simp$8 = conv$0$simp$50;
-    read conv$10$simp$17 = acc$conv$10$simp$8 [Error];
-    read c$conv$11$simp$22 = acc$c$conv$11$simp$6 [Error];
-    read c$conv$11$simp$23 = acc$c$conv$11$simp$7 [Int];
+    write acc$conv$10$simp$4 = conv$0$simp$50;
+    read aval$1$simp$17 = acc$conv$10$simp$4 [Error];
+    read aval$0$simp$22 = acc$c$conv$11$simp$9 [Error];
+    read aval$0$simp$23 = acc$c$conv$11$simp$10 [Int];
     init flat$2$simp$24@{Error} = ExceptNotAnError@{Error};
     init flat$2$simp$25@{Int} = 0@{Int};
-    if (eq#@{Error} conv$10$simp$17 (ExceptNotAnError@{Error}))
+    if (eq#@{Error} aval$1$simp$17 (ExceptNotAnError@{Error}))
     {
       init flat$5$simp$26@{Error} = ExceptNotAnError@{Error};
       init flat$5$simp$27@{Int} = 0@{Int};
-      if (eq#@{Error} c$conv$11$simp$22 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} aval$0$simp$22 (ExceptNotAnError@{Error}))
       {
         write flat$5$simp$26 = ExceptNotAnError@{Error};
-        write flat$5$simp$27 = add#@{Int} c$conv$11$simp$23 (1@{Int});
+        write flat$5$simp$27 = add#@{Int} aval$0$simp$23 (1@{Int});
       }
       else
       {
-        write flat$5$simp$26 = c$conv$11$simp$22;
+        write flat$5$simp$26 = aval$0$simp$22;
         write flat$5$simp$27 = 0@{Int};
       }
       read flat$5$simp$28 = flat$5$simp$26 [Error];
@@ -88,28 +86,28 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$50@{Error}, conv$
     }
     else
     {
-      write flat$2$simp$24 = conv$10$simp$17;
+      write flat$2$simp$24 = aval$1$simp$17;
       write flat$2$simp$25 = 0@{Int};
     }
     read flat$2$simp$34 = flat$2$simp$24 [Error];
     read flat$2$simp$35 = flat$2$simp$25 [Int];
-    write acc$c$conv$11$simp$6 = flat$2$simp$34;
-    write acc$c$conv$11$simp$7 = flat$2$simp$35;
+    write acc$c$conv$11$simp$9 = flat$2$simp$34;
+    write acc$c$conv$11$simp$10 = flat$2$simp$35;
   }
-  read acc$conv$26$simp$4 = acc$conv$26$simp$4 [Buf 3 Error];
-  write acc$conv$26$simp$4 = Buf_push#@{Buf 3 Error} acc$conv$26$simp$4 conv$0$simp$50;
-  read acc$conv$26$simp$5 = acc$conv$26$simp$5 [Buf 3 Int];
-  write acc$conv$26$simp$5 = Buf_push#@{Buf 3 Int} acc$conv$26$simp$5 conv$0$simp$51;
+  read acc$conv$26$simp$11 = acc$conv$26$simp$11 [Buf 3 Error];
+  write acc$conv$26$simp$11 = Buf_push#@{Buf 3 Error} acc$conv$26$simp$11 conv$0$simp$50;
+  read acc$conv$26$simp$12 = acc$conv$26$simp$12 [Buf 3 Int];
+  write acc$conv$26$simp$12 = Buf_push#@{Buf 3 Int} acc$conv$26$simp$12 conv$0$simp$51;
 }
-save_resumable@{Buf 3 Error} acc$conv$26$simp$4;
-save_resumable@{Buf 3 Int} acc$conv$26$simp$5;
-save_resumable@{Error} acc$c$conv$11$simp$6;
-save_resumable@{Int} acc$c$conv$11$simp$7;
-save_resumable@{Error} acc$conv$10$simp$8;
-read conv$26$simp$38 = acc$conv$26$simp$4 [Buf 3 Error];
-read conv$26$simp$39 = acc$conv$26$simp$5 [Buf 3 Int];
-read c$conv$11$simp$40 = acc$c$conv$11$simp$6 [Error];
-read c$conv$11$simp$41 = acc$c$conv$11$simp$7 [Int];
+save_resumable@{Buf 3 Error} acc$conv$26$simp$11;
+save_resumable@{Buf 3 Int} acc$conv$26$simp$12;
+save_resumable@{Error} acc$c$conv$11$simp$9;
+save_resumable@{Int} acc$c$conv$11$simp$10;
+save_resumable@{Error} acc$conv$10$simp$4;
+read conv$26$simp$38 = acc$conv$26$simp$11 [Buf 3 Error];
+read conv$26$simp$39 = acc$conv$26$simp$12 [Buf 3 Int];
+read c$conv$11$simp$40 = acc$c$conv$11$simp$9 [Error];
+read c$conv$11$simp$41 = acc$c$conv$11$simp$10 [Int];
 init flat$16$simp$42@{Error} = ExceptNotAnError@{Error};
 init flat$16$simp$43@{Int} = 0@{Int};
 init flat$16$simp$44@{Array Error} = []@{Array Error};
@@ -149,17 +147,17 @@ load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$15;
 load_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$16;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$79@{Error}, conv$0$simp$80@{Int}, conv$0$simp$81@{Time}) in new
 {
-  read conv$4$simp$18 = acc$conv$4$simp$14 [Array Time];
-  read conv$4$simp$19 = acc$conv$4$simp$15 [Array (Buf 2 Error)];
-  read conv$4$simp$20 = acc$conv$4$simp$16 [Array (Buf 2 Int)];
+  read aval$0$simp$18 = acc$conv$4$simp$14 [Array Time];
+  read aval$0$simp$19 = acc$conv$4$simp$15 [Array (Buf 2 Error)];
+  read aval$0$simp$20 = acc$conv$4$simp$16 [Array (Buf 2 Int)];
   let simp$391 = Buf_make#@{Buf 2 Error} (()@{Unit});
   let simp$219 = Buf_push#@{Buf 2 Error} simp$391 conv$0$simp$79;
   let simp$393 = Buf_make#@{Buf 2 Int} (()@{Unit});
   let simp$221 = Buf_push#@{Buf 2 Int} simp$393 conv$0$simp$80;
   init flat$1@{Bool} = False@{Bool};
-  init flat$2@{Array Time} = conv$4$simp$18;
-  init flat$3$simp$22@{Array (Buf 2 Error)} = conv$4$simp$19;
-  init flat$3$simp$23@{Array (Buf 2 Int)} = conv$4$simp$20;
+  init flat$2@{Array Time} = aval$0$simp$18;
+  init flat$3$simp$22@{Array (Buf 2 Error)} = aval$0$simp$19;
+  init flat$3$simp$23@{Array (Buf 2 Int)} = aval$0$simp$20;
   read flat$2 = flat$2 [Array Time];
   let flat$4 = Array_length#@{Time} flat$2;
   foreach (flat$5 in 0@{Int} .. flat$4)

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -25,59 +25,52 @@ ok, c is now on
 > > -- An interesting expression with structs and strings
 > - Flattened:
 conv$3 = TIME
-init acc$a$conv$63$simp$66@{Error} = ExceptNotAnError@{Error};
-init acc$a$conv$63$simp$67@{Double} = 0.0@{Double};
-init acc$a$conv$63$simp$68@{Double} = 0.0@{Double};
-init acc$a$conv$63$simp$69@{Double} = 0.0@{Double};
-init acc$conv$62$simp$70@{Error} = ExceptNotAnError@{Error};
-init acc$conv$62$simp$71@{Double} = 0.0@{Double};
-init acc$conv$58$simp$80@{Error} = ExceptNotAnError@{Error};
-init acc$conv$58$simp$81@{Int} = 0@{Int};
-init acc$conv$57$simp$88@{Error} = ExceptNotAnError@{Error};
-init acc$conv$57$simp$89@{Int} = 0@{Int};
-init acc$s$reify$6$conv$12$simp$94@{Error} = ExceptNotAnError@{Error};
-init acc$s$reify$6$conv$12$simp$95@{Double} = 0.0@{Double};
-init acc$s$reify$6$conv$12$simp$96@{Double} = 0.0@{Double};
-init acc$conv$11$simp$97@{Error} = ExceptNotAnError@{Error};
-init acc$conv$11$simp$98@{Double} = 0.0@{Double};
-init acc$conv$7$simp$105@{Error} = ExceptNotAnError@{Error};
-init acc$conv$7$simp$106@{Double} = 0.0@{Double};
-write acc$s$reify$6$conv$12$simp$94 = ExceptFold1NoValue@{Error};
-write acc$s$reify$6$conv$12$simp$95 = 0.0@{Double};
-write acc$s$reify$6$conv$12$simp$96 = 0.0@{Double};
-write acc$a$conv$63$simp$66 = ExceptNotAnError@{Error};
-write acc$a$conv$63$simp$67 = 0.0@{Double};
-write acc$a$conv$63$simp$68 = 0.0@{Double};
-write acc$a$conv$63$simp$69 = 0.0@{Double};
-load_resumable@{Error} acc$a$conv$63$simp$66;
-load_resumable@{Double} acc$a$conv$63$simp$67;
-load_resumable@{Double} acc$a$conv$63$simp$68;
-load_resumable@{Double} acc$a$conv$63$simp$69;
-load_resumable@{Error} acc$conv$62$simp$70;
-load_resumable@{Double} acc$conv$62$simp$71;
-load_resumable@{Error} acc$conv$58$simp$80;
-load_resumable@{Int} acc$conv$58$simp$81;
-load_resumable@{Error} acc$conv$57$simp$88;
-load_resumable@{Int} acc$conv$57$simp$89;
-load_resumable@{Error} acc$s$reify$6$conv$12$simp$94;
-load_resumable@{Double} acc$s$reify$6$conv$12$simp$95;
-load_resumable@{Double} acc$s$reify$6$conv$12$simp$96;
-load_resumable@{Error} acc$conv$11$simp$97;
-load_resumable@{Double} acc$conv$11$simp$98;
-load_resumable@{Error} acc$conv$7$simp$105;
-load_resumable@{Double} acc$conv$7$simp$106;
-for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv$0$simp$334@{String}, conv$0$simp$335@{Int}, conv$0$simp$336@{Time}) in new
+init acc$conv$7$simp$66@{Error} = ExceptNotAnError@{Error};
+init acc$conv$7$simp$67@{Double} = 0.0@{Double};
+init acc$conv$11$simp$72@{Error} = ExceptNotAnError@{Error};
+init acc$conv$11$simp$73@{Double} = 0.0@{Double};
+init acc$s$reify$6$conv$12$simp$80@{Error} = ExceptFold1NoValue@{Error};
+init acc$s$reify$6$conv$12$simp$81@{Double} = 0.0@{Double};
+init acc$s$reify$6$conv$12$simp$82@{Double} = 0.0@{Double};
+init acc$conv$57$simp$83@{Error} = ExceptNotAnError@{Error};
+init acc$conv$57$simp$84@{Int} = 0@{Int};
+init acc$conv$58$simp$89@{Error} = ExceptNotAnError@{Error};
+init acc$conv$58$simp$90@{Int} = 0@{Int};
+init acc$conv$62$simp$97@{Error} = ExceptNotAnError@{Error};
+init acc$conv$62$simp$98@{Double} = 0.0@{Double};
+init acc$a$conv$63$simp$107@{Error} = ExceptNotAnError@{Error};
+init acc$a$conv$63$simp$108@{Double} = 0.0@{Double};
+init acc$a$conv$63$simp$109@{Double} = 0.0@{Double};
+init acc$a$conv$63$simp$110@{Double} = 0.0@{Double};
+load_resumable@{Error} acc$a$conv$63$simp$107;
+load_resumable@{Double} acc$a$conv$63$simp$108;
+load_resumable@{Double} acc$a$conv$63$simp$109;
+load_resumable@{Double} acc$a$conv$63$simp$110;
+load_resumable@{Error} acc$conv$62$simp$97;
+load_resumable@{Double} acc$conv$62$simp$98;
+load_resumable@{Error} acc$conv$58$simp$89;
+load_resumable@{Int} acc$conv$58$simp$90;
+load_resumable@{Error} acc$conv$57$simp$83;
+load_resumable@{Int} acc$conv$57$simp$84;
+load_resumable@{Error} acc$s$reify$6$conv$12$simp$80;
+load_resumable@{Double} acc$s$reify$6$conv$12$simp$81;
+load_resumable@{Double} acc$s$reify$6$conv$12$simp$82;
+load_resumable@{Error} acc$conv$11$simp$72;
+load_resumable@{Double} acc$conv$11$simp$73;
+load_resumable@{Error} acc$conv$7$simp$66;
+load_resumable@{Double} acc$conv$7$simp$67;
+for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv$0$simp$316@{String}, conv$0$simp$317@{Int}, conv$0$simp$318@{Time}) in new
 {
   init flat$0$simp$111@{Error} = ExceptNotAnError@{Error};
   init flat$0$simp$112@{Int} = 0@{Int};
-  if (eq#@{Error} conv$0$simp$333 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} conv$0$simp$315 (ExceptNotAnError@{Error}))
   {
     write flat$0$simp$111 = ExceptNotAnError@{Error};
-    write flat$0$simp$112 = conv$0$simp$335;
+    write flat$0$simp$112 = conv$0$simp$317;
   }
   else
   {
-    write flat$0$simp$111 = conv$0$simp$333;
+    write flat$0$simp$111 = conv$0$simp$315;
     write flat$0$simp$112 = 0@{Int};
   }
   read flat$0$simp$113 = flat$0$simp$111 [Error];
@@ -96,51 +89,51 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
   }
   read flat$1$simp$117 = flat$1$simp$115 [Error];
   read flat$1$simp$118 = flat$1$simp$116 [Double];
-  write acc$conv$7$simp$105 = flat$1$simp$117;
-  write acc$conv$7$simp$106 = flat$1$simp$118;
-  read conv$7$simp$119 = acc$conv$7$simp$105 [Error];
-  read conv$7$simp$120 = acc$conv$7$simp$106 [Double];
+  write acc$conv$7$simp$66 = flat$1$simp$117;
+  write acc$conv$7$simp$67 = flat$1$simp$118;
+  read aval$0$simp$119 = acc$conv$7$simp$66 [Error];
+  read aval$0$simp$120 = acc$conv$7$simp$67 [Double];
   init flat$2$simp$125@{Error} = ExceptNotAnError@{Error};
   init flat$2$simp$126@{Double} = 0.0@{Double};
-  if (eq#@{Error} conv$7$simp$119 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} aval$0$simp$119 (ExceptNotAnError@{Error}))
   {
     write flat$2$simp$125 = ExceptNotAnError@{Error};
-    write flat$2$simp$126 = conv$7$simp$120;
+    write flat$2$simp$126 = aval$0$simp$120;
   }
   else
   {
-    write flat$2$simp$125 = conv$7$simp$119;
+    write flat$2$simp$125 = aval$0$simp$119;
     write flat$2$simp$126 = 0.0@{Double};
   }
   read flat$2$simp$127 = flat$2$simp$125 [Error];
   read flat$2$simp$128 = flat$2$simp$126 [Double];
-  write acc$conv$11$simp$97 = flat$2$simp$127;
-  write acc$conv$11$simp$98 = flat$2$simp$128;
-  read conv$11$simp$129 = acc$conv$11$simp$97 [Error];
-  read conv$11$simp$130 = acc$conv$11$simp$98 [Double];
-  read s$reify$6$conv$12$simp$137 = acc$s$reify$6$conv$12$simp$94 [Error];
-  read s$reify$6$conv$12$simp$138 = acc$s$reify$6$conv$12$simp$95 [Double];
-  read s$reify$6$conv$12$simp$139 = acc$s$reify$6$conv$12$simp$96 [Double];
+  write acc$conv$11$simp$72 = flat$2$simp$127;
+  write acc$conv$11$simp$73 = flat$2$simp$128;
+  read aval$2$simp$129 = acc$conv$11$simp$72 [Error];
+  read aval$2$simp$130 = acc$conv$11$simp$73 [Double];
+  read aval$1$simp$137 = acc$s$reify$6$conv$12$simp$80 [Error];
+  read aval$1$simp$138 = acc$s$reify$6$conv$12$simp$81 [Double];
+  read aval$1$simp$139 = acc$s$reify$6$conv$12$simp$82 [Double];
   init flat$3$simp$140@{Error} = ExceptNotAnError@{Error};
   init flat$3$simp$141@{Double} = 0.0@{Double};
   init flat$3$simp$142@{Double} = 0.0@{Double};
-  if (eq#@{Error} s$reify$6$conv$12$simp$137 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} aval$1$simp$137 (ExceptNotAnError@{Error}))
   {
     init flat$10$simp$143@{Error} = ExceptNotAnError@{Error};
     init flat$10$simp$144@{Double} = 0.0@{Double};
     init flat$10$simp$145@{Double} = 0.0@{Double};
-    if (eq#@{Error} s$reify$6$conv$12$simp$137 (ExceptNotAnError@{Error}))
+    if (eq#@{Error} aval$1$simp$137 (ExceptNotAnError@{Error}))
     {
       init flat$13$simp$146@{Error} = ExceptNotAnError@{Error};
       init flat$13$simp$147@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv$11$simp$129 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} aval$2$simp$129 (ExceptNotAnError@{Error}))
       {
         write flat$13$simp$146 = ExceptNotAnError@{Error};
-        write flat$13$simp$147 = sub#@{Double} conv$11$simp$130 s$reify$6$conv$12$simp$138;
+        write flat$13$simp$147 = sub#@{Double} aval$2$simp$130 aval$1$simp$138;
       }
       else
       {
-        write flat$13$simp$146 = conv$11$simp$129;
+        write flat$13$simp$146 = aval$2$simp$129;
         write flat$13$simp$147 = 0.0@{Double};
       }
       read flat$13$simp$148 = flat$13$simp$146 [Error];
@@ -150,8 +143,8 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
       if (eq#@{Error} flat$13$simp$148 (ExceptNotAnError@{Error}))
       {
         write flat$14$simp$150 = ExceptNotAnError@{Error};
-        let simp$461 = add#@{Double} s$reify$6$conv$12$simp$139 (1.0@{Double});
-        write flat$14$simp$151 = div# flat$13$simp$149 simp$461;
+        let simp$443 = add#@{Double} aval$1$simp$139 (1.0@{Double});
+        write flat$14$simp$151 = div# flat$13$simp$149 simp$443;
       }
       else
       {
@@ -165,7 +158,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
       if (eq#@{Error} flat$14$simp$152 (ExceptNotAnError@{Error}))
       {
         write flat$15$simp$154 = ExceptNotAnError@{Error};
-        write flat$15$simp$155 = add#@{Double} s$reify$6$conv$12$simp$138 flat$14$simp$153;
+        write flat$15$simp$155 = add#@{Double} aval$1$simp$138 flat$14$simp$153;
       }
       else
       {
@@ -181,7 +174,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
       {
         write flat$16$simp$158 = ExceptNotAnError@{Error};
         write flat$16$simp$159 = flat$15$simp$157;
-        write flat$16$simp$160 = add#@{Double} s$reify$6$conv$12$simp$139 (1.0@{Double});
+        write flat$16$simp$160 = add#@{Double} aval$1$simp$139 (1.0@{Double});
       }
       else
       {
@@ -198,7 +191,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
     }
     else
     {
-      write flat$10$simp$143 = s$reify$6$conv$12$simp$137;
+      write flat$10$simp$143 = aval$1$simp$137;
       write flat$10$simp$144 = 0.0@{Double};
       write flat$10$simp$145 = 0.0@{Double};
     }
@@ -214,20 +207,20 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
     init flat$6$simp$167@{Error} = ExceptNotAnError@{Error};
     init flat$6$simp$168@{Double} = 0.0@{Double};
     init flat$6$simp$169@{Double} = 0.0@{Double};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s$reify$6$conv$12$simp$137)
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) aval$1$simp$137)
     {
       init flat$7$simp$170@{Error} = ExceptNotAnError@{Error};
       init flat$7$simp$171@{Double} = 0.0@{Double};
       init flat$7$simp$172@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv$11$simp$129 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} aval$2$simp$129 (ExceptNotAnError@{Error}))
       {
         write flat$7$simp$170 = ExceptNotAnError@{Error};
-        write flat$7$simp$171 = conv$11$simp$130;
+        write flat$7$simp$171 = aval$2$simp$130;
         write flat$7$simp$172 = 1.0@{Double};
       }
       else
       {
-        write flat$7$simp$170 = conv$11$simp$129;
+        write flat$7$simp$170 = aval$2$simp$129;
         write flat$7$simp$171 = 0.0@{Double};
         write flat$7$simp$172 = 0.0@{Double};
       }
@@ -240,7 +233,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
     }
     else
     {
-      write flat$6$simp$167 = s$reify$6$conv$12$simp$137;
+      write flat$6$simp$167 = aval$1$simp$137;
       write flat$6$simp$168 = 0.0@{Double};
       write flat$6$simp$169 = 0.0@{Double};
     }
@@ -254,19 +247,19 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
   read flat$3$simp$179 = flat$3$simp$140 [Error];
   read flat$3$simp$180 = flat$3$simp$141 [Double];
   read flat$3$simp$181 = flat$3$simp$142 [Double];
-  write acc$s$reify$6$conv$12$simp$94 = flat$3$simp$179;
-  write acc$s$reify$6$conv$12$simp$95 = flat$3$simp$180;
-  write acc$s$reify$6$conv$12$simp$96 = flat$3$simp$181;
+  write acc$s$reify$6$conv$12$simp$80 = flat$3$simp$179;
+  write acc$s$reify$6$conv$12$simp$81 = flat$3$simp$180;
+  write acc$s$reify$6$conv$12$simp$82 = flat$3$simp$181;
   init flat$25$simp$182@{Error} = ExceptNotAnError@{Error};
   init flat$25$simp$183@{String} = ""@{String};
-  if (eq#@{Error} conv$0$simp$333 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} conv$0$simp$315 (ExceptNotAnError@{Error}))
   {
     write flat$25$simp$182 = ExceptNotAnError@{Error};
-    write flat$25$simp$183 = conv$0$simp$334;
+    write flat$25$simp$183 = conv$0$simp$316;
   }
   else
   {
-    write flat$25$simp$182 = conv$0$simp$333;
+    write flat$25$simp$182 = conv$0$simp$315;
     write flat$25$simp$183 = ""@{String};
   }
   read flat$25$simp$184 = flat$25$simp$182 [Error];
@@ -297,348 +290,348 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
   read flat$27 = flat$27 [Bool];
   if (flat$27)
   {
-    init flat$28$simp$196@{Error} = ExceptNotAnError@{Error};
-    init flat$28$simp$197@{Int} = 0@{Int};
-    if (eq#@{Error} conv$0$simp$333 (ExceptNotAnError@{Error}))
+    init flat$28$simp$190@{Error} = ExceptNotAnError@{Error};
+    init flat$28$simp$191@{Int} = 0@{Int};
+    if (eq#@{Error} conv$0$simp$315 (ExceptNotAnError@{Error}))
     {
-      write flat$28$simp$196 = ExceptNotAnError@{Error};
-      write flat$28$simp$197 = conv$0$simp$335;
+      write flat$28$simp$190 = ExceptNotAnError@{Error};
+      write flat$28$simp$191 = conv$0$simp$317;
     }
     else
     {
-      write flat$28$simp$196 = conv$0$simp$333;
-      write flat$28$simp$197 = 0@{Int};
+      write flat$28$simp$190 = conv$0$simp$315;
+      write flat$28$simp$191 = 0@{Int};
     }
-    read flat$28$simp$198 = flat$28$simp$196 [Error];
-    read flat$28$simp$199 = flat$28$simp$197 [Int];
-    write acc$conv$57$simp$88 = flat$28$simp$198;
-    write acc$conv$57$simp$89 = flat$28$simp$199;
-    read conv$57$simp$200 = acc$conv$57$simp$88 [Error];
-    read conv$57$simp$201 = acc$conv$57$simp$89 [Int];
-    write acc$conv$58$simp$80 = conv$57$simp$200;
-    write acc$conv$58$simp$81 = conv$57$simp$201;
-    read conv$58$simp$212 = acc$conv$58$simp$80 [Error];
-    read conv$58$simp$213 = acc$conv$58$simp$81 [Int];
-    init flat$29$simp$220@{Error} = ExceptNotAnError@{Error};
-    init flat$29$simp$221@{Double} = 0.0@{Double};
-    if (eq#@{Error} conv$58$simp$212 (ExceptNotAnError@{Error}))
+    read flat$28$simp$192 = flat$28$simp$190 [Error];
+    read flat$28$simp$193 = flat$28$simp$191 [Int];
+    write acc$conv$57$simp$83 = flat$28$simp$192;
+    write acc$conv$57$simp$84 = flat$28$simp$193;
+    read aval$3$simp$194 = acc$conv$57$simp$83 [Error];
+    read aval$3$simp$195 = acc$conv$57$simp$84 [Int];
+    write acc$conv$58$simp$89 = aval$3$simp$194;
+    write acc$conv$58$simp$90 = aval$3$simp$195;
+    read aval$4$simp$200 = acc$conv$58$simp$89 [Error];
+    read aval$4$simp$201 = acc$conv$58$simp$90 [Int];
+    init flat$29$simp$208@{Error} = ExceptNotAnError@{Error};
+    init flat$29$simp$209@{Double} = 0.0@{Double};
+    if (eq#@{Error} aval$4$simp$200 (ExceptNotAnError@{Error}))
     {
-      write flat$29$simp$220 = ExceptNotAnError@{Error};
-      write flat$29$simp$221 = doubleOfInt# conv$58$simp$213;
+      write flat$29$simp$208 = ExceptNotAnError@{Error};
+      write flat$29$simp$209 = doubleOfInt# aval$4$simp$201;
     }
     else
     {
-      write flat$29$simp$220 = conv$58$simp$212;
-      write flat$29$simp$221 = 0.0@{Double};
+      write flat$29$simp$208 = aval$4$simp$200;
+      write flat$29$simp$209 = 0.0@{Double};
     }
-    read flat$29$simp$222 = flat$29$simp$220 [Error];
-    read flat$29$simp$223 = flat$29$simp$221 [Double];
-    write acc$conv$62$simp$70 = flat$29$simp$222;
-    write acc$conv$62$simp$71 = flat$29$simp$223;
-    read conv$62$simp$230 = acc$conv$62$simp$70 [Error];
-    read conv$62$simp$231 = acc$conv$62$simp$71 [Double];
-    read a$conv$63$simp$240 = acc$a$conv$63$simp$66 [Error];
-    read a$conv$63$simp$241 = acc$a$conv$63$simp$67 [Double];
-    read a$conv$63$simp$242 = acc$a$conv$63$simp$68 [Double];
-    read a$conv$63$simp$243 = acc$a$conv$63$simp$69 [Double];
-    init flat$30$simp$244@{Error} = ExceptNotAnError@{Error};
-    init flat$30$simp$245@{Double} = 0.0@{Double};
-    init flat$30$simp$246@{Double} = 0.0@{Double};
-    init flat$30$simp$247@{Double} = 0.0@{Double};
-    if (eq#@{Error} a$conv$63$simp$240 (ExceptNotAnError@{Error}))
+    read flat$29$simp$210 = flat$29$simp$208 [Error];
+    read flat$29$simp$211 = flat$29$simp$209 [Double];
+    write acc$conv$62$simp$97 = flat$29$simp$210;
+    write acc$conv$62$simp$98 = flat$29$simp$211;
+    read aval$6$simp$212 = acc$conv$62$simp$97 [Error];
+    read aval$6$simp$213 = acc$conv$62$simp$98 [Double];
+    read aval$5$simp$222 = acc$a$conv$63$simp$107 [Error];
+    read aval$5$simp$223 = acc$a$conv$63$simp$108 [Double];
+    read aval$5$simp$224 = acc$a$conv$63$simp$109 [Double];
+    read aval$5$simp$225 = acc$a$conv$63$simp$110 [Double];
+    init flat$30$simp$226@{Error} = ExceptNotAnError@{Error};
+    init flat$30$simp$227@{Double} = 0.0@{Double};
+    init flat$30$simp$228@{Double} = 0.0@{Double};
+    init flat$30$simp$229@{Double} = 0.0@{Double};
+    if (eq#@{Error} aval$5$simp$222 (ExceptNotAnError@{Error}))
     {
-      let nn$conv$70 = add#@{Double} a$conv$63$simp$241 (1.0@{Double});
-      init flat$33$simp$248@{Error} = ExceptNotAnError@{Error};
-      init flat$33$simp$249@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv$62$simp$230 (ExceptNotAnError@{Error}))
+      let nn$conv$70 = add#@{Double} aval$5$simp$223 (1.0@{Double});
+      init flat$33$simp$230@{Error} = ExceptNotAnError@{Error};
+      init flat$33$simp$231@{Double} = 0.0@{Double};
+      if (eq#@{Error} aval$6$simp$212 (ExceptNotAnError@{Error}))
       {
-        write flat$33$simp$248 = ExceptNotAnError@{Error};
-        write flat$33$simp$249 = sub#@{Double} conv$62$simp$231 a$conv$63$simp$242;
+        write flat$33$simp$230 = ExceptNotAnError@{Error};
+        write flat$33$simp$231 = sub#@{Double} aval$6$simp$213 aval$5$simp$224;
       }
       else
       {
-        write flat$33$simp$248 = conv$62$simp$230;
-        write flat$33$simp$249 = 0.0@{Double};
+        write flat$33$simp$230 = aval$6$simp$212;
+        write flat$33$simp$231 = 0.0@{Double};
       }
-      read flat$33$simp$250 = flat$33$simp$248 [Error];
-      read flat$33$simp$251 = flat$33$simp$249 [Double];
-      init flat$34$simp$252@{Error} = ExceptNotAnError@{Error};
-      init flat$34$simp$253@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$33$simp$250 (ExceptNotAnError@{Error}))
+      read flat$33$simp$232 = flat$33$simp$230 [Error];
+      read flat$33$simp$233 = flat$33$simp$231 [Double];
+      init flat$34$simp$234@{Error} = ExceptNotAnError@{Error};
+      init flat$34$simp$235@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$33$simp$232 (ExceptNotAnError@{Error}))
       {
-        write flat$34$simp$252 = ExceptNotAnError@{Error};
-        write flat$34$simp$253 = div# flat$33$simp$251 nn$conv$70;
-      }
-      else
-      {
-        write flat$34$simp$252 = flat$33$simp$250;
-        write flat$34$simp$253 = 0.0@{Double};
-      }
-      read flat$34$simp$254 = flat$34$simp$252 [Error];
-      read flat$34$simp$255 = flat$34$simp$253 [Double];
-      init flat$35$simp$256@{Error} = ExceptNotAnError@{Error};
-      init flat$35$simp$257@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$34$simp$254 (ExceptNotAnError@{Error}))
-      {
-        write flat$35$simp$256 = ExceptNotAnError@{Error};
-        write flat$35$simp$257 = add#@{Double} a$conv$63$simp$242 flat$34$simp$255;
+        write flat$34$simp$234 = ExceptNotAnError@{Error};
+        write flat$34$simp$235 = div# flat$33$simp$233 nn$conv$70;
       }
       else
       {
-        write flat$35$simp$256 = flat$34$simp$254;
-        write flat$35$simp$257 = 0.0@{Double};
+        write flat$34$simp$234 = flat$33$simp$232;
+        write flat$34$simp$235 = 0.0@{Double};
       }
-      read flat$35$simp$258 = flat$35$simp$256 [Error];
-      read flat$35$simp$259 = flat$35$simp$257 [Double];
-      init flat$36$simp$260@{Error} = ExceptNotAnError@{Error};
-      init flat$36$simp$261@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$33$simp$250 (ExceptNotAnError@{Error}))
+      read flat$34$simp$236 = flat$34$simp$234 [Error];
+      read flat$34$simp$237 = flat$34$simp$235 [Double];
+      init flat$35$simp$238@{Error} = ExceptNotAnError@{Error};
+      init flat$35$simp$239@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$34$simp$236 (ExceptNotAnError@{Error}))
       {
-        init flat$51$simp$262@{Error} = ExceptNotAnError@{Error};
-        init flat$51$simp$263@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv$62$simp$230 (ExceptNotAnError@{Error}))
+        write flat$35$simp$238 = ExceptNotAnError@{Error};
+        write flat$35$simp$239 = add#@{Double} aval$5$simp$224 flat$34$simp$237;
+      }
+      else
+      {
+        write flat$35$simp$238 = flat$34$simp$236;
+        write flat$35$simp$239 = 0.0@{Double};
+      }
+      read flat$35$simp$240 = flat$35$simp$238 [Error];
+      read flat$35$simp$241 = flat$35$simp$239 [Double];
+      init flat$36$simp$242@{Error} = ExceptNotAnError@{Error};
+      init flat$36$simp$243@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$33$simp$232 (ExceptNotAnError@{Error}))
+      {
+        init flat$51$simp$244@{Error} = ExceptNotAnError@{Error};
+        init flat$51$simp$245@{Double} = 0.0@{Double};
+        if (eq#@{Error} aval$6$simp$212 (ExceptNotAnError@{Error}))
         {
-          init flat$57$simp$264@{Error} = ExceptNotAnError@{Error};
-          init flat$57$simp$265@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat$35$simp$258 (ExceptNotAnError@{Error}))
+          init flat$57$simp$246@{Error} = ExceptNotAnError@{Error};
+          init flat$57$simp$247@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat$35$simp$240 (ExceptNotAnError@{Error}))
           {
-            write flat$57$simp$264 = ExceptNotAnError@{Error};
-            write flat$57$simp$265 = sub#@{Double} conv$62$simp$231 flat$35$simp$259;
+            write flat$57$simp$246 = ExceptNotAnError@{Error};
+            write flat$57$simp$247 = sub#@{Double} aval$6$simp$213 flat$35$simp$241;
           }
           else
           {
-            write flat$57$simp$264 = flat$35$simp$258;
-            write flat$57$simp$265 = 0.0@{Double};
+            write flat$57$simp$246 = flat$35$simp$240;
+            write flat$57$simp$247 = 0.0@{Double};
           }
-          read flat$57$simp$266 = flat$57$simp$264 [Error];
-          read flat$57$simp$267 = flat$57$simp$265 [Double];
-          write flat$51$simp$262 = flat$57$simp$266;
-          write flat$51$simp$263 = flat$57$simp$267;
+          read flat$57$simp$248 = flat$57$simp$246 [Error];
+          read flat$57$simp$249 = flat$57$simp$247 [Double];
+          write flat$51$simp$244 = flat$57$simp$248;
+          write flat$51$simp$245 = flat$57$simp$249;
         }
         else
         {
-          write flat$51$simp$262 = conv$62$simp$230;
-          write flat$51$simp$263 = 0.0@{Double};
+          write flat$51$simp$244 = aval$6$simp$212;
+          write flat$51$simp$245 = 0.0@{Double};
         }
-        read flat$51$simp$268 = flat$51$simp$262 [Error];
-        read flat$51$simp$269 = flat$51$simp$263 [Double];
-        init flat$52$simp$270@{Error} = ExceptNotAnError@{Error};
-        init flat$52$simp$271@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$51$simp$268 (ExceptNotAnError@{Error}))
+        read flat$51$simp$250 = flat$51$simp$244 [Error];
+        read flat$51$simp$251 = flat$51$simp$245 [Double];
+        init flat$52$simp$252@{Error} = ExceptNotAnError@{Error};
+        init flat$52$simp$253@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$51$simp$250 (ExceptNotAnError@{Error}))
         {
-          write flat$52$simp$270 = ExceptNotAnError@{Error};
-          write flat$52$simp$271 = mul#@{Double} flat$33$simp$251 flat$51$simp$269;
+          write flat$52$simp$252 = ExceptNotAnError@{Error};
+          write flat$52$simp$253 = mul#@{Double} flat$33$simp$233 flat$51$simp$251;
         }
         else
         {
-          write flat$52$simp$270 = flat$51$simp$268;
-          write flat$52$simp$271 = 0.0@{Double};
+          write flat$52$simp$252 = flat$51$simp$250;
+          write flat$52$simp$253 = 0.0@{Double};
         }
-        read flat$52$simp$272 = flat$52$simp$270 [Error];
-        read flat$52$simp$273 = flat$52$simp$271 [Double];
-        write flat$36$simp$260 = flat$52$simp$272;
-        write flat$36$simp$261 = flat$52$simp$273;
+        read flat$52$simp$254 = flat$52$simp$252 [Error];
+        read flat$52$simp$255 = flat$52$simp$253 [Double];
+        write flat$36$simp$242 = flat$52$simp$254;
+        write flat$36$simp$243 = flat$52$simp$255;
       }
       else
       {
-        write flat$36$simp$260 = flat$33$simp$250;
-        write flat$36$simp$261 = 0.0@{Double};
+        write flat$36$simp$242 = flat$33$simp$232;
+        write flat$36$simp$243 = 0.0@{Double};
       }
-      read flat$36$simp$274 = flat$36$simp$260 [Error];
-      read flat$36$simp$275 = flat$36$simp$261 [Double];
-      init flat$37$simp$276@{Error} = ExceptNotAnError@{Error};
-      init flat$37$simp$277@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$36$simp$274 (ExceptNotAnError@{Error}))
+      read flat$36$simp$256 = flat$36$simp$242 [Error];
+      read flat$36$simp$257 = flat$36$simp$243 [Double];
+      init flat$37$simp$258@{Error} = ExceptNotAnError@{Error};
+      init flat$37$simp$259@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$36$simp$256 (ExceptNotAnError@{Error}))
       {
-        write flat$37$simp$276 = ExceptNotAnError@{Error};
-        write flat$37$simp$277 = add#@{Double} a$conv$63$simp$243 flat$36$simp$275;
-      }
-      else
-      {
-        write flat$37$simp$276 = flat$36$simp$274;
-        write flat$37$simp$277 = 0.0@{Double};
-      }
-      read flat$37$simp$278 = flat$37$simp$276 [Error];
-      read flat$37$simp$279 = flat$37$simp$277 [Double];
-      init flat$38$simp$280@{Error} = ExceptNotAnError@{Error};
-      init flat$38$simp$281@{Double} = 0.0@{Double};
-      init flat$38$simp$282@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$35$simp$258 (ExceptNotAnError@{Error}))
-      {
-        write flat$38$simp$280 = ExceptNotAnError@{Error};
-        write flat$38$simp$281 = add#@{Double} a$conv$63$simp$241 (1.0@{Double});
-        write flat$38$simp$282 = flat$35$simp$259;
+        write flat$37$simp$258 = ExceptNotAnError@{Error};
+        write flat$37$simp$259 = add#@{Double} aval$5$simp$225 flat$36$simp$257;
       }
       else
       {
-        write flat$38$simp$280 = flat$35$simp$258;
-        write flat$38$simp$281 = 0.0@{Double};
-        write flat$38$simp$282 = 0.0@{Double};
+        write flat$37$simp$258 = flat$36$simp$256;
+        write flat$37$simp$259 = 0.0@{Double};
       }
-      read flat$38$simp$283 = flat$38$simp$280 [Error];
-      read flat$38$simp$284 = flat$38$simp$281 [Double];
-      read flat$38$simp$285 = flat$38$simp$282 [Double];
-      init flat$39$simp$286@{Error} = ExceptNotAnError@{Error};
-      init flat$39$simp$287@{Double} = 0.0@{Double};
-      init flat$39$simp$288@{Double} = 0.0@{Double};
-      init flat$39$simp$289@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$38$simp$283 (ExceptNotAnError@{Error}))
+      read flat$37$simp$260 = flat$37$simp$258 [Error];
+      read flat$37$simp$261 = flat$37$simp$259 [Double];
+      init flat$38$simp$262@{Error} = ExceptNotAnError@{Error};
+      init flat$38$simp$263@{Double} = 0.0@{Double};
+      init flat$38$simp$264@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$35$simp$240 (ExceptNotAnError@{Error}))
       {
-        init flat$42$simp$290@{Error} = ExceptNotAnError@{Error};
-        init flat$42$simp$291@{Double} = 0.0@{Double};
-        init flat$42$simp$292@{Double} = 0.0@{Double};
-        init flat$42$simp$293@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$37$simp$278 (ExceptNotAnError@{Error}))
+        write flat$38$simp$262 = ExceptNotAnError@{Error};
+        write flat$38$simp$263 = add#@{Double} aval$5$simp$223 (1.0@{Double});
+        write flat$38$simp$264 = flat$35$simp$241;
+      }
+      else
+      {
+        write flat$38$simp$262 = flat$35$simp$240;
+        write flat$38$simp$263 = 0.0@{Double};
+        write flat$38$simp$264 = 0.0@{Double};
+      }
+      read flat$38$simp$265 = flat$38$simp$262 [Error];
+      read flat$38$simp$266 = flat$38$simp$263 [Double];
+      read flat$38$simp$267 = flat$38$simp$264 [Double];
+      init flat$39$simp$268@{Error} = ExceptNotAnError@{Error};
+      init flat$39$simp$269@{Double} = 0.0@{Double};
+      init flat$39$simp$270@{Double} = 0.0@{Double};
+      init flat$39$simp$271@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$38$simp$265 (ExceptNotAnError@{Error}))
+      {
+        init flat$42$simp$272@{Error} = ExceptNotAnError@{Error};
+        init flat$42$simp$273@{Double} = 0.0@{Double};
+        init flat$42$simp$274@{Double} = 0.0@{Double};
+        init flat$42$simp$275@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$37$simp$260 (ExceptNotAnError@{Error}))
         {
-          write flat$42$simp$290 = ExceptNotAnError@{Error};
-          write flat$42$simp$291 = flat$38$simp$284;
-          write flat$42$simp$292 = flat$38$simp$285;
-          write flat$42$simp$293 = flat$37$simp$279;
+          write flat$42$simp$272 = ExceptNotAnError@{Error};
+          write flat$42$simp$273 = flat$38$simp$266;
+          write flat$42$simp$274 = flat$38$simp$267;
+          write flat$42$simp$275 = flat$37$simp$261;
         }
         else
         {
-          write flat$42$simp$290 = flat$37$simp$278;
-          write flat$42$simp$291 = 0.0@{Double};
-          write flat$42$simp$292 = 0.0@{Double};
-          write flat$42$simp$293 = 0.0@{Double};
+          write flat$42$simp$272 = flat$37$simp$260;
+          write flat$42$simp$273 = 0.0@{Double};
+          write flat$42$simp$274 = 0.0@{Double};
+          write flat$42$simp$275 = 0.0@{Double};
         }
-        read flat$42$simp$294 = flat$42$simp$290 [Error];
-        read flat$42$simp$295 = flat$42$simp$291 [Double];
-        read flat$42$simp$296 = flat$42$simp$292 [Double];
-        read flat$42$simp$297 = flat$42$simp$293 [Double];
-        write flat$39$simp$286 = flat$42$simp$294;
-        write flat$39$simp$287 = flat$42$simp$295;
-        write flat$39$simp$288 = flat$42$simp$296;
-        write flat$39$simp$289 = flat$42$simp$297;
+        read flat$42$simp$276 = flat$42$simp$272 [Error];
+        read flat$42$simp$277 = flat$42$simp$273 [Double];
+        read flat$42$simp$278 = flat$42$simp$274 [Double];
+        read flat$42$simp$279 = flat$42$simp$275 [Double];
+        write flat$39$simp$268 = flat$42$simp$276;
+        write flat$39$simp$269 = flat$42$simp$277;
+        write flat$39$simp$270 = flat$42$simp$278;
+        write flat$39$simp$271 = flat$42$simp$279;
       }
       else
       {
-        write flat$39$simp$286 = flat$38$simp$283;
-        write flat$39$simp$287 = 0.0@{Double};
-        write flat$39$simp$288 = 0.0@{Double};
-        write flat$39$simp$289 = 0.0@{Double};
+        write flat$39$simp$268 = flat$38$simp$265;
+        write flat$39$simp$269 = 0.0@{Double};
+        write flat$39$simp$270 = 0.0@{Double};
+        write flat$39$simp$271 = 0.0@{Double};
       }
-      read flat$39$simp$298 = flat$39$simp$286 [Error];
-      read flat$39$simp$299 = flat$39$simp$287 [Double];
-      read flat$39$simp$300 = flat$39$simp$288 [Double];
-      read flat$39$simp$301 = flat$39$simp$289 [Double];
-      write flat$30$simp$244 = flat$39$simp$298;
-      write flat$30$simp$245 = flat$39$simp$299;
-      write flat$30$simp$246 = flat$39$simp$300;
-      write flat$30$simp$247 = flat$39$simp$301;
+      read flat$39$simp$280 = flat$39$simp$268 [Error];
+      read flat$39$simp$281 = flat$39$simp$269 [Double];
+      read flat$39$simp$282 = flat$39$simp$270 [Double];
+      read flat$39$simp$283 = flat$39$simp$271 [Double];
+      write flat$30$simp$226 = flat$39$simp$280;
+      write flat$30$simp$227 = flat$39$simp$281;
+      write flat$30$simp$228 = flat$39$simp$282;
+      write flat$30$simp$229 = flat$39$simp$283;
     }
     else
     {
-      write flat$30$simp$244 = a$conv$63$simp$240;
-      write flat$30$simp$245 = 0.0@{Double};
-      write flat$30$simp$246 = 0.0@{Double};
-      write flat$30$simp$247 = 0.0@{Double};
+      write flat$30$simp$226 = aval$5$simp$222;
+      write flat$30$simp$227 = 0.0@{Double};
+      write flat$30$simp$228 = 0.0@{Double};
+      write flat$30$simp$229 = 0.0@{Double};
     }
-    read flat$30$simp$302 = flat$30$simp$244 [Error];
-    read flat$30$simp$303 = flat$30$simp$245 [Double];
-    read flat$30$simp$304 = flat$30$simp$246 [Double];
-    read flat$30$simp$305 = flat$30$simp$247 [Double];
-    write acc$a$conv$63$simp$66 = flat$30$simp$302;
-    write acc$a$conv$63$simp$67 = flat$30$simp$303;
-    write acc$a$conv$63$simp$68 = flat$30$simp$304;
-    write acc$a$conv$63$simp$69 = flat$30$simp$305;
+    read flat$30$simp$284 = flat$30$simp$226 [Error];
+    read flat$30$simp$285 = flat$30$simp$227 [Double];
+    read flat$30$simp$286 = flat$30$simp$228 [Double];
+    read flat$30$simp$287 = flat$30$simp$229 [Double];
+    write acc$a$conv$63$simp$107 = flat$30$simp$284;
+    write acc$a$conv$63$simp$108 = flat$30$simp$285;
+    write acc$a$conv$63$simp$109 = flat$30$simp$286;
+    write acc$a$conv$63$simp$110 = flat$30$simp$287;
   }
 }
-save_resumable@{Error} acc$a$conv$63$simp$66;
-save_resumable@{Double} acc$a$conv$63$simp$67;
-save_resumable@{Double} acc$a$conv$63$simp$68;
-save_resumable@{Double} acc$a$conv$63$simp$69;
-save_resumable@{Error} acc$conv$62$simp$70;
-save_resumable@{Double} acc$conv$62$simp$71;
-save_resumable@{Error} acc$conv$58$simp$80;
-save_resumable@{Int} acc$conv$58$simp$81;
-save_resumable@{Error} acc$conv$57$simp$88;
-save_resumable@{Int} acc$conv$57$simp$89;
-save_resumable@{Error} acc$s$reify$6$conv$12$simp$94;
-save_resumable@{Double} acc$s$reify$6$conv$12$simp$95;
-save_resumable@{Double} acc$s$reify$6$conv$12$simp$96;
-save_resumable@{Error} acc$conv$11$simp$97;
-save_resumable@{Double} acc$conv$11$simp$98;
-save_resumable@{Error} acc$conv$7$simp$105;
-save_resumable@{Double} acc$conv$7$simp$106;
-read a$conv$63$simp$306 = acc$a$conv$63$simp$66 [Error];
-read a$conv$63$simp$307 = acc$a$conv$63$simp$67 [Double];
-read a$conv$63$simp$309 = acc$a$conv$63$simp$69 [Double];
-read s$reify$6$conv$12$simp$310 = acc$s$reify$6$conv$12$simp$94 [Error];
-read s$reify$6$conv$12$simp$311 = acc$s$reify$6$conv$12$simp$95 [Double];
-init flat$82$simp$313@{Error} = ExceptNotAnError@{Error};
-init flat$82$simp$314@{Double} = 0.0@{Double};
-if (eq#@{Error} s$reify$6$conv$12$simp$310 (ExceptNotAnError@{Error}))
+save_resumable@{Error} acc$a$conv$63$simp$107;
+save_resumable@{Double} acc$a$conv$63$simp$108;
+save_resumable@{Double} acc$a$conv$63$simp$109;
+save_resumable@{Double} acc$a$conv$63$simp$110;
+save_resumable@{Error} acc$conv$62$simp$97;
+save_resumable@{Double} acc$conv$62$simp$98;
+save_resumable@{Error} acc$conv$58$simp$89;
+save_resumable@{Int} acc$conv$58$simp$90;
+save_resumable@{Error} acc$conv$57$simp$83;
+save_resumable@{Int} acc$conv$57$simp$84;
+save_resumable@{Error} acc$s$reify$6$conv$12$simp$80;
+save_resumable@{Double} acc$s$reify$6$conv$12$simp$81;
+save_resumable@{Double} acc$s$reify$6$conv$12$simp$82;
+save_resumable@{Error} acc$conv$11$simp$72;
+save_resumable@{Double} acc$conv$11$simp$73;
+save_resumable@{Error} acc$conv$7$simp$66;
+save_resumable@{Double} acc$conv$7$simp$67;
+read a$conv$63$simp$288 = acc$a$conv$63$simp$107 [Error];
+read a$conv$63$simp$289 = acc$a$conv$63$simp$108 [Double];
+read a$conv$63$simp$291 = acc$a$conv$63$simp$110 [Double];
+read s$reify$6$conv$12$simp$292 = acc$s$reify$6$conv$12$simp$80 [Error];
+read s$reify$6$conv$12$simp$293 = acc$s$reify$6$conv$12$simp$81 [Double];
+init flat$82$simp$295@{Error} = ExceptNotAnError@{Error};
+init flat$82$simp$296@{Double} = 0.0@{Double};
+if (eq#@{Error} s$reify$6$conv$12$simp$292 (ExceptNotAnError@{Error}))
 {
-  write flat$82$simp$313 = ExceptNotAnError@{Error};
-  write flat$82$simp$314 = s$reify$6$conv$12$simp$311;
+  write flat$82$simp$295 = ExceptNotAnError@{Error};
+  write flat$82$simp$296 = s$reify$6$conv$12$simp$293;
 }
 else
 {
-  write flat$82$simp$313 = s$reify$6$conv$12$simp$310;
-  write flat$82$simp$314 = 0.0@{Double};
+  write flat$82$simp$295 = s$reify$6$conv$12$simp$292;
+  write flat$82$simp$296 = 0.0@{Double};
 }
-read flat$82$simp$315 = flat$82$simp$313 [Error];
-read flat$82$simp$316 = flat$82$simp$314 [Double];
-init flat$83$simp$317@{Error} = ExceptNotAnError@{Error};
-init flat$83$simp$318@{Double} = 0.0@{Double};
-if (eq#@{Error} flat$82$simp$315 (ExceptNotAnError@{Error}))
+read flat$82$simp$297 = flat$82$simp$295 [Error];
+read flat$82$simp$298 = flat$82$simp$296 [Double];
+init flat$83$simp$299@{Error} = ExceptNotAnError@{Error};
+init flat$83$simp$300@{Double} = 0.0@{Double};
+if (eq#@{Error} flat$82$simp$297 (ExceptNotAnError@{Error}))
 {
-  init flat$86$simp$319@{Error} = ExceptNotAnError@{Error};
-  init flat$86$simp$320@{Double} = 0.0@{Double};
-  if (eq#@{Error} a$conv$63$simp$306 (ExceptNotAnError@{Error}))
+  init flat$86$simp$301@{Error} = ExceptNotAnError@{Error};
+  init flat$86$simp$302@{Double} = 0.0@{Double};
+  if (eq#@{Error} a$conv$63$simp$288 (ExceptNotAnError@{Error}))
   {
-    let conv$118 = sub#@{Double} a$conv$63$simp$307 (1.0@{Double});
-    let simp$1212 = div# a$conv$63$simp$309 conv$118;
-    write flat$86$simp$319 = ExceptNotAnError@{Error};
-    write flat$86$simp$320 = simp$1212;
+    let conv$118 = sub#@{Double} a$conv$63$simp$289 (1.0@{Double});
+    let simp$1186 = div# a$conv$63$simp$291 conv$118;
+    write flat$86$simp$301 = ExceptNotAnError@{Error};
+    write flat$86$simp$302 = simp$1186;
   }
   else
   {
-    write flat$86$simp$319 = a$conv$63$simp$306;
-    write flat$86$simp$320 = 0.0@{Double};
+    write flat$86$simp$301 = a$conv$63$simp$288;
+    write flat$86$simp$302 = 0.0@{Double};
   }
-  read flat$86$simp$321 = flat$86$simp$319 [Error];
-  read flat$86$simp$322 = flat$86$simp$320 [Double];
-  init flat$87$simp$323@{Error} = ExceptNotAnError@{Error};
-  init flat$87$simp$324@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$86$simp$321 (ExceptNotAnError@{Error}))
+  read flat$86$simp$303 = flat$86$simp$301 [Error];
+  read flat$86$simp$304 = flat$86$simp$302 [Double];
+  init flat$87$simp$305@{Error} = ExceptNotAnError@{Error};
+  init flat$87$simp$306@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat$86$simp$303 (ExceptNotAnError@{Error}))
   {
-    write flat$87$simp$323 = ExceptNotAnError@{Error};
-    write flat$87$simp$324 = sqrt# flat$86$simp$322;
+    write flat$87$simp$305 = ExceptNotAnError@{Error};
+    write flat$87$simp$306 = sqrt# flat$86$simp$304;
   }
   else
   {
-    write flat$87$simp$323 = flat$86$simp$321;
-    write flat$87$simp$324 = 0.0@{Double};
+    write flat$87$simp$305 = flat$86$simp$303;
+    write flat$87$simp$306 = 0.0@{Double};
   }
-  read flat$87$simp$325 = flat$87$simp$323 [Error];
-  read flat$87$simp$326 = flat$87$simp$324 [Double];
-  init flat$88$simp$327@{Error} = ExceptNotAnError@{Error};
-  init flat$88$simp$328@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$87$simp$325 (ExceptNotAnError@{Error}))
+  read flat$87$simp$307 = flat$87$simp$305 [Error];
+  read flat$87$simp$308 = flat$87$simp$306 [Double];
+  init flat$88$simp$309@{Error} = ExceptNotAnError@{Error};
+  init flat$88$simp$310@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat$87$simp$307 (ExceptNotAnError@{Error}))
   {
-    write flat$88$simp$327 = ExceptNotAnError@{Error};
-    write flat$88$simp$328 = mul#@{Double} flat$82$simp$316 flat$87$simp$326;
+    write flat$88$simp$309 = ExceptNotAnError@{Error};
+    write flat$88$simp$310 = mul#@{Double} flat$82$simp$298 flat$87$simp$308;
   }
   else
   {
-    write flat$88$simp$327 = flat$87$simp$325;
-    write flat$88$simp$328 = 0.0@{Double};
+    write flat$88$simp$309 = flat$87$simp$307;
+    write flat$88$simp$310 = 0.0@{Double};
   }
-  read flat$88$simp$329 = flat$88$simp$327 [Error];
-  read flat$88$simp$330 = flat$88$simp$328 [Double];
-  write flat$83$simp$317 = flat$88$simp$329;
-  write flat$83$simp$318 = flat$88$simp$330;
+  read flat$88$simp$311 = flat$88$simp$309 [Error];
+  read flat$88$simp$312 = flat$88$simp$310 [Double];
+  write flat$83$simp$299 = flat$88$simp$311;
+  write flat$83$simp$300 = flat$88$simp$312;
 }
 else
 {
-  write flat$83$simp$317 = flat$82$simp$315;
-  write flat$83$simp$318 = 0.0@{Double};
+  write flat$83$simp$299 = flat$82$simp$297;
+  write flat$83$simp$300 = 0.0@{Double};
 }
-read flat$83$simp$331 = flat$83$simp$317 [Error];
-read flat$83$simp$332 = flat$83$simp$318 [Double];
-output@{(Sum Error Double)} repl (flat$83$simp$331@{Error}, flat$83$simp$332@{Double});
+read flat$83$simp$313 = flat$83$simp$299 [Error];
+read flat$83$simp$314 = flat$83$simp$300 [Double];
+output@{(Sum Error Double)} repl (flat$83$simp$313@{Error}, flat$83$simp$314@{Double});
 
 - C:
 #line 1 "state definition #0 - repl"
@@ -649,50 +642,50 @@ typedef struct {
     /* inputs */
     itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_333;
-    istring_t       *new_conv_0_simp_334;
-    iint_t          *new_conv_0_simp_335;
-    itime_t         *new_conv_0_simp_336;
+    ierror_t        *new_conv_0_simp_315;
+    istring_t       *new_conv_0_simp_316;
+    iint_t          *new_conv_0_simp_317;
+    itime_t         *new_conv_0_simp_318;
 
     /* outputs */
     ierror_t         repl_ix_0;
     idouble_t        repl_ix_1;
 
     /* resumables */
-    ibool_t          has_acc_conv_58_simp_80;
-    ierror_t         res_acc_conv_58_simp_80;
-    ibool_t          has_acc_conv_58_simp_81;
-    iint_t           res_acc_conv_58_simp_81;
-    ibool_t          has_acc_conv_57_simp_88;
-    ierror_t         res_acc_conv_57_simp_88;
-    ibool_t          has_acc_conv_57_simp_89;
-    iint_t           res_acc_conv_57_simp_89;
-    ibool_t          has_acc_s_reify_6_conv_12_simp_95;
-    idouble_t        res_acc_s_reify_6_conv_12_simp_95;
-    ibool_t          has_acc_s_reify_6_conv_12_simp_94;
-    ierror_t         res_acc_s_reify_6_conv_12_simp_94;
-    ibool_t          has_acc_s_reify_6_conv_12_simp_96;
-    idouble_t        res_acc_s_reify_6_conv_12_simp_96;
-    ibool_t          has_acc_conv_62_simp_70;
-    ierror_t         res_acc_conv_62_simp_70;
-    ibool_t          has_acc_conv_62_simp_71;
-    idouble_t        res_acc_conv_62_simp_71;
-    ibool_t          has_acc_a_conv_63_simp_66;
-    ierror_t         res_acc_a_conv_63_simp_66;
-    ibool_t          has_acc_a_conv_63_simp_67;
-    idouble_t        res_acc_a_conv_63_simp_67;
-    ibool_t          has_acc_a_conv_63_simp_68;
-    idouble_t        res_acc_a_conv_63_simp_68;
-    ibool_t          has_acc_a_conv_63_simp_69;
-    idouble_t        res_acc_a_conv_63_simp_69;
-    ibool_t          has_acc_conv_11_simp_97;
-    ierror_t         res_acc_conv_11_simp_97;
-    ibool_t          has_acc_conv_11_simp_98;
-    idouble_t        res_acc_conv_11_simp_98;
-    ibool_t          has_acc_conv_7_simp_106;
-    idouble_t        res_acc_conv_7_simp_106;
-    ibool_t          has_acc_conv_7_simp_105;
-    ierror_t         res_acc_conv_7_simp_105;
+    ibool_t          has_acc_conv_58_simp_89;
+    ierror_t         res_acc_conv_58_simp_89;
+    ibool_t          has_acc_conv_57_simp_84;
+    iint_t           res_acc_conv_57_simp_84;
+    ibool_t          has_acc_conv_57_simp_83;
+    ierror_t         res_acc_conv_57_simp_83;
+    ibool_t          has_acc_conv_58_simp_90;
+    iint_t           res_acc_conv_58_simp_90;
+    ibool_t          has_acc_a_conv_63_simp_107;
+    ierror_t         res_acc_a_conv_63_simp_107;
+    ibool_t          has_acc_a_conv_63_simp_109;
+    idouble_t        res_acc_a_conv_63_simp_109;
+    ibool_t          has_acc_a_conv_63_simp_108;
+    idouble_t        res_acc_a_conv_63_simp_108;
+    ibool_t          has_acc_a_conv_63_simp_110;
+    idouble_t        res_acc_a_conv_63_simp_110;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_82;
+    idouble_t        res_acc_s_reify_6_conv_12_simp_82;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_80;
+    ierror_t         res_acc_s_reify_6_conv_12_simp_80;
+    ibool_t          has_acc_s_reify_6_conv_12_simp_81;
+    idouble_t        res_acc_s_reify_6_conv_12_simp_81;
+    ibool_t          has_acc_conv_7_simp_67;
+    idouble_t        res_acc_conv_7_simp_67;
+    ibool_t          has_acc_conv_7_simp_66;
+    ierror_t         res_acc_conv_7_simp_66;
+    ibool_t          has_acc_conv_62_simp_98;
+    idouble_t        res_acc_conv_62_simp_98;
+    ibool_t          has_acc_conv_62_simp_97;
+    ierror_t         res_acc_conv_62_simp_97;
+    ibool_t          has_acc_conv_11_simp_73;
+    idouble_t        res_acc_conv_11_simp_73;
+    ibool_t          has_acc_conv_11_simp_72;
+    ierror_t         res_acc_conv_11_simp_72;
 } iprogram_0_t;
 
 iint_t size_of_state_iprogram_0 ()
@@ -703,16 +696,16 @@ iint_t size_of_state_iprogram_0 ()
 #line 1 "compute function #0 - repl"
 void iprogram_0(iprogram_0_t *s)
 {
-    idouble_t        flat_39_simp_289;
-    idouble_t        flat_39_simp_288;
-    idouble_t        flat_39_simp_287;
-    ierror_t         flat_39_simp_286;
-    idouble_t        flat_38_simp_285;
-    idouble_t        flat_38_simp_281;
-    idouble_t        flat_38_simp_284;
-    idouble_t        flat_38_simp_282;
-    ierror_t         flat_38_simp_280;
-    ierror_t         flat_38_simp_283;
+    ierror_t         flat_29_simp_208;
+    idouble_t        flat_29_simp_209;
+    ierror_t         flat_39_simp_280;
+    idouble_t        flat_39_simp_283;
+    idouble_t        flat_39_simp_282;
+    idouble_t        flat_39_simp_281;
+    idouble_t        flat_30_simp_285;
+    idouble_t        flat_30_simp_286;
+    ierror_t         flat_30_simp_284;
+    idouble_t        flat_30_simp_287;
     idouble_t        flat_16_simp_162;
     idouble_t        flat_16_simp_163;
     idouble_t        flat_16_simp_160;
@@ -720,6 +713,8 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         flat_10_simp_164;
     idouble_t        flat_10_simp_165;
     idouble_t        flat_10_simp_166;
+    ierror_t         flat_29_simp_210;
+    idouble_t        flat_29_simp_211;
     ierror_t         flat_1_simp_117;
     ierror_t         flat_1_simp_115;
     idouble_t        flat_1_simp_116;
@@ -728,22 +723,14 @@ void iprogram_0(iprogram_0_t *s)
     iint_t           flat_0_simp_114;
     ierror_t         flat_0_simp_111;
     iint_t           flat_0_simp_112;
-    ierror_t         flat_39_simp_298;
-    idouble_t        flat_39_simp_299;
-    ierror_t         acc_conv_58_simp_80;
-    iint_t           acc_conv_58_simp_81;
-    ierror_t         acc_conv_57_simp_88;
-    iint_t           acc_conv_57_simp_89;
-    ierror_t         flat_29_simp_222;
-    idouble_t        flat_29_simp_223;
-    ierror_t         flat_29_simp_220;
-    idouble_t        flat_29_simp_221;
-    idouble_t        flat_30_simp_245;
-    idouble_t        flat_30_simp_246;
-    ierror_t         flat_30_simp_244;
-    idouble_t        flat_30_simp_247;
-    idouble_t        flat_33_simp_249;
-    ierror_t         flat_33_simp_248;
+    ierror_t         acc_conv_58_simp_89;
+    iint_t           acc_conv_57_simp_84;
+    ierror_t         acc_conv_57_simp_83;
+    iint_t           acc_conv_58_simp_90;
+    ierror_t         flat_36_simp_242;
+    idouble_t        flat_36_simp_243;
+    ierror_t         flat_35_simp_240;
+    idouble_t        flat_35_simp_241;
     idouble_t        flat_14_simp_153;
     ierror_t         flat_14_simp_150;
     ierror_t         flat_14_simp_152;
@@ -761,16 +748,10 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_10_simp_144;
     idouble_t        flat_10_simp_145;
     ierror_t         flat_10_simp_143;
-    idouble_t        flat_35_simp_257;
-    ierror_t         flat_35_simp_258;
-    idouble_t        flat_35_simp_259;
-    ierror_t         flat_35_simp_256;
-    ierror_t         flat_33_simp_250;
-    idouble_t        flat_33_simp_251;
-    idouble_t        flat_34_simp_255;
-    idouble_t        flat_34_simp_253;
-    ierror_t         flat_34_simp_254;
-    ierror_t         flat_34_simp_252;
+    idouble_t        flat_36_simp_257;
+    ierror_t         flat_36_simp_256;
+    ierror_t         flat_37_simp_258;
+    idouble_t        flat_37_simp_259;
     istring_t        flat_25_simp_183;
     ierror_t         flat_25_simp_182;
     istring_t        flat_25_simp_185;
@@ -779,18 +760,23 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         flat_26_simp_186;
     ibool_t          flat_26_simp_189;
     ierror_t         flat_26_simp_188;
+    ierror_t         acc_a_conv_63_simp_107;
+    idouble_t        acc_a_conv_63_simp_109;
+    idouble_t        acc_a_conv_63_simp_108;
     idouble_t        flat_6_simp_169;
     idouble_t        flat_6_simp_168;
     ierror_t         flat_6_simp_167;
-    ierror_t         flat_37_simp_278;
-    idouble_t        flat_37_simp_279;
-    ierror_t         flat_37_simp_276;
-    idouble_t        flat_37_simp_277;
-    idouble_t        flat_36_simp_275;
-    ierror_t         flat_36_simp_274;
+    idouble_t        flat_39_simp_271;
+    idouble_t        flat_39_simp_270;
     ierror_t         flat_3_simp_179;
-    ierror_t         flat_36_simp_260;
-    idouble_t        flat_36_simp_261;
+    idouble_t        flat_38_simp_263;
+    idouble_t        flat_38_simp_267;
+    ierror_t         flat_38_simp_262;
+    idouble_t        flat_38_simp_264;
+    idouble_t        flat_38_simp_266;
+    ierror_t         flat_38_simp_265;
+    idouble_t        flat_37_simp_261;
+    ierror_t         flat_37_simp_260;
     idouble_t        flat_7_simp_174;
     idouble_t        flat_7_simp_175;
     idouble_t        flat_7_simp_172;
@@ -800,219 +786,219 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         flat_6_simp_176;
     idouble_t        flat_6_simp_177;
     idouble_t        flat_6_simp_178;
+    idouble_t        flat_39_simp_269;
+    ierror_t         flat_39_simp_268;
+    idouble_t        acc_a_conv_63_simp_110;
     ierror_t         flat_3_simp_140;
     idouble_t        flat_3_simp_142;
     idouble_t        flat_3_simp_141;
-    idouble_t        flat_30_simp_304;
-    idouble_t        flat_30_simp_305;
-    idouble_t        flat_30_simp_303;
-    ierror_t         flat_30_simp_302;
-    idouble_t        flat_39_simp_301;
-    idouble_t        flat_39_simp_300;
-    idouble_t        acc_s_reify_6_conv_12_simp_95;
-    ierror_t         acc_s_reify_6_conv_12_simp_94;
-    idouble_t        acc_s_reify_6_conv_12_simp_96;
-    ierror_t         flat_28_simp_196;
-    iint_t           flat_28_simp_197;
-    ierror_t         flat_28_simp_198;
-    iint_t           flat_28_simp_199;
+    idouble_t        flat_30_simp_227;
+    ierror_t         flat_30_simp_226;
+    idouble_t        flat_30_simp_229;
+    idouble_t        flat_30_simp_228;
+    ierror_t         flat_28_simp_190;
+    iint_t           flat_28_simp_191;
+    ierror_t         flat_28_simp_192;
+    iint_t           flat_28_simp_193;
+    ierror_t         flat_35_simp_238;
+    idouble_t        flat_35_simp_239;
+    ierror_t         flat_33_simp_232;
+    idouble_t        flat_33_simp_233;
+    ierror_t         flat_33_simp_230;
+    idouble_t        flat_33_simp_231;
+    ierror_t         flat_34_simp_234;
+    idouble_t        flat_34_simp_235;
+    ierror_t         flat_34_simp_236;
+    idouble_t        flat_34_simp_237;
+    idouble_t        acc_s_reify_6_conv_12_simp_82;
+    ierror_t         acc_s_reify_6_conv_12_simp_80;
+    idouble_t        acc_s_reify_6_conv_12_simp_81;
     idouble_t        flat_2_simp_126;
     ierror_t         flat_2_simp_125;
     ierror_t         flat_2_simp_127;
     idouble_t        flat_2_simp_128;
-    ierror_t         conv_11_simp_129;
-    ierror_t         flat_83_simp_331;
-    idouble_t        flat_83_simp_332;
-    idouble_t        flat_88_simp_330;
-    ierror_t         flat_82_simp_315;
-    idouble_t        flat_82_simp_314;
-    idouble_t        flat_82_simp_316;
-    ierror_t         flat_82_simp_313;
-    idouble_t        flat_83_simp_318;
-    ierror_t         flat_83_simp_317;
-    ierror_t         flat_86_simp_319;
-    ierror_t         conv_7_simp_119;
-    idouble_t        flat_87_simp_326;
-    ierror_t         flat_87_simp_323;
-    idouble_t        flat_87_simp_324;
-    ierror_t         flat_87_simp_325;
-    idouble_t        flat_86_simp_320;
-    ierror_t         flat_86_simp_321;
-    idouble_t        flat_86_simp_322;
-    idouble_t        flat_88_simp_328;
-    ierror_t         flat_88_simp_329;
-    ierror_t         flat_88_simp_327;
-    idouble_t        conv_7_simp_120;
+    idouble_t        acc_conv_7_simp_67;
+    ierror_t         acc_conv_7_simp_66;
+    idouble_t        flat_83_simp_314;
+    ierror_t         flat_83_simp_313;
+    ierror_t         flat_88_simp_311;
+    idouble_t        flat_88_simp_310;
+    idouble_t        flat_88_simp_312;
     idouble_t        flat_3_simp_181;
     idouble_t        flat_3_simp_180;
-    idouble_t        conv_11_simp_130;
-    ierror_t         acc_conv_62_simp_70;
-    idouble_t        acc_conv_62_simp_71;
-    idouble_t        s_reify_6_conv_12_simp_311;
-    ierror_t         s_reify_6_conv_12_simp_310;
-    ierror_t         acc_a_conv_63_simp_66;
-    idouble_t        acc_a_conv_63_simp_67;
-    idouble_t        acc_a_conv_63_simp_68;
-    idouble_t        acc_a_conv_63_simp_69;
-    ierror_t         acc_conv_11_simp_97;
-    idouble_t        acc_conv_11_simp_98;
-    ierror_t         conv_58_simp_212;
-    iint_t           conv_58_simp_213;
-    iint_t           conv_57_simp_201;
-    ierror_t         conv_57_simp_200;
-    idouble_t        conv_62_simp_231;
-    ierror_t         conv_62_simp_230;
-    idouble_t        a_conv_63_simp_307;
-    ierror_t         a_conv_63_simp_306;
-    idouble_t        a_conv_63_simp_309;
-    idouble_t        s_reify_6_conv_12_simp_139;
-    idouble_t        s_reify_6_conv_12_simp_138;
-    ierror_t         s_reify_6_conv_12_simp_137;
-    idouble_t        flat_42_simp_293;
-    idouble_t        flat_42_simp_292;
-    idouble_t        flat_42_simp_291;
-    ierror_t         flat_42_simp_290;
-    idouble_t        flat_42_simp_297;
-    idouble_t        flat_42_simp_296;
-    idouble_t        flat_42_simp_295;
-    ierror_t         flat_42_simp_294;
-    ierror_t         flat_57_simp_264;
-    ierror_t         flat_57_simp_266;
-    idouble_t        flat_57_simp_265;
-    idouble_t        flat_57_simp_267;
-    ierror_t         flat_51_simp_262;
-    ierror_t         flat_51_simp_268;
-    idouble_t        flat_51_simp_269;
-    idouble_t        flat_51_simp_263;
-    idouble_t        flat_52_simp_271;
-    ierror_t         flat_52_simp_272;
-    idouble_t        flat_52_simp_273;
-    ierror_t         flat_52_simp_270;
-    idouble_t        acc_conv_7_simp_106;
-    ierror_t         acc_conv_7_simp_105;
+    idouble_t        acc_conv_62_simp_98;
+    ierror_t         acc_conv_62_simp_97;
+    idouble_t        acc_conv_11_simp_73;
+    ierror_t         acc_conv_11_simp_72;
+    iint_t           aval_3_simp_195;
+    ierror_t         aval_3_simp_194;
+    ierror_t         flat_83_simp_299;
+    ierror_t         flat_82_simp_297;
+    ierror_t         flat_82_simp_295;
+    idouble_t        flat_82_simp_296;
+    idouble_t        flat_82_simp_298;
+    idouble_t        aval_6_simp_213;
+    ierror_t         aval_6_simp_212;
+    ierror_t         flat_87_simp_307;
+    ierror_t         flat_87_simp_305;
+    idouble_t        flat_87_simp_306;
+    idouble_t        flat_87_simp_308;
+    ierror_t         flat_86_simp_301;
+    idouble_t        flat_86_simp_302;
+    ierror_t         flat_86_simp_303;
+    idouble_t        flat_86_simp_304;
+    idouble_t        flat_83_simp_300;
+    ierror_t         flat_88_simp_309;
+    iint_t           aval_4_simp_201;
+    ierror_t         aval_4_simp_200;
+    idouble_t        aval_5_simp_223;
+    ierror_t         aval_5_simp_222;
+    idouble_t        aval_5_simp_225;
+    idouble_t        aval_5_simp_224;
+    ierror_t         s_reify_6_conv_12_simp_292;
+    idouble_t        s_reify_6_conv_12_simp_293;
+    idouble_t        flat_42_simp_279;
+    idouble_t        flat_42_simp_278;
+    idouble_t        flat_42_simp_275;
+    idouble_t        flat_42_simp_274;
+    idouble_t        flat_42_simp_277;
+    ierror_t         flat_42_simp_276;
+    idouble_t        flat_42_simp_273;
+    ierror_t         flat_42_simp_272;
+    ierror_t         flat_52_simp_252;
+    idouble_t        flat_52_simp_253;
+    ierror_t         flat_52_simp_254;
+    idouble_t        flat_52_simp_255;
+    idouble_t        flat_51_simp_251;
+    ierror_t         flat_51_simp_250;
+    ierror_t         aval_2_simp_129;
+    idouble_t        aval_0_simp_120;
+    ierror_t         flat_57_simp_248;
+    idouble_t        flat_57_simp_249;
+    ierror_t         flat_57_simp_246;
+    idouble_t        flat_57_simp_247;
+    idouble_t        flat_51_simp_245;
+    ierror_t         flat_51_simp_244;
+    ierror_t         aval_0_simp_119;
     ibool_t          flat_27;
-    idouble_t        a_conv_63_simp_242;
-    ierror_t         a_conv_63_simp_240;
-    idouble_t        a_conv_63_simp_243;
-    idouble_t        a_conv_63_simp_241;
+    idouble_t        aval_2_simp_130;
+    ierror_t         aval_1_simp_137;
+    idouble_t        aval_1_simp_138;
+    idouble_t        aval_1_simp_139;
+    idouble_t        a_conv_63_simp_291;
+    ierror_t         a_conv_63_simp_288;
+    idouble_t        a_conv_63_simp_289;
 
     imempool_t      *mempool                  = s->mempool;
     itime_t          conv_3                   = s->conv_3;
 
-    acc_a_conv_63_simp_66                     = ierror_not_an_error;                  /* init */
-    acc_a_conv_63_simp_67                     = 0.0;                                  /* init */
-    acc_a_conv_63_simp_68                     = 0.0;                                  /* init */
-    acc_a_conv_63_simp_69                     = 0.0;                                  /* init */
-    acc_conv_62_simp_70                       = ierror_not_an_error;                  /* init */
-    acc_conv_62_simp_71                       = 0.0;                                  /* init */
-    acc_conv_58_simp_80                       = ierror_not_an_error;                  /* init */
-    acc_conv_58_simp_81                       = 0;                                    /* init */
-    acc_conv_57_simp_88                       = ierror_not_an_error;                  /* init */
-    acc_conv_57_simp_89                       = 0;                                    /* init */
-    acc_s_reify_6_conv_12_simp_94             = ierror_not_an_error;                  /* init */
-    acc_s_reify_6_conv_12_simp_95             = 0.0;                                  /* init */
-    acc_s_reify_6_conv_12_simp_96             = 0.0;                                  /* init */
-    acc_conv_11_simp_97                       = ierror_not_an_error;                  /* init */
-    acc_conv_11_simp_98                       = 0.0;                                  /* init */
-    acc_conv_7_simp_105                       = ierror_not_an_error;                  /* init */
-    acc_conv_7_simp_106                       = 0.0;                                  /* init */
-    acc_s_reify_6_conv_12_simp_94             = ierror_fold1_no_value;                /* write */
-    acc_s_reify_6_conv_12_simp_95             = 0.0;                                  /* write */
-    acc_s_reify_6_conv_12_simp_96             = 0.0;                                  /* write */
-    acc_a_conv_63_simp_66                     = ierror_not_an_error;                  /* write */
-    acc_a_conv_63_simp_67                     = 0.0;                                  /* write */
-    acc_a_conv_63_simp_68                     = 0.0;                                  /* write */
-    acc_a_conv_63_simp_69                     = 0.0;                                  /* write */
+    acc_conv_7_simp_66                        = ierror_not_an_error;                  /* init */
+    acc_conv_7_simp_67                        = 0.0;                                  /* init */
+    acc_conv_11_simp_72                       = ierror_not_an_error;                  /* init */
+    acc_conv_11_simp_73                       = 0.0;                                  /* init */
+    acc_s_reify_6_conv_12_simp_80             = ierror_fold1_no_value;                /* init */
+    acc_s_reify_6_conv_12_simp_81             = 0.0;                                  /* init */
+    acc_s_reify_6_conv_12_simp_82             = 0.0;                                  /* init */
+    acc_conv_57_simp_83                       = ierror_not_an_error;                  /* init */
+    acc_conv_57_simp_84                       = 0;                                    /* init */
+    acc_conv_58_simp_89                       = ierror_not_an_error;                  /* init */
+    acc_conv_58_simp_90                       = 0;                                    /* init */
+    acc_conv_62_simp_97                       = ierror_not_an_error;                  /* init */
+    acc_conv_62_simp_98                       = 0.0;                                  /* init */
+    acc_a_conv_63_simp_107                    = ierror_not_an_error;                  /* init */
+    acc_a_conv_63_simp_108                    = 0.0;                                  /* init */
+    acc_a_conv_63_simp_109                    = 0.0;                                  /* init */
+    acc_a_conv_63_simp_110                    = 0.0;                                  /* init */
     
-    if (s->has_acc_a_conv_63_simp_66) {
-        acc_a_conv_63_simp_66                 = s->res_acc_a_conv_63_simp_66;         /* load */
+    if (s->has_acc_a_conv_63_simp_107) {
+        acc_a_conv_63_simp_107                = s->res_acc_a_conv_63_simp_107;        /* load */
     }
     
-    if (s->has_acc_a_conv_63_simp_67) {
-        acc_a_conv_63_simp_67                 = s->res_acc_a_conv_63_simp_67;         /* load */
+    if (s->has_acc_a_conv_63_simp_108) {
+        acc_a_conv_63_simp_108                = s->res_acc_a_conv_63_simp_108;        /* load */
     }
     
-    if (s->has_acc_a_conv_63_simp_68) {
-        acc_a_conv_63_simp_68                 = s->res_acc_a_conv_63_simp_68;         /* load */
+    if (s->has_acc_a_conv_63_simp_109) {
+        acc_a_conv_63_simp_109                = s->res_acc_a_conv_63_simp_109;        /* load */
     }
     
-    if (s->has_acc_a_conv_63_simp_69) {
-        acc_a_conv_63_simp_69                 = s->res_acc_a_conv_63_simp_69;         /* load */
+    if (s->has_acc_a_conv_63_simp_110) {
+        acc_a_conv_63_simp_110                = s->res_acc_a_conv_63_simp_110;        /* load */
     }
     
-    if (s->has_acc_conv_62_simp_70) {
-        acc_conv_62_simp_70                   = s->res_acc_conv_62_simp_70;           /* load */
+    if (s->has_acc_conv_62_simp_97) {
+        acc_conv_62_simp_97                   = s->res_acc_conv_62_simp_97;           /* load */
     }
     
-    if (s->has_acc_conv_62_simp_71) {
-        acc_conv_62_simp_71                   = s->res_acc_conv_62_simp_71;           /* load */
+    if (s->has_acc_conv_62_simp_98) {
+        acc_conv_62_simp_98                   = s->res_acc_conv_62_simp_98;           /* load */
     }
     
-    if (s->has_acc_conv_58_simp_80) {
-        acc_conv_58_simp_80                   = s->res_acc_conv_58_simp_80;           /* load */
+    if (s->has_acc_conv_58_simp_89) {
+        acc_conv_58_simp_89                   = s->res_acc_conv_58_simp_89;           /* load */
     }
     
-    if (s->has_acc_conv_58_simp_81) {
-        acc_conv_58_simp_81                   = s->res_acc_conv_58_simp_81;           /* load */
+    if (s->has_acc_conv_58_simp_90) {
+        acc_conv_58_simp_90                   = s->res_acc_conv_58_simp_90;           /* load */
     }
     
-    if (s->has_acc_conv_57_simp_88) {
-        acc_conv_57_simp_88                   = s->res_acc_conv_57_simp_88;           /* load */
+    if (s->has_acc_conv_57_simp_83) {
+        acc_conv_57_simp_83                   = s->res_acc_conv_57_simp_83;           /* load */
     }
     
-    if (s->has_acc_conv_57_simp_89) {
-        acc_conv_57_simp_89                   = s->res_acc_conv_57_simp_89;           /* load */
+    if (s->has_acc_conv_57_simp_84) {
+        acc_conv_57_simp_84                   = s->res_acc_conv_57_simp_84;           /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_12_simp_94) {
-        acc_s_reify_6_conv_12_simp_94         = s->res_acc_s_reify_6_conv_12_simp_94; /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_80) {
+        acc_s_reify_6_conv_12_simp_80         = s->res_acc_s_reify_6_conv_12_simp_80; /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_12_simp_95) {
-        acc_s_reify_6_conv_12_simp_95         = s->res_acc_s_reify_6_conv_12_simp_95; /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_81) {
+        acc_s_reify_6_conv_12_simp_81         = s->res_acc_s_reify_6_conv_12_simp_81; /* load */
     }
     
-    if (s->has_acc_s_reify_6_conv_12_simp_96) {
-        acc_s_reify_6_conv_12_simp_96         = s->res_acc_s_reify_6_conv_12_simp_96; /* load */
+    if (s->has_acc_s_reify_6_conv_12_simp_82) {
+        acc_s_reify_6_conv_12_simp_82         = s->res_acc_s_reify_6_conv_12_simp_82; /* load */
     }
     
-    if (s->has_acc_conv_11_simp_97) {
-        acc_conv_11_simp_97                   = s->res_acc_conv_11_simp_97;           /* load */
+    if (s->has_acc_conv_11_simp_72) {
+        acc_conv_11_simp_72                   = s->res_acc_conv_11_simp_72;           /* load */
     }
     
-    if (s->has_acc_conv_11_simp_98) {
-        acc_conv_11_simp_98                   = s->res_acc_conv_11_simp_98;           /* load */
+    if (s->has_acc_conv_11_simp_73) {
+        acc_conv_11_simp_73                   = s->res_acc_conv_11_simp_73;           /* load */
     }
     
-    if (s->has_acc_conv_7_simp_105) {
-        acc_conv_7_simp_105                   = s->res_acc_conv_7_simp_105;           /* load */
+    if (s->has_acc_conv_7_simp_66) {
+        acc_conv_7_simp_66                    = s->res_acc_conv_7_simp_66;            /* load */
     }
     
-    if (s->has_acc_conv_7_simp_106) {
-        acc_conv_7_simp_106                   = s->res_acc_conv_7_simp_106;           /* load */
+    if (s->has_acc_conv_7_simp_67) {
+        acc_conv_7_simp_67                    = s->res_acc_conv_7_simp_67;            /* load */
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_333 = s->new_conv_0_simp_333;
-    const istring_t *const new_conv_0_simp_334 = s->new_conv_0_simp_334;
-    const iint_t    *const new_conv_0_simp_335 = s->new_conv_0_simp_335;
-    const itime_t   *const new_conv_0_simp_336 = s->new_conv_0_simp_336;
+    const ierror_t  *const new_conv_0_simp_315 = s->new_conv_0_simp_315;
+    const istring_t *const new_conv_0_simp_316 = s->new_conv_0_simp_316;
+    const iint_t    *const new_conv_0_simp_317 = s->new_conv_0_simp_317;
+    const itime_t   *const new_conv_0_simp_318 = s->new_conv_0_simp_318;
     
     for (iint_t i = 0; i < new_count; i++) {
         iint_t           conv_1               = i;
-        itime_t          conv_2               = new_conv_0_simp_336[i];
-        ierror_t         conv_0_simp_333      = new_conv_0_simp_333[i];
-        istring_t        conv_0_simp_334      = new_conv_0_simp_334[i];
-        iint_t           conv_0_simp_335      = new_conv_0_simp_335[i];
-        itime_t          conv_0_simp_336      = new_conv_0_simp_336[i];
+        itime_t          conv_2               = new_conv_0_simp_318[i];
+        ierror_t         conv_0_simp_315      = new_conv_0_simp_315[i];
+        istring_t        conv_0_simp_316      = new_conv_0_simp_316[i];
+        iint_t           conv_0_simp_317      = new_conv_0_simp_317[i];
+        itime_t          conv_0_simp_318      = new_conv_0_simp_318[i];
         flat_0_simp_111                       = ierror_not_an_error;                  /* init */
         flat_0_simp_112                       = 0;                                    /* init */
         
-        if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
+        if (ierror_eq (conv_0_simp_315, ierror_not_an_error)) {
             flat_0_simp_111                   = ierror_not_an_error;                  /* write */
-            flat_0_simp_112                   = conv_0_simp_335;                      /* write */
+            flat_0_simp_112                   = conv_0_simp_317;                      /* write */
         } else {
-            flat_0_simp_111                   = conv_0_simp_333;                      /* write */
+            flat_0_simp_111                   = conv_0_simp_315;                      /* write */
             flat_0_simp_112                   = 0;                                    /* write */
         }
         
@@ -1031,48 +1017,48 @@ void iprogram_0(iprogram_0_t *s)
         
         flat_1_simp_117                       = flat_1_simp_115;                      /* read */
         flat_1_simp_118                       = flat_1_simp_116;                      /* read */
-        acc_conv_7_simp_105                   = flat_1_simp_117;                      /* write */
-        acc_conv_7_simp_106                   = flat_1_simp_118;                      /* write */
-        conv_7_simp_119                       = acc_conv_7_simp_105;                  /* read */
-        conv_7_simp_120                       = acc_conv_7_simp_106;                  /* read */
+        acc_conv_7_simp_66                    = flat_1_simp_117;                      /* write */
+        acc_conv_7_simp_67                    = flat_1_simp_118;                      /* write */
+        aval_0_simp_119                       = acc_conv_7_simp_66;                   /* read */
+        aval_0_simp_120                       = acc_conv_7_simp_67;                   /* read */
         flat_2_simp_125                       = ierror_not_an_error;                  /* init */
         flat_2_simp_126                       = 0.0;                                  /* init */
         
-        if (ierror_eq (conv_7_simp_119, ierror_not_an_error)) {
+        if (ierror_eq (aval_0_simp_119, ierror_not_an_error)) {
             flat_2_simp_125                   = ierror_not_an_error;                  /* write */
-            flat_2_simp_126                   = conv_7_simp_120;                      /* write */
+            flat_2_simp_126                   = aval_0_simp_120;                      /* write */
         } else {
-            flat_2_simp_125                   = conv_7_simp_119;                      /* write */
+            flat_2_simp_125                   = aval_0_simp_119;                      /* write */
             flat_2_simp_126                   = 0.0;                                  /* write */
         }
         
         flat_2_simp_127                       = flat_2_simp_125;                      /* read */
         flat_2_simp_128                       = flat_2_simp_126;                      /* read */
-        acc_conv_11_simp_97                   = flat_2_simp_127;                      /* write */
-        acc_conv_11_simp_98                   = flat_2_simp_128;                      /* write */
-        conv_11_simp_129                      = acc_conv_11_simp_97;                  /* read */
-        conv_11_simp_130                      = acc_conv_11_simp_98;                  /* read */
-        s_reify_6_conv_12_simp_137            = acc_s_reify_6_conv_12_simp_94;        /* read */
-        s_reify_6_conv_12_simp_138            = acc_s_reify_6_conv_12_simp_95;        /* read */
-        s_reify_6_conv_12_simp_139            = acc_s_reify_6_conv_12_simp_96;        /* read */
+        acc_conv_11_simp_72                   = flat_2_simp_127;                      /* write */
+        acc_conv_11_simp_73                   = flat_2_simp_128;                      /* write */
+        aval_2_simp_129                       = acc_conv_11_simp_72;                  /* read */
+        aval_2_simp_130                       = acc_conv_11_simp_73;                  /* read */
+        aval_1_simp_137                       = acc_s_reify_6_conv_12_simp_80;        /* read */
+        aval_1_simp_138                       = acc_s_reify_6_conv_12_simp_81;        /* read */
+        aval_1_simp_139                       = acc_s_reify_6_conv_12_simp_82;        /* read */
         flat_3_simp_140                       = ierror_not_an_error;                  /* init */
         flat_3_simp_141                       = 0.0;                                  /* init */
         flat_3_simp_142                       = 0.0;                                  /* init */
         
-        if (ierror_eq (s_reify_6_conv_12_simp_137, ierror_not_an_error)) {
+        if (ierror_eq (aval_1_simp_137, ierror_not_an_error)) {
             flat_10_simp_143                  = ierror_not_an_error;                  /* init */
             flat_10_simp_144                  = 0.0;                                  /* init */
             flat_10_simp_145                  = 0.0;                                  /* init */
             
-            if (ierror_eq (s_reify_6_conv_12_simp_137, ierror_not_an_error)) {
+            if (ierror_eq (aval_1_simp_137, ierror_not_an_error)) {
                 flat_13_simp_146              = ierror_not_an_error;                  /* init */
                 flat_13_simp_147              = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_11_simp_129, ierror_not_an_error)) {
+                if (ierror_eq (aval_2_simp_129, ierror_not_an_error)) {
                     flat_13_simp_146          = ierror_not_an_error;                  /* write */
-                    flat_13_simp_147          = idouble_sub (conv_11_simp_130, s_reify_6_conv_12_simp_138); /* write */
+                    flat_13_simp_147          = idouble_sub (aval_2_simp_130, aval_1_simp_138); /* write */
                 } else {
-                    flat_13_simp_146          = conv_11_simp_129;                     /* write */
+                    flat_13_simp_146          = aval_2_simp_129;                      /* write */
                     flat_13_simp_147          = 0.0;                                  /* write */
                 }
                 
@@ -1083,8 +1069,8 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_13_simp_148, ierror_not_an_error)) {
                     flat_14_simp_150          = ierror_not_an_error;                  /* write */
-                    idouble_t        simp_461 = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* let */
-                    flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_461); /* write */
+                    idouble_t        simp_443 = idouble_add (aval_1_simp_139, 1.0);   /* let */
+                    flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_443); /* write */
                 } else {
                     flat_14_simp_150          = flat_13_simp_148;                     /* write */
                     flat_14_simp_151          = 0.0;                                  /* write */
@@ -1097,7 +1083,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_14_simp_152, ierror_not_an_error)) {
                     flat_15_simp_154          = ierror_not_an_error;                  /* write */
-                    flat_15_simp_155          = idouble_add (s_reify_6_conv_12_simp_138, flat_14_simp_153); /* write */
+                    flat_15_simp_155          = idouble_add (aval_1_simp_138, flat_14_simp_153); /* write */
                 } else {
                     flat_15_simp_154          = flat_14_simp_152;                     /* write */
                     flat_15_simp_155          = 0.0;                                  /* write */
@@ -1112,7 +1098,7 @@ void iprogram_0(iprogram_0_t *s)
                 if (ierror_eq (flat_15_simp_156, ierror_not_an_error)) {
                     flat_16_simp_158          = ierror_not_an_error;                  /* write */
                     flat_16_simp_159          = flat_15_simp_157;                     /* write */
-                    flat_16_simp_160          = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* write */
+                    flat_16_simp_160          = idouble_add (aval_1_simp_139, 1.0);   /* write */
                 } else {
                     flat_16_simp_158          = flat_15_simp_156;                     /* write */
                     flat_16_simp_159          = 0.0;                                  /* write */
@@ -1126,7 +1112,7 @@ void iprogram_0(iprogram_0_t *s)
                 flat_10_simp_144              = flat_16_simp_162;                     /* write */
                 flat_10_simp_145              = flat_16_simp_163;                     /* write */
             } else {
-                flat_10_simp_143              = s_reify_6_conv_12_simp_137;           /* write */
+                flat_10_simp_143              = aval_1_simp_137;                      /* write */
                 flat_10_simp_144              = 0.0;                                  /* write */
                 flat_10_simp_145              = 0.0;                                  /* write */
             }
@@ -1142,17 +1128,17 @@ void iprogram_0(iprogram_0_t *s)
             flat_6_simp_168                   = 0.0;                                  /* init */
             flat_6_simp_169                   = 0.0;                                  /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, s_reify_6_conv_12_simp_137)) {
+            if (ierror_eq (ierror_fold1_no_value, aval_1_simp_137)) {
                 flat_7_simp_170               = ierror_not_an_error;                  /* init */
                 flat_7_simp_171               = 0.0;                                  /* init */
                 flat_7_simp_172               = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_11_simp_129, ierror_not_an_error)) {
+                if (ierror_eq (aval_2_simp_129, ierror_not_an_error)) {
                     flat_7_simp_170           = ierror_not_an_error;                  /* write */
-                    flat_7_simp_171           = conv_11_simp_130;                     /* write */
+                    flat_7_simp_171           = aval_2_simp_130;                      /* write */
                     flat_7_simp_172           = 1.0;                                  /* write */
                 } else {
-                    flat_7_simp_170           = conv_11_simp_129;                     /* write */
+                    flat_7_simp_170           = aval_2_simp_129;                      /* write */
                     flat_7_simp_171           = 0.0;                                  /* write */
                     flat_7_simp_172           = 0.0;                                  /* write */
                 }
@@ -1164,7 +1150,7 @@ void iprogram_0(iprogram_0_t *s)
                 flat_6_simp_168               = flat_7_simp_174;                      /* write */
                 flat_6_simp_169               = flat_7_simp_175;                      /* write */
             } else {
-                flat_6_simp_167               = s_reify_6_conv_12_simp_137;           /* write */
+                flat_6_simp_167               = aval_1_simp_137;                      /* write */
                 flat_6_simp_168               = 0.0;                                  /* write */
                 flat_6_simp_169               = 0.0;                                  /* write */
             }
@@ -1180,17 +1166,17 @@ void iprogram_0(iprogram_0_t *s)
         flat_3_simp_179                       = flat_3_simp_140;                      /* read */
         flat_3_simp_180                       = flat_3_simp_141;                      /* read */
         flat_3_simp_181                       = flat_3_simp_142;                      /* read */
-        acc_s_reify_6_conv_12_simp_94         = flat_3_simp_179;                      /* write */
-        acc_s_reify_6_conv_12_simp_95         = flat_3_simp_180;                      /* write */
-        acc_s_reify_6_conv_12_simp_96         = flat_3_simp_181;                      /* write */
+        acc_s_reify_6_conv_12_simp_80         = flat_3_simp_179;                      /* write */
+        acc_s_reify_6_conv_12_simp_81         = flat_3_simp_180;                      /* write */
+        acc_s_reify_6_conv_12_simp_82         = flat_3_simp_181;                      /* write */
         flat_25_simp_182                      = ierror_not_an_error;                  /* init */
         flat_25_simp_183                      = "";                                   /* init */
         
-        if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
+        if (ierror_eq (conv_0_simp_315, ierror_not_an_error)) {
             flat_25_simp_182                  = ierror_not_an_error;                  /* write */
-            flat_25_simp_183                  = conv_0_simp_334;                      /* write */
+            flat_25_simp_183                  = conv_0_simp_316;                      /* write */
         } else {
-            flat_25_simp_182                  = conv_0_simp_333;                      /* write */
+            flat_25_simp_182                  = conv_0_simp_315;                      /* write */
             flat_25_simp_183                  = "";                                   /* write */
         }
         
@@ -1220,366 +1206,366 @@ void iprogram_0(iprogram_0_t *s)
         flat_27                               = flat_27;                              /* read */
         
         if (flat_27) {
-            flat_28_simp_196                  = ierror_not_an_error;                  /* init */
-            flat_28_simp_197                  = 0;                                    /* init */
+            flat_28_simp_190                  = ierror_not_an_error;                  /* init */
+            flat_28_simp_191                  = 0;                                    /* init */
             
-            if (ierror_eq (conv_0_simp_333, ierror_not_an_error)) {
-                flat_28_simp_196              = ierror_not_an_error;                  /* write */
-                flat_28_simp_197              = conv_0_simp_335;                      /* write */
+            if (ierror_eq (conv_0_simp_315, ierror_not_an_error)) {
+                flat_28_simp_190              = ierror_not_an_error;                  /* write */
+                flat_28_simp_191              = conv_0_simp_317;                      /* write */
             } else {
-                flat_28_simp_196              = conv_0_simp_333;                      /* write */
-                flat_28_simp_197              = 0;                                    /* write */
+                flat_28_simp_190              = conv_0_simp_315;                      /* write */
+                flat_28_simp_191              = 0;                                    /* write */
             }
             
-            flat_28_simp_198                  = flat_28_simp_196;                     /* read */
-            flat_28_simp_199                  = flat_28_simp_197;                     /* read */
-            acc_conv_57_simp_88               = flat_28_simp_198;                     /* write */
-            acc_conv_57_simp_89               = flat_28_simp_199;                     /* write */
-            conv_57_simp_200                  = acc_conv_57_simp_88;                  /* read */
-            conv_57_simp_201                  = acc_conv_57_simp_89;                  /* read */
-            acc_conv_58_simp_80               = conv_57_simp_200;                     /* write */
-            acc_conv_58_simp_81               = conv_57_simp_201;                     /* write */
-            conv_58_simp_212                  = acc_conv_58_simp_80;                  /* read */
-            conv_58_simp_213                  = acc_conv_58_simp_81;                  /* read */
-            flat_29_simp_220                  = ierror_not_an_error;                  /* init */
-            flat_29_simp_221                  = 0.0;                                  /* init */
+            flat_28_simp_192                  = flat_28_simp_190;                     /* read */
+            flat_28_simp_193                  = flat_28_simp_191;                     /* read */
+            acc_conv_57_simp_83               = flat_28_simp_192;                     /* write */
+            acc_conv_57_simp_84               = flat_28_simp_193;                     /* write */
+            aval_3_simp_194                   = acc_conv_57_simp_83;                  /* read */
+            aval_3_simp_195                   = acc_conv_57_simp_84;                  /* read */
+            acc_conv_58_simp_89               = aval_3_simp_194;                      /* write */
+            acc_conv_58_simp_90               = aval_3_simp_195;                      /* write */
+            aval_4_simp_200                   = acc_conv_58_simp_89;                  /* read */
+            aval_4_simp_201                   = acc_conv_58_simp_90;                  /* read */
+            flat_29_simp_208                  = ierror_not_an_error;                  /* init */
+            flat_29_simp_209                  = 0.0;                                  /* init */
             
-            if (ierror_eq (conv_58_simp_212, ierror_not_an_error)) {
-                flat_29_simp_220              = ierror_not_an_error;                  /* write */
-                flat_29_simp_221              = iint_extend (conv_58_simp_213);       /* write */
+            if (ierror_eq (aval_4_simp_200, ierror_not_an_error)) {
+                flat_29_simp_208              = ierror_not_an_error;                  /* write */
+                flat_29_simp_209              = iint_extend (aval_4_simp_201);        /* write */
             } else {
-                flat_29_simp_220              = conv_58_simp_212;                     /* write */
-                flat_29_simp_221              = 0.0;                                  /* write */
+                flat_29_simp_208              = aval_4_simp_200;                      /* write */
+                flat_29_simp_209              = 0.0;                                  /* write */
             }
             
-            flat_29_simp_222                  = flat_29_simp_220;                     /* read */
-            flat_29_simp_223                  = flat_29_simp_221;                     /* read */
-            acc_conv_62_simp_70               = flat_29_simp_222;                     /* write */
-            acc_conv_62_simp_71               = flat_29_simp_223;                     /* write */
-            conv_62_simp_230                  = acc_conv_62_simp_70;                  /* read */
-            conv_62_simp_231                  = acc_conv_62_simp_71;                  /* read */
-            a_conv_63_simp_240                = acc_a_conv_63_simp_66;                /* read */
-            a_conv_63_simp_241                = acc_a_conv_63_simp_67;                /* read */
-            a_conv_63_simp_242                = acc_a_conv_63_simp_68;                /* read */
-            a_conv_63_simp_243                = acc_a_conv_63_simp_69;                /* read */
-            flat_30_simp_244                  = ierror_not_an_error;                  /* init */
-            flat_30_simp_245                  = 0.0;                                  /* init */
-            flat_30_simp_246                  = 0.0;                                  /* init */
-            flat_30_simp_247                  = 0.0;                                  /* init */
+            flat_29_simp_210                  = flat_29_simp_208;                     /* read */
+            flat_29_simp_211                  = flat_29_simp_209;                     /* read */
+            acc_conv_62_simp_97               = flat_29_simp_210;                     /* write */
+            acc_conv_62_simp_98               = flat_29_simp_211;                     /* write */
+            aval_6_simp_212                   = acc_conv_62_simp_97;                  /* read */
+            aval_6_simp_213                   = acc_conv_62_simp_98;                  /* read */
+            aval_5_simp_222                   = acc_a_conv_63_simp_107;               /* read */
+            aval_5_simp_223                   = acc_a_conv_63_simp_108;               /* read */
+            aval_5_simp_224                   = acc_a_conv_63_simp_109;               /* read */
+            aval_5_simp_225                   = acc_a_conv_63_simp_110;               /* read */
+            flat_30_simp_226                  = ierror_not_an_error;                  /* init */
+            flat_30_simp_227                  = 0.0;                                  /* init */
+            flat_30_simp_228                  = 0.0;                                  /* init */
+            flat_30_simp_229                  = 0.0;                                  /* init */
             
-            if (ierror_eq (a_conv_63_simp_240, ierror_not_an_error)) {
-                idouble_t        nn_conv_70   = idouble_add (a_conv_63_simp_241, 1.0); /* let */
-                flat_33_simp_248              = ierror_not_an_error;                  /* init */
-                flat_33_simp_249              = 0.0;                                  /* init */
+            if (ierror_eq (aval_5_simp_222, ierror_not_an_error)) {
+                idouble_t        nn_conv_70   = idouble_add (aval_5_simp_223, 1.0);   /* let */
+                flat_33_simp_230              = ierror_not_an_error;                  /* init */
+                flat_33_simp_231              = 0.0;                                  /* init */
                 
-                if (ierror_eq (conv_62_simp_230, ierror_not_an_error)) {
-                    flat_33_simp_248          = ierror_not_an_error;                  /* write */
-                    flat_33_simp_249          = idouble_sub (conv_62_simp_231, a_conv_63_simp_242); /* write */
+                if (ierror_eq (aval_6_simp_212, ierror_not_an_error)) {
+                    flat_33_simp_230          = ierror_not_an_error;                  /* write */
+                    flat_33_simp_231          = idouble_sub (aval_6_simp_213, aval_5_simp_224); /* write */
                 } else {
-                    flat_33_simp_248          = conv_62_simp_230;                     /* write */
-                    flat_33_simp_249          = 0.0;                                  /* write */
+                    flat_33_simp_230          = aval_6_simp_212;                      /* write */
+                    flat_33_simp_231          = 0.0;                                  /* write */
                 }
                 
-                flat_33_simp_250              = flat_33_simp_248;                     /* read */
-                flat_33_simp_251              = flat_33_simp_249;                     /* read */
-                flat_34_simp_252              = ierror_not_an_error;                  /* init */
-                flat_34_simp_253              = 0.0;                                  /* init */
+                flat_33_simp_232              = flat_33_simp_230;                     /* read */
+                flat_33_simp_233              = flat_33_simp_231;                     /* read */
+                flat_34_simp_234              = ierror_not_an_error;                  /* init */
+                flat_34_simp_235              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_33_simp_250, ierror_not_an_error)) {
-                    flat_34_simp_252          = ierror_not_an_error;                  /* write */
-                    flat_34_simp_253          = idouble_div (flat_33_simp_251, nn_conv_70); /* write */
+                if (ierror_eq (flat_33_simp_232, ierror_not_an_error)) {
+                    flat_34_simp_234          = ierror_not_an_error;                  /* write */
+                    flat_34_simp_235          = idouble_div (flat_33_simp_233, nn_conv_70); /* write */
                 } else {
-                    flat_34_simp_252          = flat_33_simp_250;                     /* write */
-                    flat_34_simp_253          = 0.0;                                  /* write */
+                    flat_34_simp_234          = flat_33_simp_232;                     /* write */
+                    flat_34_simp_235          = 0.0;                                  /* write */
                 }
                 
-                flat_34_simp_254              = flat_34_simp_252;                     /* read */
-                flat_34_simp_255              = flat_34_simp_253;                     /* read */
-                flat_35_simp_256              = ierror_not_an_error;                  /* init */
-                flat_35_simp_257              = 0.0;                                  /* init */
+                flat_34_simp_236              = flat_34_simp_234;                     /* read */
+                flat_34_simp_237              = flat_34_simp_235;                     /* read */
+                flat_35_simp_238              = ierror_not_an_error;                  /* init */
+                flat_35_simp_239              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_34_simp_254, ierror_not_an_error)) {
-                    flat_35_simp_256          = ierror_not_an_error;                  /* write */
-                    flat_35_simp_257          = idouble_add (a_conv_63_simp_242, flat_34_simp_255); /* write */
+                if (ierror_eq (flat_34_simp_236, ierror_not_an_error)) {
+                    flat_35_simp_238          = ierror_not_an_error;                  /* write */
+                    flat_35_simp_239          = idouble_add (aval_5_simp_224, flat_34_simp_237); /* write */
                 } else {
-                    flat_35_simp_256          = flat_34_simp_254;                     /* write */
-                    flat_35_simp_257          = 0.0;                                  /* write */
+                    flat_35_simp_238          = flat_34_simp_236;                     /* write */
+                    flat_35_simp_239          = 0.0;                                  /* write */
                 }
                 
-                flat_35_simp_258              = flat_35_simp_256;                     /* read */
-                flat_35_simp_259              = flat_35_simp_257;                     /* read */
-                flat_36_simp_260              = ierror_not_an_error;                  /* init */
-                flat_36_simp_261              = 0.0;                                  /* init */
+                flat_35_simp_240              = flat_35_simp_238;                     /* read */
+                flat_35_simp_241              = flat_35_simp_239;                     /* read */
+                flat_36_simp_242              = ierror_not_an_error;                  /* init */
+                flat_36_simp_243              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_33_simp_250, ierror_not_an_error)) {
-                    flat_51_simp_262          = ierror_not_an_error;                  /* init */
-                    flat_51_simp_263          = 0.0;                                  /* init */
+                if (ierror_eq (flat_33_simp_232, ierror_not_an_error)) {
+                    flat_51_simp_244          = ierror_not_an_error;                  /* init */
+                    flat_51_simp_245          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (conv_62_simp_230, ierror_not_an_error)) {
-                        flat_57_simp_264      = ierror_not_an_error;                  /* init */
-                        flat_57_simp_265      = 0.0;                                  /* init */
+                    if (ierror_eq (aval_6_simp_212, ierror_not_an_error)) {
+                        flat_57_simp_246      = ierror_not_an_error;                  /* init */
+                        flat_57_simp_247      = 0.0;                                  /* init */
                         
-                        if (ierror_eq (flat_35_simp_258, ierror_not_an_error)) {
-                            flat_57_simp_264  = ierror_not_an_error;                  /* write */
-                            flat_57_simp_265  = idouble_sub (conv_62_simp_231, flat_35_simp_259); /* write */
+                        if (ierror_eq (flat_35_simp_240, ierror_not_an_error)) {
+                            flat_57_simp_246  = ierror_not_an_error;                  /* write */
+                            flat_57_simp_247  = idouble_sub (aval_6_simp_213, flat_35_simp_241); /* write */
                         } else {
-                            flat_57_simp_264  = flat_35_simp_258;                     /* write */
-                            flat_57_simp_265  = 0.0;                                  /* write */
+                            flat_57_simp_246  = flat_35_simp_240;                     /* write */
+                            flat_57_simp_247  = 0.0;                                  /* write */
                         }
                         
-                        flat_57_simp_266      = flat_57_simp_264;                     /* read */
-                        flat_57_simp_267      = flat_57_simp_265;                     /* read */
-                        flat_51_simp_262      = flat_57_simp_266;                     /* write */
-                        flat_51_simp_263      = flat_57_simp_267;                     /* write */
+                        flat_57_simp_248      = flat_57_simp_246;                     /* read */
+                        flat_57_simp_249      = flat_57_simp_247;                     /* read */
+                        flat_51_simp_244      = flat_57_simp_248;                     /* write */
+                        flat_51_simp_245      = flat_57_simp_249;                     /* write */
                     } else {
-                        flat_51_simp_262      = conv_62_simp_230;                     /* write */
-                        flat_51_simp_263      = 0.0;                                  /* write */
+                        flat_51_simp_244      = aval_6_simp_212;                      /* write */
+                        flat_51_simp_245      = 0.0;                                  /* write */
                     }
                     
-                    flat_51_simp_268          = flat_51_simp_262;                     /* read */
-                    flat_51_simp_269          = flat_51_simp_263;                     /* read */
-                    flat_52_simp_270          = ierror_not_an_error;                  /* init */
-                    flat_52_simp_271          = 0.0;                                  /* init */
+                    flat_51_simp_250          = flat_51_simp_244;                     /* read */
+                    flat_51_simp_251          = flat_51_simp_245;                     /* read */
+                    flat_52_simp_252          = ierror_not_an_error;                  /* init */
+                    flat_52_simp_253          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_51_simp_268, ierror_not_an_error)) {
-                        flat_52_simp_270      = ierror_not_an_error;                  /* write */
-                        flat_52_simp_271      = idouble_mul (flat_33_simp_251, flat_51_simp_269); /* write */
+                    if (ierror_eq (flat_51_simp_250, ierror_not_an_error)) {
+                        flat_52_simp_252      = ierror_not_an_error;                  /* write */
+                        flat_52_simp_253      = idouble_mul (flat_33_simp_233, flat_51_simp_251); /* write */
                     } else {
-                        flat_52_simp_270      = flat_51_simp_268;                     /* write */
-                        flat_52_simp_271      = 0.0;                                  /* write */
+                        flat_52_simp_252      = flat_51_simp_250;                     /* write */
+                        flat_52_simp_253      = 0.0;                                  /* write */
                     }
                     
-                    flat_52_simp_272          = flat_52_simp_270;                     /* read */
-                    flat_52_simp_273          = flat_52_simp_271;                     /* read */
-                    flat_36_simp_260          = flat_52_simp_272;                     /* write */
-                    flat_36_simp_261          = flat_52_simp_273;                     /* write */
+                    flat_52_simp_254          = flat_52_simp_252;                     /* read */
+                    flat_52_simp_255          = flat_52_simp_253;                     /* read */
+                    flat_36_simp_242          = flat_52_simp_254;                     /* write */
+                    flat_36_simp_243          = flat_52_simp_255;                     /* write */
                 } else {
-                    flat_36_simp_260          = flat_33_simp_250;                     /* write */
-                    flat_36_simp_261          = 0.0;                                  /* write */
+                    flat_36_simp_242          = flat_33_simp_232;                     /* write */
+                    flat_36_simp_243          = 0.0;                                  /* write */
                 }
                 
-                flat_36_simp_274              = flat_36_simp_260;                     /* read */
-                flat_36_simp_275              = flat_36_simp_261;                     /* read */
-                flat_37_simp_276              = ierror_not_an_error;                  /* init */
-                flat_37_simp_277              = 0.0;                                  /* init */
+                flat_36_simp_256              = flat_36_simp_242;                     /* read */
+                flat_36_simp_257              = flat_36_simp_243;                     /* read */
+                flat_37_simp_258              = ierror_not_an_error;                  /* init */
+                flat_37_simp_259              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_36_simp_274, ierror_not_an_error)) {
-                    flat_37_simp_276          = ierror_not_an_error;                  /* write */
-                    flat_37_simp_277          = idouble_add (a_conv_63_simp_243, flat_36_simp_275); /* write */
+                if (ierror_eq (flat_36_simp_256, ierror_not_an_error)) {
+                    flat_37_simp_258          = ierror_not_an_error;                  /* write */
+                    flat_37_simp_259          = idouble_add (aval_5_simp_225, flat_36_simp_257); /* write */
                 } else {
-                    flat_37_simp_276          = flat_36_simp_274;                     /* write */
-                    flat_37_simp_277          = 0.0;                                  /* write */
+                    flat_37_simp_258          = flat_36_simp_256;                     /* write */
+                    flat_37_simp_259          = 0.0;                                  /* write */
                 }
                 
-                flat_37_simp_278              = flat_37_simp_276;                     /* read */
-                flat_37_simp_279              = flat_37_simp_277;                     /* read */
-                flat_38_simp_280              = ierror_not_an_error;                  /* init */
-                flat_38_simp_281              = 0.0;                                  /* init */
-                flat_38_simp_282              = 0.0;                                  /* init */
+                flat_37_simp_260              = flat_37_simp_258;                     /* read */
+                flat_37_simp_261              = flat_37_simp_259;                     /* read */
+                flat_38_simp_262              = ierror_not_an_error;                  /* init */
+                flat_38_simp_263              = 0.0;                                  /* init */
+                flat_38_simp_264              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_35_simp_258, ierror_not_an_error)) {
-                    flat_38_simp_280          = ierror_not_an_error;                  /* write */
-                    flat_38_simp_281          = idouble_add (a_conv_63_simp_241, 1.0); /* write */
-                    flat_38_simp_282          = flat_35_simp_259;                     /* write */
+                if (ierror_eq (flat_35_simp_240, ierror_not_an_error)) {
+                    flat_38_simp_262          = ierror_not_an_error;                  /* write */
+                    flat_38_simp_263          = idouble_add (aval_5_simp_223, 1.0);   /* write */
+                    flat_38_simp_264          = flat_35_simp_241;                     /* write */
                 } else {
-                    flat_38_simp_280          = flat_35_simp_258;                     /* write */
-                    flat_38_simp_281          = 0.0;                                  /* write */
-                    flat_38_simp_282          = 0.0;                                  /* write */
+                    flat_38_simp_262          = flat_35_simp_240;                     /* write */
+                    flat_38_simp_263          = 0.0;                                  /* write */
+                    flat_38_simp_264          = 0.0;                                  /* write */
                 }
                 
-                flat_38_simp_283              = flat_38_simp_280;                     /* read */
-                flat_38_simp_284              = flat_38_simp_281;                     /* read */
-                flat_38_simp_285              = flat_38_simp_282;                     /* read */
-                flat_39_simp_286              = ierror_not_an_error;                  /* init */
-                flat_39_simp_287              = 0.0;                                  /* init */
-                flat_39_simp_288              = 0.0;                                  /* init */
-                flat_39_simp_289              = 0.0;                                  /* init */
+                flat_38_simp_265              = flat_38_simp_262;                     /* read */
+                flat_38_simp_266              = flat_38_simp_263;                     /* read */
+                flat_38_simp_267              = flat_38_simp_264;                     /* read */
+                flat_39_simp_268              = ierror_not_an_error;                  /* init */
+                flat_39_simp_269              = 0.0;                                  /* init */
+                flat_39_simp_270              = 0.0;                                  /* init */
+                flat_39_simp_271              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_38_simp_283, ierror_not_an_error)) {
-                    flat_42_simp_290          = ierror_not_an_error;                  /* init */
-                    flat_42_simp_291          = 0.0;                                  /* init */
-                    flat_42_simp_292          = 0.0;                                  /* init */
-                    flat_42_simp_293          = 0.0;                                  /* init */
+                if (ierror_eq (flat_38_simp_265, ierror_not_an_error)) {
+                    flat_42_simp_272          = ierror_not_an_error;                  /* init */
+                    flat_42_simp_273          = 0.0;                                  /* init */
+                    flat_42_simp_274          = 0.0;                                  /* init */
+                    flat_42_simp_275          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_37_simp_278, ierror_not_an_error)) {
-                        flat_42_simp_290      = ierror_not_an_error;                  /* write */
-                        flat_42_simp_291      = flat_38_simp_284;                     /* write */
-                        flat_42_simp_292      = flat_38_simp_285;                     /* write */
-                        flat_42_simp_293      = flat_37_simp_279;                     /* write */
+                    if (ierror_eq (flat_37_simp_260, ierror_not_an_error)) {
+                        flat_42_simp_272      = ierror_not_an_error;                  /* write */
+                        flat_42_simp_273      = flat_38_simp_266;                     /* write */
+                        flat_42_simp_274      = flat_38_simp_267;                     /* write */
+                        flat_42_simp_275      = flat_37_simp_261;                     /* write */
                     } else {
-                        flat_42_simp_290      = flat_37_simp_278;                     /* write */
-                        flat_42_simp_291      = 0.0;                                  /* write */
-                        flat_42_simp_292      = 0.0;                                  /* write */
-                        flat_42_simp_293      = 0.0;                                  /* write */
+                        flat_42_simp_272      = flat_37_simp_260;                     /* write */
+                        flat_42_simp_273      = 0.0;                                  /* write */
+                        flat_42_simp_274      = 0.0;                                  /* write */
+                        flat_42_simp_275      = 0.0;                                  /* write */
                     }
                     
-                    flat_42_simp_294          = flat_42_simp_290;                     /* read */
-                    flat_42_simp_295          = flat_42_simp_291;                     /* read */
-                    flat_42_simp_296          = flat_42_simp_292;                     /* read */
-                    flat_42_simp_297          = flat_42_simp_293;                     /* read */
-                    flat_39_simp_286          = flat_42_simp_294;                     /* write */
-                    flat_39_simp_287          = flat_42_simp_295;                     /* write */
-                    flat_39_simp_288          = flat_42_simp_296;                     /* write */
-                    flat_39_simp_289          = flat_42_simp_297;                     /* write */
+                    flat_42_simp_276          = flat_42_simp_272;                     /* read */
+                    flat_42_simp_277          = flat_42_simp_273;                     /* read */
+                    flat_42_simp_278          = flat_42_simp_274;                     /* read */
+                    flat_42_simp_279          = flat_42_simp_275;                     /* read */
+                    flat_39_simp_268          = flat_42_simp_276;                     /* write */
+                    flat_39_simp_269          = flat_42_simp_277;                     /* write */
+                    flat_39_simp_270          = flat_42_simp_278;                     /* write */
+                    flat_39_simp_271          = flat_42_simp_279;                     /* write */
                 } else {
-                    flat_39_simp_286          = flat_38_simp_283;                     /* write */
-                    flat_39_simp_287          = 0.0;                                  /* write */
-                    flat_39_simp_288          = 0.0;                                  /* write */
-                    flat_39_simp_289          = 0.0;                                  /* write */
+                    flat_39_simp_268          = flat_38_simp_265;                     /* write */
+                    flat_39_simp_269          = 0.0;                                  /* write */
+                    flat_39_simp_270          = 0.0;                                  /* write */
+                    flat_39_simp_271          = 0.0;                                  /* write */
                 }
                 
-                flat_39_simp_298              = flat_39_simp_286;                     /* read */
-                flat_39_simp_299              = flat_39_simp_287;                     /* read */
-                flat_39_simp_300              = flat_39_simp_288;                     /* read */
-                flat_39_simp_301              = flat_39_simp_289;                     /* read */
-                flat_30_simp_244              = flat_39_simp_298;                     /* write */
-                flat_30_simp_245              = flat_39_simp_299;                     /* write */
-                flat_30_simp_246              = flat_39_simp_300;                     /* write */
-                flat_30_simp_247              = flat_39_simp_301;                     /* write */
+                flat_39_simp_280              = flat_39_simp_268;                     /* read */
+                flat_39_simp_281              = flat_39_simp_269;                     /* read */
+                flat_39_simp_282              = flat_39_simp_270;                     /* read */
+                flat_39_simp_283              = flat_39_simp_271;                     /* read */
+                flat_30_simp_226              = flat_39_simp_280;                     /* write */
+                flat_30_simp_227              = flat_39_simp_281;                     /* write */
+                flat_30_simp_228              = flat_39_simp_282;                     /* write */
+                flat_30_simp_229              = flat_39_simp_283;                     /* write */
             } else {
-                flat_30_simp_244              = a_conv_63_simp_240;                   /* write */
-                flat_30_simp_245              = 0.0;                                  /* write */
-                flat_30_simp_246              = 0.0;                                  /* write */
-                flat_30_simp_247              = 0.0;                                  /* write */
+                flat_30_simp_226              = aval_5_simp_222;                      /* write */
+                flat_30_simp_227              = 0.0;                                  /* write */
+                flat_30_simp_228              = 0.0;                                  /* write */
+                flat_30_simp_229              = 0.0;                                  /* write */
             }
             
-            flat_30_simp_302                  = flat_30_simp_244;                     /* read */
-            flat_30_simp_303                  = flat_30_simp_245;                     /* read */
-            flat_30_simp_304                  = flat_30_simp_246;                     /* read */
-            flat_30_simp_305                  = flat_30_simp_247;                     /* read */
-            acc_a_conv_63_simp_66             = flat_30_simp_302;                     /* write */
-            acc_a_conv_63_simp_67             = flat_30_simp_303;                     /* write */
-            acc_a_conv_63_simp_68             = flat_30_simp_304;                     /* write */
-            acc_a_conv_63_simp_69             = flat_30_simp_305;                     /* write */
+            flat_30_simp_284                  = flat_30_simp_226;                     /* read */
+            flat_30_simp_285                  = flat_30_simp_227;                     /* read */
+            flat_30_simp_286                  = flat_30_simp_228;                     /* read */
+            flat_30_simp_287                  = flat_30_simp_229;                     /* read */
+            acc_a_conv_63_simp_107            = flat_30_simp_284;                     /* write */
+            acc_a_conv_63_simp_108            = flat_30_simp_285;                     /* write */
+            acc_a_conv_63_simp_109            = flat_30_simp_286;                     /* write */
+            acc_a_conv_63_simp_110            = flat_30_simp_287;                     /* write */
         }
         
     }
     
-    s->has_acc_a_conv_63_simp_66              = itrue;                                /* save */
-    s->res_acc_a_conv_63_simp_66              = acc_a_conv_63_simp_66;                /* save */
+    s->has_acc_a_conv_63_simp_107             = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_107             = acc_a_conv_63_simp_107;               /* save */
     
-    s->has_acc_a_conv_63_simp_67              = itrue;                                /* save */
-    s->res_acc_a_conv_63_simp_67              = acc_a_conv_63_simp_67;                /* save */
+    s->has_acc_a_conv_63_simp_108             = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_108             = acc_a_conv_63_simp_108;               /* save */
     
-    s->has_acc_a_conv_63_simp_68              = itrue;                                /* save */
-    s->res_acc_a_conv_63_simp_68              = acc_a_conv_63_simp_68;                /* save */
+    s->has_acc_a_conv_63_simp_109             = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_109             = acc_a_conv_63_simp_109;               /* save */
     
-    s->has_acc_a_conv_63_simp_69              = itrue;                                /* save */
-    s->res_acc_a_conv_63_simp_69              = acc_a_conv_63_simp_69;                /* save */
+    s->has_acc_a_conv_63_simp_110             = itrue;                                /* save */
+    s->res_acc_a_conv_63_simp_110             = acc_a_conv_63_simp_110;               /* save */
     
-    s->has_acc_conv_62_simp_70                = itrue;                                /* save */
-    s->res_acc_conv_62_simp_70                = acc_conv_62_simp_70;                  /* save */
+    s->has_acc_conv_62_simp_97                = itrue;                                /* save */
+    s->res_acc_conv_62_simp_97                = acc_conv_62_simp_97;                  /* save */
     
-    s->has_acc_conv_62_simp_71                = itrue;                                /* save */
-    s->res_acc_conv_62_simp_71                = acc_conv_62_simp_71;                  /* save */
+    s->has_acc_conv_62_simp_98                = itrue;                                /* save */
+    s->res_acc_conv_62_simp_98                = acc_conv_62_simp_98;                  /* save */
     
-    s->has_acc_conv_58_simp_80                = itrue;                                /* save */
-    s->res_acc_conv_58_simp_80                = acc_conv_58_simp_80;                  /* save */
+    s->has_acc_conv_58_simp_89                = itrue;                                /* save */
+    s->res_acc_conv_58_simp_89                = acc_conv_58_simp_89;                  /* save */
     
-    s->has_acc_conv_58_simp_81                = itrue;                                /* save */
-    s->res_acc_conv_58_simp_81                = acc_conv_58_simp_81;                  /* save */
+    s->has_acc_conv_58_simp_90                = itrue;                                /* save */
+    s->res_acc_conv_58_simp_90                = acc_conv_58_simp_90;                  /* save */
     
-    s->has_acc_conv_57_simp_88                = itrue;                                /* save */
-    s->res_acc_conv_57_simp_88                = acc_conv_57_simp_88;                  /* save */
+    s->has_acc_conv_57_simp_83                = itrue;                                /* save */
+    s->res_acc_conv_57_simp_83                = acc_conv_57_simp_83;                  /* save */
     
-    s->has_acc_conv_57_simp_89                = itrue;                                /* save */
-    s->res_acc_conv_57_simp_89                = acc_conv_57_simp_89;                  /* save */
+    s->has_acc_conv_57_simp_84                = itrue;                                /* save */
+    s->res_acc_conv_57_simp_84                = acc_conv_57_simp_84;                  /* save */
     
-    s->has_acc_s_reify_6_conv_12_simp_94      = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_12_simp_94      = acc_s_reify_6_conv_12_simp_94;        /* save */
+    s->has_acc_s_reify_6_conv_12_simp_80      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_80      = acc_s_reify_6_conv_12_simp_80;        /* save */
     
-    s->has_acc_s_reify_6_conv_12_simp_95      = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_12_simp_95      = acc_s_reify_6_conv_12_simp_95;        /* save */
+    s->has_acc_s_reify_6_conv_12_simp_81      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_81      = acc_s_reify_6_conv_12_simp_81;        /* save */
     
-    s->has_acc_s_reify_6_conv_12_simp_96      = itrue;                                /* save */
-    s->res_acc_s_reify_6_conv_12_simp_96      = acc_s_reify_6_conv_12_simp_96;        /* save */
+    s->has_acc_s_reify_6_conv_12_simp_82      = itrue;                                /* save */
+    s->res_acc_s_reify_6_conv_12_simp_82      = acc_s_reify_6_conv_12_simp_82;        /* save */
     
-    s->has_acc_conv_11_simp_97                = itrue;                                /* save */
-    s->res_acc_conv_11_simp_97                = acc_conv_11_simp_97;                  /* save */
+    s->has_acc_conv_11_simp_72                = itrue;                                /* save */
+    s->res_acc_conv_11_simp_72                = acc_conv_11_simp_72;                  /* save */
     
-    s->has_acc_conv_11_simp_98                = itrue;                                /* save */
-    s->res_acc_conv_11_simp_98                = acc_conv_11_simp_98;                  /* save */
+    s->has_acc_conv_11_simp_73                = itrue;                                /* save */
+    s->res_acc_conv_11_simp_73                = acc_conv_11_simp_73;                  /* save */
     
-    s->has_acc_conv_7_simp_105                = itrue;                                /* save */
-    s->res_acc_conv_7_simp_105                = acc_conv_7_simp_105;                  /* save */
+    s->has_acc_conv_7_simp_66                 = itrue;                                /* save */
+    s->res_acc_conv_7_simp_66                 = acc_conv_7_simp_66;                   /* save */
     
-    s->has_acc_conv_7_simp_106                = itrue;                                /* save */
-    s->res_acc_conv_7_simp_106                = acc_conv_7_simp_106;                  /* save */
+    s->has_acc_conv_7_simp_67                 = itrue;                                /* save */
+    s->res_acc_conv_7_simp_67                 = acc_conv_7_simp_67;                   /* save */
     
-    a_conv_63_simp_306                        = acc_a_conv_63_simp_66;                /* read */
-    a_conv_63_simp_307                        = acc_a_conv_63_simp_67;                /* read */
-    a_conv_63_simp_309                        = acc_a_conv_63_simp_69;                /* read */
-    s_reify_6_conv_12_simp_310                = acc_s_reify_6_conv_12_simp_94;        /* read */
-    s_reify_6_conv_12_simp_311                = acc_s_reify_6_conv_12_simp_95;        /* read */
-    flat_82_simp_313                          = ierror_not_an_error;                  /* init */
-    flat_82_simp_314                          = 0.0;                                  /* init */
+    a_conv_63_simp_288                        = acc_a_conv_63_simp_107;               /* read */
+    a_conv_63_simp_289                        = acc_a_conv_63_simp_108;               /* read */
+    a_conv_63_simp_291                        = acc_a_conv_63_simp_110;               /* read */
+    s_reify_6_conv_12_simp_292                = acc_s_reify_6_conv_12_simp_80;        /* read */
+    s_reify_6_conv_12_simp_293                = acc_s_reify_6_conv_12_simp_81;        /* read */
+    flat_82_simp_295                          = ierror_not_an_error;                  /* init */
+    flat_82_simp_296                          = 0.0;                                  /* init */
     
-    if (ierror_eq (s_reify_6_conv_12_simp_310, ierror_not_an_error)) {
-        flat_82_simp_313                      = ierror_not_an_error;                  /* write */
-        flat_82_simp_314                      = s_reify_6_conv_12_simp_311;           /* write */
+    if (ierror_eq (s_reify_6_conv_12_simp_292, ierror_not_an_error)) {
+        flat_82_simp_295                      = ierror_not_an_error;                  /* write */
+        flat_82_simp_296                      = s_reify_6_conv_12_simp_293;           /* write */
     } else {
-        flat_82_simp_313                      = s_reify_6_conv_12_simp_310;           /* write */
-        flat_82_simp_314                      = 0.0;                                  /* write */
+        flat_82_simp_295                      = s_reify_6_conv_12_simp_292;           /* write */
+        flat_82_simp_296                      = 0.0;                                  /* write */
     }
     
-    flat_82_simp_315                          = flat_82_simp_313;                     /* read */
-    flat_82_simp_316                          = flat_82_simp_314;                     /* read */
-    flat_83_simp_317                          = ierror_not_an_error;                  /* init */
-    flat_83_simp_318                          = 0.0;                                  /* init */
+    flat_82_simp_297                          = flat_82_simp_295;                     /* read */
+    flat_82_simp_298                          = flat_82_simp_296;                     /* read */
+    flat_83_simp_299                          = ierror_not_an_error;                  /* init */
+    flat_83_simp_300                          = 0.0;                                  /* init */
     
-    if (ierror_eq (flat_82_simp_315, ierror_not_an_error)) {
-        flat_86_simp_319                      = ierror_not_an_error;                  /* init */
-        flat_86_simp_320                      = 0.0;                                  /* init */
+    if (ierror_eq (flat_82_simp_297, ierror_not_an_error)) {
+        flat_86_simp_301                      = ierror_not_an_error;                  /* init */
+        flat_86_simp_302                      = 0.0;                                  /* init */
         
-        if (ierror_eq (a_conv_63_simp_306, ierror_not_an_error)) {
-            idouble_t        conv_118         = idouble_sub (a_conv_63_simp_307, 1.0); /* let */
-            idouble_t        simp_1212        = idouble_div (a_conv_63_simp_309, conv_118); /* let */
-            flat_86_simp_319                  = ierror_not_an_error;                  /* write */
-            flat_86_simp_320                  = simp_1212;                            /* write */
+        if (ierror_eq (a_conv_63_simp_288, ierror_not_an_error)) {
+            idouble_t        conv_118         = idouble_sub (a_conv_63_simp_289, 1.0); /* let */
+            idouble_t        simp_1186        = idouble_div (a_conv_63_simp_291, conv_118); /* let */
+            flat_86_simp_301                  = ierror_not_an_error;                  /* write */
+            flat_86_simp_302                  = simp_1186;                            /* write */
         } else {
-            flat_86_simp_319                  = a_conv_63_simp_306;                   /* write */
-            flat_86_simp_320                  = 0.0;                                  /* write */
+            flat_86_simp_301                  = a_conv_63_simp_288;                   /* write */
+            flat_86_simp_302                  = 0.0;                                  /* write */
         }
         
-        flat_86_simp_321                      = flat_86_simp_319;                     /* read */
-        flat_86_simp_322                      = flat_86_simp_320;                     /* read */
-        flat_87_simp_323                      = ierror_not_an_error;                  /* init */
-        flat_87_simp_324                      = 0.0;                                  /* init */
+        flat_86_simp_303                      = flat_86_simp_301;                     /* read */
+        flat_86_simp_304                      = flat_86_simp_302;                     /* read */
+        flat_87_simp_305                      = ierror_not_an_error;                  /* init */
+        flat_87_simp_306                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_86_simp_321, ierror_not_an_error)) {
-            flat_87_simp_323                  = ierror_not_an_error;                  /* write */
-            flat_87_simp_324                  = idouble_sqrt (flat_86_simp_322);      /* write */
+        if (ierror_eq (flat_86_simp_303, ierror_not_an_error)) {
+            flat_87_simp_305                  = ierror_not_an_error;                  /* write */
+            flat_87_simp_306                  = idouble_sqrt (flat_86_simp_304);      /* write */
         } else {
-            flat_87_simp_323                  = flat_86_simp_321;                     /* write */
-            flat_87_simp_324                  = 0.0;                                  /* write */
+            flat_87_simp_305                  = flat_86_simp_303;                     /* write */
+            flat_87_simp_306                  = 0.0;                                  /* write */
         }
         
-        flat_87_simp_325                      = flat_87_simp_323;                     /* read */
-        flat_87_simp_326                      = flat_87_simp_324;                     /* read */
-        flat_88_simp_327                      = ierror_not_an_error;                  /* init */
-        flat_88_simp_328                      = 0.0;                                  /* init */
+        flat_87_simp_307                      = flat_87_simp_305;                     /* read */
+        flat_87_simp_308                      = flat_87_simp_306;                     /* read */
+        flat_88_simp_309                      = ierror_not_an_error;                  /* init */
+        flat_88_simp_310                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_87_simp_325, ierror_not_an_error)) {
-            flat_88_simp_327                  = ierror_not_an_error;                  /* write */
-            flat_88_simp_328                  = idouble_mul (flat_82_simp_316, flat_87_simp_326); /* write */
+        if (ierror_eq (flat_87_simp_307, ierror_not_an_error)) {
+            flat_88_simp_309                  = ierror_not_an_error;                  /* write */
+            flat_88_simp_310                  = idouble_mul (flat_82_simp_298, flat_87_simp_308); /* write */
         } else {
-            flat_88_simp_327                  = flat_87_simp_325;                     /* write */
-            flat_88_simp_328                  = 0.0;                                  /* write */
+            flat_88_simp_309                  = flat_87_simp_307;                     /* write */
+            flat_88_simp_310                  = 0.0;                                  /* write */
         }
         
-        flat_88_simp_329                      = flat_88_simp_327;                     /* read */
-        flat_88_simp_330                      = flat_88_simp_328;                     /* read */
-        flat_83_simp_317                      = flat_88_simp_329;                     /* write */
-        flat_83_simp_318                      = flat_88_simp_330;                     /* write */
+        flat_88_simp_311                      = flat_88_simp_309;                     /* read */
+        flat_88_simp_312                      = flat_88_simp_310;                     /* read */
+        flat_83_simp_299                      = flat_88_simp_311;                     /* write */
+        flat_83_simp_300                      = flat_88_simp_312;                     /* write */
     } else {
-        flat_83_simp_317                      = flat_82_simp_315;                     /* write */
-        flat_83_simp_318                      = 0.0;                                  /* write */
+        flat_83_simp_299                      = flat_82_simp_297;                     /* write */
+        flat_83_simp_300                      = 0.0;                                  /* write */
     }
     
-    flat_83_simp_331                          = flat_83_simp_317;                     /* read */
-    flat_83_simp_332                          = flat_83_simp_318;                     /* read */
-    s->repl_ix_0                              = flat_83_simp_331;                     /* output */
-    s->repl_ix_1                              = flat_83_simp_332;                     /* output */
+    flat_83_simp_313                          = flat_83_simp_299;                     /* read */
+    flat_83_simp_314                          = flat_83_simp_300;                     /* read */
+    s->repl_ix_0                              = flat_83_simp_313;                     /* output */
+    s->repl_ix_1                              = flat_83_simp_314;                     /* output */
 }
 
 - C evaluation:
@@ -1591,34 +1577,32 @@ void iprogram_0(iprogram_0_t *s)
 > > -- Times
 > - Flattened:
 conv$3 = TIME
-init acc$s$reify$2$conv$5$simp$4@{Error} = ExceptNotAnError@{Error};
-init acc$s$reify$2$conv$5$simp$5@{Time} = 1858-11-17@{Time};
-init acc$conv$4$simp$6@{Time} = 1858-11-17@{Time};
-write acc$s$reify$2$conv$5$simp$4 = ExceptFold1NoValue@{Error};
-write acc$s$reify$2$conv$5$simp$5 = 1858-11-17@{Time};
-load_resumable@{Error} acc$s$reify$2$conv$5$simp$4;
-load_resumable@{Time} acc$s$reify$2$conv$5$simp$5;
-load_resumable@{Time} acc$conv$4$simp$6;
+init acc$conv$4$simp$4@{Time} = 1858-11-17@{Time};
+init acc$s$reify$2$conv$5$simp$8@{Error} = ExceptFold1NoValue@{Error};
+init acc$s$reify$2$conv$5$simp$9@{Time} = 1858-11-17@{Time};
+load_resumable@{Error} acc$s$reify$2$conv$5$simp$8;
+load_resumable@{Time} acc$s$reify$2$conv$5$simp$9;
+load_resumable@{Time} acc$conv$4$simp$4;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$26@{Error}, conv$0$simp$27@{Int}, conv$0$simp$28@{Time}) in new
 {
   let anf$1 = Time_daysDifference# (1980-01-06@{Time}) conv$0$simp$28;
   let anf$2 = negate#@{Int} anf$1;
-  write acc$conv$4$simp$6 = Time_minusDays# (2000-01-01@{Time}) anf$2;
-  read conv$4$simp$10 = acc$conv$4$simp$6 [Time];
-  read s$reify$2$conv$5$simp$14 = acc$s$reify$2$conv$5$simp$4 [Error];
-  read s$reify$2$conv$5$simp$15 = acc$s$reify$2$conv$5$simp$5 [Time];
+  write acc$conv$4$simp$4 = Time_minusDays# (2000-01-01@{Time}) anf$2;
+  read aval$1$simp$10 = acc$conv$4$simp$4 [Time];
+  read aval$0$simp$14 = acc$s$reify$2$conv$5$simp$8 [Error];
+  read aval$0$simp$15 = acc$s$reify$2$conv$5$simp$9 [Time];
   init flat$0$simp$16@{Error} = ExceptNotAnError@{Error};
   init flat$0$simp$17@{Time} = 1858-11-17@{Time};
-  if (eq#@{Error} s$reify$2$conv$5$simp$14 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} aval$0$simp$14 (ExceptNotAnError@{Error}))
   {
     init flat$4@{Time} = 1858-11-17@{Time};
-    if (gt#@{Time} conv$4$simp$10 s$reify$2$conv$5$simp$15)
+    if (gt#@{Time} aval$1$simp$10 aval$0$simp$15)
     {
-      write flat$4 = conv$4$simp$10;
+      write flat$4 = aval$1$simp$10;
     }
     else
     {
-      write flat$4 = s$reify$2$conv$5$simp$15;
+      write flat$4 = aval$0$simp$15;
     }
     read flat$4 = flat$4 [Time];
     write flat$0$simp$16 = ExceptNotAnError@{Error};
@@ -1628,14 +1612,14 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$26@{Error}, conv$
   {
     init flat$3$simp$18@{Error} = ExceptNotAnError@{Error};
     init flat$3$simp$19@{Time} = 1858-11-17@{Time};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s$reify$2$conv$5$simp$14)
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) aval$0$simp$14)
     {
       write flat$3$simp$18 = ExceptNotAnError@{Error};
-      write flat$3$simp$19 = conv$4$simp$10;
+      write flat$3$simp$19 = aval$1$simp$10;
     }
     else
     {
-      write flat$3$simp$18 = s$reify$2$conv$5$simp$14;
+      write flat$3$simp$18 = aval$0$simp$14;
       write flat$3$simp$19 = 1858-11-17@{Time};
     }
     read flat$3$simp$20 = flat$3$simp$18 [Error];
@@ -1645,14 +1629,14 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$26@{Error}, conv$
   }
   read flat$0$simp$22 = flat$0$simp$16 [Error];
   read flat$0$simp$23 = flat$0$simp$17 [Time];
-  write acc$s$reify$2$conv$5$simp$4 = flat$0$simp$22;
-  write acc$s$reify$2$conv$5$simp$5 = flat$0$simp$23;
+  write acc$s$reify$2$conv$5$simp$8 = flat$0$simp$22;
+  write acc$s$reify$2$conv$5$simp$9 = flat$0$simp$23;
 }
-save_resumable@{Error} acc$s$reify$2$conv$5$simp$4;
-save_resumable@{Time} acc$s$reify$2$conv$5$simp$5;
-save_resumable@{Time} acc$conv$4$simp$6;
-read s$reify$2$conv$5$simp$24 = acc$s$reify$2$conv$5$simp$4 [Error];
-read s$reify$2$conv$5$simp$25 = acc$s$reify$2$conv$5$simp$5 [Time];
+save_resumable@{Error} acc$s$reify$2$conv$5$simp$8;
+save_resumable@{Time} acc$s$reify$2$conv$5$simp$9;
+save_resumable@{Time} acc$conv$4$simp$4;
+read s$reify$2$conv$5$simp$24 = acc$s$reify$2$conv$5$simp$8 [Error];
+read s$reify$2$conv$5$simp$25 = acc$s$reify$2$conv$5$simp$9 [Time];
 output@{(Sum Error Time)} repl (s$reify$2$conv$5$simp$24@{Error}, s$reify$2$conv$5$simp$25@{Time});
 
 - C:
@@ -1673,12 +1657,12 @@ typedef struct {
     itime_t          repl_ix_1;
 
     /* resumables */
-    ibool_t          has_acc_s_reify_2_conv_5_simp_5;
-    itime_t          res_acc_s_reify_2_conv_5_simp_5;
-    ibool_t          has_acc_s_reify_2_conv_5_simp_4;
-    ierror_t         res_acc_s_reify_2_conv_5_simp_4;
-    ibool_t          has_acc_conv_4_simp_6;
-    itime_t          res_acc_conv_4_simp_6;
+    ibool_t          has_acc_s_reify_2_conv_5_simp_9;
+    itime_t          res_acc_s_reify_2_conv_5_simp_9;
+    ibool_t          has_acc_s_reify_2_conv_5_simp_8;
+    ierror_t         res_acc_s_reify_2_conv_5_simp_8;
+    ibool_t          has_acc_conv_4_simp_4;
+    itime_t          res_acc_conv_4_simp_4;
 } iprogram_0_t;
 
 iint_t size_of_state_iprogram_0 ()
@@ -1690,12 +1674,13 @@ iint_t size_of_state_iprogram_0 ()
 void iprogram_0(iprogram_0_t *s)
 {
     itime_t          flat_4;
-    itime_t          acc_s_reify_2_conv_5_simp_5;
-    ierror_t         acc_s_reify_2_conv_5_simp_4;
+    itime_t          acc_s_reify_2_conv_5_simp_9;
+    ierror_t         acc_s_reify_2_conv_5_simp_8;
     ierror_t         s_reify_2_conv_5_simp_24;
     itime_t          s_reify_2_conv_5_simp_25;
-    itime_t          s_reify_2_conv_5_simp_15;
-    ierror_t         s_reify_2_conv_5_simp_14;
+    itime_t          aval_1_simp_10;
+    ierror_t         aval_0_simp_14;
+    itime_t          aval_0_simp_15;
     itime_t          flat_0_simp_23;
     ierror_t         flat_0_simp_22;
     ierror_t         flat_3_simp_20;
@@ -1704,28 +1689,25 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         flat_3_simp_18;
     itime_t          flat_0_simp_17;
     ierror_t         flat_0_simp_16;
-    itime_t          acc_conv_4_simp_6;
-    itime_t          conv_4_simp_10;
+    itime_t          acc_conv_4_simp_4;
 
     imempool_t      *mempool                  = s->mempool;
     itime_t          conv_3                   = s->conv_3;
 
-    acc_s_reify_2_conv_5_simp_4               = ierror_not_an_error;                  /* init */
-    acc_s_reify_2_conv_5_simp_5               = 0x7420b1100000000;                    /* init */
-    acc_conv_4_simp_6                         = 0x7420b1100000000;                    /* init */
-    acc_s_reify_2_conv_5_simp_4               = ierror_fold1_no_value;                /* write */
-    acc_s_reify_2_conv_5_simp_5               = 0x7420b1100000000;                    /* write */
+    acc_conv_4_simp_4                         = 0x7420b1100000000;                    /* init */
+    acc_s_reify_2_conv_5_simp_8               = ierror_fold1_no_value;                /* init */
+    acc_s_reify_2_conv_5_simp_9               = 0x7420b1100000000;                    /* init */
     
-    if (s->has_acc_s_reify_2_conv_5_simp_4) {
-        acc_s_reify_2_conv_5_simp_4           = s->res_acc_s_reify_2_conv_5_simp_4;   /* load */
+    if (s->has_acc_s_reify_2_conv_5_simp_8) {
+        acc_s_reify_2_conv_5_simp_8           = s->res_acc_s_reify_2_conv_5_simp_8;   /* load */
     }
     
-    if (s->has_acc_s_reify_2_conv_5_simp_5) {
-        acc_s_reify_2_conv_5_simp_5           = s->res_acc_s_reify_2_conv_5_simp_5;   /* load */
+    if (s->has_acc_s_reify_2_conv_5_simp_9) {
+        acc_s_reify_2_conv_5_simp_9           = s->res_acc_s_reify_2_conv_5_simp_9;   /* load */
     }
     
-    if (s->has_acc_conv_4_simp_6) {
-        acc_conv_4_simp_6                     = s->res_acc_conv_4_simp_6;             /* load */
+    if (s->has_acc_conv_4_simp_4) {
+        acc_conv_4_simp_4                     = s->res_acc_conv_4_simp_4;             /* load */
     }
     
     const iint_t     new_count                = s->new_count;
@@ -1741,20 +1723,20 @@ void iprogram_0(iprogram_0_t *s)
         itime_t          conv_0_simp_28       = new_conv_0_simp_28[i];
         iint_t           anf_1                = itime_days_diff (0x7bc010600000000, conv_0_simp_28); /* let */
         iint_t           anf_2                = iint_neg (anf_1);                     /* let */
-        acc_conv_4_simp_6                     = itime_minus_days (0x7d0010100000000, anf_2); /* write */
-        conv_4_simp_10                        = acc_conv_4_simp_6;                    /* read */
-        s_reify_2_conv_5_simp_14              = acc_s_reify_2_conv_5_simp_4;          /* read */
-        s_reify_2_conv_5_simp_15              = acc_s_reify_2_conv_5_simp_5;          /* read */
+        acc_conv_4_simp_4                     = itime_minus_days (0x7d0010100000000, anf_2); /* write */
+        aval_1_simp_10                        = acc_conv_4_simp_4;                    /* read */
+        aval_0_simp_14                        = acc_s_reify_2_conv_5_simp_8;          /* read */
+        aval_0_simp_15                        = acc_s_reify_2_conv_5_simp_9;          /* read */
         flat_0_simp_16                        = ierror_not_an_error;                  /* init */
         flat_0_simp_17                        = 0x7420b1100000000;                    /* init */
         
-        if (ierror_eq (s_reify_2_conv_5_simp_14, ierror_not_an_error)) {
+        if (ierror_eq (aval_0_simp_14, ierror_not_an_error)) {
             flat_4                            = 0x7420b1100000000;                    /* init */
             
-            if (itime_gt (conv_4_simp_10, s_reify_2_conv_5_simp_15)) {
-                flat_4                        = conv_4_simp_10;                       /* write */
+            if (itime_gt (aval_1_simp_10, aval_0_simp_15)) {
+                flat_4                        = aval_1_simp_10;                       /* write */
             } else {
-                flat_4                        = s_reify_2_conv_5_simp_15;             /* write */
+                flat_4                        = aval_0_simp_15;                       /* write */
             }
             
             flat_4                            = flat_4;                               /* read */
@@ -1764,11 +1746,11 @@ void iprogram_0(iprogram_0_t *s)
             flat_3_simp_18                    = ierror_not_an_error;                  /* init */
             flat_3_simp_19                    = 0x7420b1100000000;                    /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, s_reify_2_conv_5_simp_14)) {
+            if (ierror_eq (ierror_fold1_no_value, aval_0_simp_14)) {
                 flat_3_simp_18                = ierror_not_an_error;                  /* write */
-                flat_3_simp_19                = conv_4_simp_10;                       /* write */
+                flat_3_simp_19                = aval_1_simp_10;                       /* write */
             } else {
-                flat_3_simp_18                = s_reify_2_conv_5_simp_14;             /* write */
+                flat_3_simp_18                = aval_0_simp_14;                       /* write */
                 flat_3_simp_19                = 0x7420b1100000000;                    /* write */
             }
             
@@ -1780,21 +1762,21 @@ void iprogram_0(iprogram_0_t *s)
         
         flat_0_simp_22                        = flat_0_simp_16;                       /* read */
         flat_0_simp_23                        = flat_0_simp_17;                       /* read */
-        acc_s_reify_2_conv_5_simp_4           = flat_0_simp_22;                       /* write */
-        acc_s_reify_2_conv_5_simp_5           = flat_0_simp_23;                       /* write */
+        acc_s_reify_2_conv_5_simp_8           = flat_0_simp_22;                       /* write */
+        acc_s_reify_2_conv_5_simp_9           = flat_0_simp_23;                       /* write */
     }
     
-    s->has_acc_s_reify_2_conv_5_simp_4        = itrue;                                /* save */
-    s->res_acc_s_reify_2_conv_5_simp_4        = acc_s_reify_2_conv_5_simp_4;          /* save */
+    s->has_acc_s_reify_2_conv_5_simp_8        = itrue;                                /* save */
+    s->res_acc_s_reify_2_conv_5_simp_8        = acc_s_reify_2_conv_5_simp_8;          /* save */
     
-    s->has_acc_s_reify_2_conv_5_simp_5        = itrue;                                /* save */
-    s->res_acc_s_reify_2_conv_5_simp_5        = acc_s_reify_2_conv_5_simp_5;          /* save */
+    s->has_acc_s_reify_2_conv_5_simp_9        = itrue;                                /* save */
+    s->res_acc_s_reify_2_conv_5_simp_9        = acc_s_reify_2_conv_5_simp_9;          /* save */
     
-    s->has_acc_conv_4_simp_6                  = itrue;                                /* save */
-    s->res_acc_conv_4_simp_6                  = acc_conv_4_simp_6;                    /* save */
+    s->has_acc_conv_4_simp_4                  = itrue;                                /* save */
+    s->res_acc_conv_4_simp_4                  = acc_conv_4_simp_4;                    /* save */
     
-    s_reify_2_conv_5_simp_24                  = acc_s_reify_2_conv_5_simp_4;          /* read */
-    s_reify_2_conv_5_simp_25                  = acc_s_reify_2_conv_5_simp_5;          /* read */
+    s_reify_2_conv_5_simp_24                  = acc_s_reify_2_conv_5_simp_8;          /* read */
+    s_reify_2_conv_5_simp_25                  = acc_s_reify_2_conv_5_simp_9;          /* read */
     s->repl_ix_0                              = s_reify_2_conv_5_simp_24;             /* output */
     s->repl_ix_1                              = s_reify_2_conv_5_simp_25;             /* output */
 }

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -149,9 +149,9 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$333@{Error}, conv
       init flat$14$simp$151@{Double} = 0.0@{Double};
       if (eq#@{Error} flat$13$simp$148 (ExceptNotAnError@{Error}))
       {
-        let simp$457 = add#@{Double} s$reify$6$conv$12$simp$139 (1.0@{Double});
         write flat$14$simp$150 = ExceptNotAnError@{Error};
-        write flat$14$simp$151 = div# flat$13$simp$149 simp$457;
+        let simp$461 = add#@{Double} s$reify$6$conv$12$simp$139 (1.0@{Double});
+        write flat$14$simp$151 = div# flat$13$simp$149 simp$461;
       }
       else
       {
@@ -589,9 +589,9 @@ if (eq#@{Error} flat$82$simp$315 (ExceptNotAnError@{Error}))
   if (eq#@{Error} a$conv$63$simp$306 (ExceptNotAnError@{Error}))
   {
     let conv$118 = sub#@{Double} a$conv$63$simp$307 (1.0@{Double});
-    let simp$1408 = div# a$conv$63$simp$309 conv$118;
+    let simp$1212 = div# a$conv$63$simp$309 conv$118;
     write flat$86$simp$319 = ExceptNotAnError@{Error};
-    write flat$86$simp$320 = simp$1408;
+    write flat$86$simp$320 = simp$1212;
   }
   else
   {
@@ -1082,9 +1082,9 @@ void iprogram_0(iprogram_0_t *s)
                 flat_14_simp_151              = 0.0;                                  /* init */
                 
                 if (ierror_eq (flat_13_simp_148, ierror_not_an_error)) {
-                    idouble_t        simp_457 = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* let */
                     flat_14_simp_150          = ierror_not_an_error;                  /* write */
-                    flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_457); /* write */
+                    idouble_t        simp_461 = idouble_add (s_reify_6_conv_12_simp_139, 1.0); /* let */
+                    flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_461); /* write */
                 } else {
                     flat_14_simp_150          = flat_13_simp_148;                     /* write */
                     flat_14_simp_151          = 0.0;                                  /* write */
@@ -1533,9 +1533,9 @@ void iprogram_0(iprogram_0_t *s)
         
         if (ierror_eq (a_conv_63_simp_306, ierror_not_an_error)) {
             idouble_t        conv_118         = idouble_sub (a_conv_63_simp_307, 1.0); /* let */
-            idouble_t        simp_1408        = idouble_div (a_conv_63_simp_309, conv_118); /* let */
+            idouble_t        simp_1212        = idouble_div (a_conv_63_simp_309, conv_118); /* let */
             flat_86_simp_319                  = ierror_not_an_error;                  /* write */
-            flat_86_simp_320                  = simp_1408;                            /* write */
+            flat_86_simp_320                  = simp_1212;                            /* write */
         } else {
             flat_86_simp_319                  = a_conv_63_simp_306;                   /* write */
             flat_86_simp_320                  = 0.0;                                  /* write */

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -56,6 +56,9 @@ iint_t size_of_state_iprogram_0 ()
 void iprogram_0(iprogram_0_t *s)
 {
     idouble_t        acc_perhaps_conv_4_simp_10;
+    iint_t           aval_0_simp_12;
+    idouble_t        aval_0_simp_13;
+    ibool_t          aval_0_simp_11;
     ibool_t          acc_perhaps_conv_4_simp_8;
     iint_t           acc_perhaps_conv_4_simp_9;
     ibool_t          flat_0_simp_14;
@@ -64,9 +67,6 @@ void iprogram_0(iprogram_0_t *s)
     iint_t           flat_0_simp_18;
     idouble_t        flat_0_simp_19;
     idouble_t        flat_0_simp_16;
-    idouble_t        perhaps_conv_4_simp_13;
-    ibool_t          perhaps_conv_4_simp_11;
-    iint_t           perhaps_conv_4_simp_12;
     idouble_t        perhaps_conv_4_simp_22;
     iint_t           perhaps_conv_4_simp_21;
     ibool_t          perhaps_conv_4_simp_20;
@@ -101,22 +101,22 @@ void iprogram_0(iprogram_0_t *s)
         ierror_t         conv_0_simp_23       = new_conv_0_simp_23[i];
         iint_t           conv_0_simp_24       = new_conv_0_simp_24[i];
         itime_t          conv_0_simp_25       = new_conv_0_simp_25[i];
-        perhaps_conv_4_simp_11                = acc_perhaps_conv_4_simp_8;            /* read */
-        perhaps_conv_4_simp_12                = acc_perhaps_conv_4_simp_9;            /* read */
-        perhaps_conv_4_simp_13                = acc_perhaps_conv_4_simp_10;           /* read */
+        aval_0_simp_11                        = acc_perhaps_conv_4_simp_8;            /* read */
+        aval_0_simp_12                        = acc_perhaps_conv_4_simp_9;            /* read */
+        aval_0_simp_13                        = acc_perhaps_conv_4_simp_10;           /* read */
         flat_0_simp_14                        = ifalse;                               /* init */
         flat_0_simp_15                        = 0;                                    /* init */
         flat_0_simp_16                        = 0.0;                                  /* init */
         
-        if (perhaps_conv_4_simp_11) {
+        if (aval_0_simp_11) {
             flat_0_simp_14                    = ifalse;                               /* write */
-            iint_t           simp_35          = idouble_trunc (perhaps_conv_4_simp_13); /* let */
+            iint_t           simp_35          = idouble_trunc (aval_0_simp_13);       /* let */
             flat_0_simp_15                    = iint_add (simp_35, 1);                /* write */
             flat_0_simp_16                    = 0.0;                                  /* write */
         } else {
             flat_0_simp_14                    = itrue;                                /* write */
             flat_0_simp_15                    = 0;                                    /* write */
-            idouble_t        simp_53          = iint_extend (perhaps_conv_4_simp_12); /* let */
+            idouble_t        simp_53          = iint_extend (aval_0_simp_12);         /* let */
             flat_0_simp_16                    = idouble_add (simp_53, 1.0);           /* write */
         }
         

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -109,15 +109,15 @@ void iprogram_0(iprogram_0_t *s)
         flat_0_simp_16                        = 0.0;                                  /* init */
         
         if (perhaps_conv_4_simp_11) {
-            iint_t           simp_31          = idouble_trunc (perhaps_conv_4_simp_13); /* let */
             flat_0_simp_14                    = ifalse;                               /* write */
-            flat_0_simp_15                    = iint_add (simp_31, 1);                /* write */
+            iint_t           simp_35          = idouble_trunc (perhaps_conv_4_simp_13); /* let */
+            flat_0_simp_15                    = iint_add (simp_35, 1);                /* write */
             flat_0_simp_16                    = 0.0;                                  /* write */
         } else {
-            idouble_t        simp_45          = iint_extend (perhaps_conv_4_simp_12); /* let */
             flat_0_simp_14                    = itrue;                                /* write */
             flat_0_simp_15                    = 0;                                    /* write */
-            flat_0_simp_16                    = idouble_add (simp_45, 1.0);           /* write */
+            idouble_t        simp_53          = iint_extend (perhaps_conv_4_simp_12); /* let */
+            flat_0_simp_16                    = idouble_add (simp_53, 1.0);           /* write */
         }
         
         flat_0_simp_17                        = flat_0_simp_14;                       /* read */


### PR DESCRIPTION
With 80 fields:

```
amos@Amos icicle $ time dist/build/icicle-repl/icicle-repl ":dictionary bigdict.toml" "feature big ~> group s0 ~> newest s1" < /dev/nullwelcome to iREPL
ok, loaded dictionary with 2 features and 24 functions
- Core evaluation:
[]

>
real	0m12.959s
user	0m12.797s
sys	0m0.156s
```

while this was around 50s before. Yay!