### PR TITLE
Bubblegum: save fact identifiers used by latest buffers

### DIFF
--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -29,6 +29,7 @@ typedef uint64_t ibool_t;
 typedef  int64_t iint_t;
 typedef   double idouble_t;
 typedef  int64_t itime_t;
+typedef uint64_t ifactid_t;
 
 typedef const char *istring_t;
 

--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -16,6 +16,7 @@ MK_SIMPLE_CMPS(ierror_t, ierror_)
 MK_SIMPLE_CMPS(ibool_t,  ibool_)
 MK_SIMPLE_CMPS(itime_t,  itime_)
 MK_SIMPLE_CMPS(iunit_t,  iunit_)
+MK_SIMPLE_CMPS(ifactid_t,ifactid_)
 
 #define MK_SIMPLE_COPY(t,pre)                                                   \
     static t    INLINE pre##copy(imempool_t *into, t val) { return val; } \
@@ -24,6 +25,7 @@ MK_SIMPLE_COPY(ierror_t, ierror_)
 MK_SIMPLE_COPY(ibool_t,  ibool_)
 MK_SIMPLE_COPY(itime_t,  itime_)
 MK_SIMPLE_COPY(iunit_t,  iunit_)
+MK_SIMPLE_COPY(ifactid_t,ifactid_)
 
 
 static idouble_t INLINE iint_extend   (iint_t    x)              { return x; }

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -88,6 +88,7 @@ library
                        Icicle.Avalanche.Statement.Flatten.Exp
                        Icicle.Avalanche.Prim.Flat
                        Icicle.Avalanche.Prim.Eval
+                       Icicle.Avalanche.Prim.Compounds
 
                        Icicle.Benchmark
                        Icicle.Benchmark.Generator

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -82,6 +82,7 @@ library
                        Icicle.Avalanche.Statement.Simp.Melt
                        Icicle.Avalanche.Statement.Flatten
                        Icicle.Avalanche.Statement.Flatten.Base
+                       Icicle.Avalanche.Statement.Flatten.Save
                        Icicle.Avalanche.Statement.Flatten.Statement
                        Icicle.Avalanche.Statement.Flatten.Type
                        Icicle.Avalanche.Statement.Flatten.Exp

--- a/src/Icicle/Avalanche/FromCore.hs
+++ b/src/Icicle/Avalanche/FromCore.hs
@@ -161,7 +161,7 @@ makeStatements _p namer streams
 
   mkReads' ((n,t):ns) inner k fvs
    | Set.member n fvs
-   = do n' <- fresh
+   = do n' <- freshPrefixBase $ nameBase n
         k' <- X.subst () n (X.XVar () n') k
         let acc = namerAccPrefix namer n
         mkReads' ns (\x -> Read n' acc t (inner x)) k' fvs

--- a/src/Icicle/Avalanche/Prim/Compounds.hs
+++ b/src/Icicle/Avalanche/Prim/Compounds.hs
@@ -41,6 +41,9 @@ data FlatOps a n = FlatOps {
   , sndF     :: ValType -> ValType -> X a n -> X a n
   , pair     :: ValType -> ValType -> X a n -> X a n -> X a n
 
+  , structGet:: StructField -> ValType -> StructType
+             -> X a n -> X a n
+
   , relEq    :: ValType -> X a n -> X a n -> X a n
 
   }
@@ -81,6 +84,9 @@ flatOps a_fresh
   fstF   t u    = p1 (PrimMinimal $ Min.PrimPair $ Min.PrimPairFst t u)
   sndF   t u    = p1 (PrimMinimal $ Min.PrimPair $ Min.PrimPairSnd t u)
   pair   t u    = p2 (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair t u)
+
+  structGet f t st
+                = p1 (PrimMinimal $ Min.PrimStruct $ Min.PrimStructGet f t st)
 
   relEq     t   = p2 (PrimMinimal $ Min.PrimRelation Min.PrimRelationEq t)
 

--- a/src/Icicle/Avalanche/Prim/Compounds.hs
+++ b/src/Icicle/Avalanche/Prim/Compounds.hs
@@ -1,0 +1,86 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE RecordWildCards #-}
+module Icicle.Avalanche.Prim.Compounds (
+    FlatOps(..)
+  , flatOps
+  ) where
+
+import              Icicle.Common.Type
+import              Icicle.Common.Exp
+import qualified    Icicle.Common.Exp.Prim.Minimal as Min
+import              Icicle.Avalanche.Prim.Flat
+
+import              P
+
+type X a n = Exp a n Prim
+
+data FlatOps a n = FlatOps {
+    arrLen  :: ValType -> X a n -> X a n
+  , arrIx   :: ValType -> X a n -> X a n -> X a n
+  , arrNew  :: ValType -> X a n -> X a n
+  , arrUpd  :: ValType -> X a n -> X a n -> X a n -> X a n
+  , arrZip  :: ValType -> ValType
+            -> X a n -> X a n -> X a n
+
+  , mapPack :: ValType -> ValType -> X a n -> X a n -> X a n
+  , mapKeys :: ValType -> ValType -> X a n -> X a n
+  , mapVals :: ValType -> ValType -> X a n -> X a n
+
+  , bufPush :: Int -> ValType -> X a n -> X a n -> X a n
+  , bufRead :: Int -> ValType -> X a n -> X a n
+
+  , isSome   :: ValType -> X a n -> X a n
+  , optionGet:: ValType -> X a n -> X a n
+  , someF    :: ValType -> X a n -> X a n
+
+  , isRightF :: ValType -> ValType -> X a n -> X a n
+  , left     :: ValType -> ValType -> X a n -> X a n
+  , right    :: ValType -> ValType -> X a n -> X a n
+
+  , fstF     :: ValType -> ValType -> X a n -> X a n
+  , sndF     :: ValType -> ValType -> X a n -> X a n
+  , pair     :: ValType -> ValType -> X a n -> X a n -> X a n
+
+  , relEq    :: ValType -> X a n -> X a n -> X a n
+
+  }
+
+flatOps :: a -> FlatOps a n
+flatOps a_fresh
+ = FlatOps{..}
+ where
+  xPrim         = XPrim  a_fresh
+  xApp          = XApp   a_fresh
+
+  p1 p x        = xPrim p  `xApp` x
+  p2 p x y      = p1 p x   `xApp` y
+  p3 p x y z    = p2 p x y `xApp` z
+
+  arrLen t      = p1 (PrimProject $ PrimProjectArrayLength t)
+  arrIx  t      = p2 (PrimUnsafe  $ PrimUnsafeArrayIndex   t)
+  arrNew t      = p1 (PrimUnsafe  $ PrimUnsafeArrayCreate  t)
+  arrUpd t      = p3 (PrimUpdate  $ PrimUpdateArrayPut     t)
+  arrZip k v    = p2 (PrimArray   $ PrimArrayZip           k v)
+
+
+  mapPack k v   = p2 (PrimMap $ PrimMapPack         k v)
+  mapKeys k v   = p1 (PrimMap $ PrimMapUnpackKeys   k v)
+  mapVals k v   = p1 (PrimMap $ PrimMapUnpackValues k v)
+
+  bufPush n t   = p2 (PrimBuf $ PrimBufPush n t)
+  bufRead n t   = p1 (PrimBuf $ PrimBufRead n t)
+
+  isSome    t   = p1 (PrimProject (PrimProjectOptionIsSome t))
+  optionGet t   = p1 (PrimUnsafe (PrimUnsafeOptionGet t))
+  someF     t   = p1 (PrimMinimal $ Min.PrimConst $ Min.PrimConstSome t)
+
+  isRightF t u  = p1 (PrimProject $ PrimProjectSumIsRight t u)
+  left     t u  = p1 (PrimUnsafe  $ PrimUnsafeSumGetLeft  t u)
+  right    t u  = p1 (PrimUnsafe  $ PrimUnsafeSumGetRight t u)
+
+  fstF   t u    = p1 (PrimMinimal $ Min.PrimPair $ Min.PrimPairFst t u)
+  sndF   t u    = p1 (PrimMinimal $ Min.PrimPair $ Min.PrimPairSnd t u)
+  pair   t u    = p2 (PrimMinimal $ Min.PrimConst $ Min.PrimConstPair t u)
+
+  relEq     t   = p2 (PrimMinimal $ Min.PrimRelation Min.PrimRelationEq t)
+

--- a/src/Icicle/Avalanche/Statement/Flatten/Save.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Save.hs
@@ -56,7 +56,10 @@ flattenSave' a_fresh xx ty
     ErrorT      -> no
     FactIdentifierT-> no
     -- Maps will not appear at this late stage
-    MapT _ _ -> no
+    MapT t u
+     -> do s1 <- forArr (fpMapKeys t u `xApp` xx) t (go t)
+           s2 <- forArr (fpMapVals t u `xApp` xx) u (go u)
+           return (s1 <> s2)
 
     -- A buffer! Look inside and mark them as necessary.
     BufT n t 
@@ -147,4 +150,7 @@ flattenSave' a_fresh xx ty
 
   fpStructGet f t st
     = xPrim (Flat.PrimMinimal $ Min.PrimStruct $ Min.PrimStructGet f t st)
+
+  fpMapKeys k v = xPrim (Flat.PrimMap (Flat.PrimMapUnpackKeys   k v))
+  fpMapVals k v = xPrim (Flat.PrimMap (Flat.PrimMapUnpackValues k v))
 

--- a/src/Icicle/Avalanche/Statement/Flatten/Save.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Save.hs
@@ -1,0 +1,150 @@
+-- | Save the buffers inside accumulators by looping through
+-- and calling KeepFactInHistory
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE PatternGuards #-}
+module Icicle.Avalanche.Statement.Flatten.Save (
+    flattenSaveAccumulator
+  ) where
+
+import              Icicle.Avalanche.Statement.Flatten.Base
+
+import              Icicle.Avalanche.Statement.Statement
+import qualified    Icicle.Avalanche.Prim.Flat     as Flat
+import qualified    Icicle.Common.Exp.Prim.Minimal as Min
+
+import              Icicle.Common.Base
+import              Icicle.Common.Type
+import              Icicle.Common.Exp
+import              Icicle.Common.Fresh
+
+import              P
+
+import qualified    Data.Map                        as Map
+import              Data.Hashable                  (Hashable)
+
+-- | Dig through the type and find any buffers of FactIdentifiers.
+-- If there are any, create loops etc to mark them with KeepFactInHistory
+flattenSaveAccumulator :: Hashable n => a -> Accumulator a n p -> FlatM a n
+flattenSaveAccumulator a_fresh (Accumulator nm ty _)
+ = do nm' <- freshPrefixBase $ nameBase nm
+      n   <- flattenSave' a_fresh (XVar a_fresh nm') ty
+      case n of
+       Just st
+        -> return $ Read nm' nm ty st
+       Nothing
+        -> return   mempty
+
+
+
+-- | Dig through the type and find any buffers of FactIdentifiers.
+-- Return Nothing if there is no Buf FactIdentifier.
+flattenSave'
+        :: (Monad m, Hashable n)
+        => a
+        -> Exp a n Flat.Prim
+        -> ValType
+        -> FreshT n m (Maybe (Statement a n Flat.Prim))
+flattenSave' a_fresh xx ty
+ = case ty of
+    -- Base types with no nested buffers
+    BoolT       -> no
+    TimeT       -> no
+    DoubleT     -> no
+    IntT        -> no
+    StringT     -> no
+    UnitT       -> no
+    ErrorT      -> no
+    FactIdentifierT-> no
+    -- Maps will not appear at this late stage
+    MapT _ _ -> no
+
+    -- A buffer! Look inside and mark them as necessary.
+    BufT n t 
+     | FactIdentifierT <- t
+     -> forBuf xx n t (yes . KeepFactInHistory)
+     -- Allow for nested buffers: while we don't allow them now, they may be useful in the future
+     | otherwise
+     -> forBuf xx n t (go t)
+
+    -- Look through the contents of the array for any Buf FactIdentifierT.
+    ArrayT t
+     -> forArr xx t (go t)
+
+    -- The Option may contain a nested Buf FactIdentifierT, so try it
+    OptionT t
+     -> do s <- go t (fpOptionGet t `xApp` xx)
+           case s of
+            -- If there is no nested buf, we must be very careful to return Nothing
+            -- Otherwise we might loop through this stuff for no reason.
+            Nothing -> no
+            Just s' -> yes $ If (fpIsSome t `xApp` xx) s' mempty
+
+    PairT t u
+     -> do s1 <- go t (fpFst t u `xApp` xx)
+           s2 <- go u (fpSnd t u `xApp` xx)
+           -- If either side contains something, this is something
+           return (s1 <> s2)
+
+    SumT t u
+     -> do s1 <- go t (fpSumLeft  t u `xApp` xx)
+           s2 <- go u (fpSumRight t u `xApp` xx)
+           case (s1 <> s2) of
+            Nothing
+             -> no
+            Just _ 
+             -> yes
+              $ If (fpIsRight t u `xApp` xx) (stmtOf s2) (stmtOf s1)
+
+    StructT st
+     -> mconcat <$> mapM (\(nm,t) -> go t (fpStructGet nm t st `xApp` xx))
+                    (Map.toList (getStructType st))
+
+
+
+ where
+  no = return Nothing
+  yes = return . Just
+
+  go t x' = flattenSave' a_fresh x' t
+
+  forBuf x n t f
+   = do nm' <- fresh
+        s <- forArr (xVar nm') t f
+        case s of
+         Nothing -> no
+         Just s' -> yes
+                  $ Let nm' (xPrim (Flat.PrimBuf $ Flat.PrimBufRead n t) `xApp` x) s'
+
+  forArr x t f
+   = do nm' <- fresh
+        let ix = xPrim (Flat.PrimUnsafe $ Flat.PrimUnsafeArrayIndex t) `makeApps'` [x, xVar nm']
+        f'  <- f ix
+        case f' of
+         Nothing -> no
+         Just s -> yes
+                 $ ForeachInts nm' xZero (xPrim (Flat.PrimProject $ Flat.PrimProjectArrayLength t) `xApp` x) s
+
+  stmtOf = fromMaybe mempty
+
+  -- Annotation plumbing
+  makeApps' = makeApps a_fresh
+  xVar      = XVar     a_fresh
+  xPrim     = XPrim    a_fresh
+  xValue    = XValue   a_fresh
+  xApp      = XApp     a_fresh
+
+  xZero     = xValue IntT (VInt 0)
+
+  fpIsSome    t = xPrim (Flat.PrimProject (Flat.PrimProjectOptionIsSome t))
+  fpOptionGet t = xPrim (Flat.PrimUnsafe (Flat.PrimUnsafeOptionGet t))
+
+  fpIsRight  t u = xPrim (Flat.PrimProject (Flat.PrimProjectSumIsRight t u))
+  fpSumLeft  t u = xPrim (Flat.PrimUnsafe (Flat.PrimUnsafeSumGetLeft  t u))
+  fpSumRight t u = xPrim (Flat.PrimUnsafe (Flat.PrimUnsafeSumGetRight t u))
+
+  fpFst t u     = xPrim (Flat.PrimMinimal $ Min.PrimPair $ Min.PrimPairFst t u)
+  fpSnd t u     = xPrim (Flat.PrimMinimal $ Min.PrimPair $ Min.PrimPairSnd t u)
+
+  fpStructGet f t st
+    = xPrim (Flat.PrimMinimal $ Min.PrimStruct $ Min.PrimStructGet f t st)
+

--- a/src/Icicle/Avalanche/Statement/Flatten/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Statement.hs
@@ -9,8 +9,11 @@ module Icicle.Avalanche.Statement.Flatten.Statement (
 import              Icicle.Avalanche.Statement.Flatten.Base
 import              Icicle.Avalanche.Statement.Flatten.Exp
 import              Icicle.Avalanche.Statement.Flatten.Type
+import              Icicle.Avalanche.Statement.Flatten.Save
+
 
 import              Icicle.Avalanche.Statement.Statement
+import qualified    Icicle.Avalanche.Prim.Flat     as Flat
 
 import qualified    Icicle.Core.Exp.Prim           as Core
 
@@ -21,6 +24,11 @@ import              P
 import qualified    Data.List                      as List
 import              Data.Hashable                  (Hashable)
 
+flatten :: (Pretty n, Hashable n, Eq n)
+        => a
+        -> Statement a n Core.Prim
+        -> FlatM a n
+flatten a_fresh s = flattenS a_fresh [] s
 
 -- Extracting FactIdentifiers from Buffers:
 --
@@ -42,46 +50,51 @@ import              Data.Hashable                  (Hashable)
 
 -- | Flatten the primitives in a statement.
 -- This just calls @flatX@ for every expression, wrapping the statement.
-flatten :: (Pretty n, Hashable n, Eq n)
+flattenS :: (Pretty n, Hashable n, Eq n)
         => a
+        -> [Accumulator a n Flat.Prim]
         -> Statement a n Core.Prim
         -> FlatM a n
-flatten a_fresh s
+flattenS a_fresh accums s
  = case s of
     If x ts es
      -> flatX a_fresh x
      $ \x'
-     -> If x' <$> flatten a_fresh ts <*> flatten a_fresh es
+     -> If x' <$> flattenS a_fresh accums ts <*> flattenS a_fresh accums es
 
     Let n x ss
      -> flatX a_fresh x
      $ \x'
-     -> Let n x' <$> flatten a_fresh ss
+     -> Let n x' <$> flattenS a_fresh accums ss
 
     ForeachInts n from to ss
      -> flatX a_fresh from
      $ \from'
      -> flatX a_fresh to
      $ \to'
-     -> ForeachInts n from' to' <$> flatten a_fresh ss
+     -> ForeachInts n from' to' <$> flattenS a_fresh accums ss
 
     ForeachFacts binds vt lo ss
      -- Input binds cannot contain Buffers, so no need to flatten the types
-     -> ForeachFacts binds (flatT vt) lo <$> flatten a_fresh ss
+     -> do  loop  <- ForeachFacts binds (flatT vt) lo <$> flattenS a_fresh accums ss
+            -- Run through all the accumulators and save the buffers
+            save  <- mapM (flattenSaveAccumulator a_fresh) accums
+            return $ mconcat (loop : save)
 
     Block ss
-     -> Block <$> mapM (flatten a_fresh) ss
+     -> Block <$> mapM (flattenS a_fresh accums) ss
 
     InitAccumulator acc ss
      -> flatX a_fresh (accInit acc)
      $ \x'
-     -> InitAccumulator
-       (acc { accInit = x'
-            , accValType = flatT (accValType acc)})
-     <$> flatten a_fresh ss
+     -> let acc' = acc
+                 { accInit = x'
+                 , accValType = flatT (accValType acc)}
+        in InitAccumulator acc'
+        <$> flattenS a_fresh (acc':accums) ss
 
     Read n m vt ss
-     -> Read n m (flatT vt) <$> flatten a_fresh ss
+     -> Read n m (flatT vt) <$> flattenS a_fresh accums ss
 
     Write n x
      -> flatX a_fresh x (return . Write n)

--- a/src/Icicle/Avalanche/Statement/Flatten/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Statement.hs
@@ -88,7 +88,7 @@ flatten a_fresh s
 
     Output n t xts
      | xs <- fmap fst xts
-     , ts <- fmap snd xts
+     , ts <- fmap (flatT.snd) xts
      -> flatXS a_fresh xs []
      $ \xs'
      -> return $ Output n (flatT t) (List.zip xs' ts)

--- a/src/Icicle/Avalanche/Statement/Flatten/Type.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Type.hs
@@ -48,7 +48,7 @@ flatT ot
     UnitT       -> ot
     ErrorT      -> ot
     FactIdentifierT-> ot
-    
+
     ArrayT t    -> ArrayT $ flatT t
     MapT t u    -> MapT  (flatT t) (flatT u)
     OptionT t   -> OptionT $ flatT t

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -39,12 +39,12 @@ makeApps a f args
 -- If it's not an application, arguments will be empty.
 takeApps :: Exp a n p -> (Exp a n p, [Exp a n p])
 takeApps xx
- = case xx of
-    XApp _ p q
-     -> let (f,as) = takeApps p
-        in  (f, as <> [q])
-    _
-     -> (xx, [])
+ = go xx []
+ where
+  go (XApp _ p q) args
+   = go p (q : args)
+  go f args
+   = (f, args)
 
 
 -- | Check if an expression is a primitive application

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -215,18 +215,12 @@ seaOfXValue v t
       | otherwise
       -> seaError "seaOfXValue: array of wrong type" (v,t)
 
-     VBuf vs
-      | BufT len t' <- t
-      -> let writes buf v'
-              = prim (PrimBuf $ PrimBufPush len t')
-                     [buf, seaOfXValue v' t']
-             init
-              = seaOfPrimDocApps
+     VBuf []
+      -> seaOfPrimDocApps
                      (PDFun (prefixOfValType t <> "make") Nothing)
                      []
-        in  foldl writes init vs
-      | otherwise
-      -> seaError "seaOfXValue: buffer of wrong type" (v,t)
+     VBuf _
+      -> seaError "seaOfXValue: buffer elements should be converted to pushes by convertValues " (v,t)
 
      VMap _
       -> seaError "seaOfXValue: maps should be removed by flatten" v

--- a/src/Icicle/Sea/FromAvalanche/Type.hs
+++ b/src/Icicle/Sea/FromAvalanche/Type.hs
@@ -123,7 +123,7 @@ baseOfValType t
      TimeT     -> "itime"
      ErrorT    -> "ierror"
      FactIdentifierT
-                -> "iint"
+               -> "ifactid"
 
      StringT   -> "istring"
      BufT n t' -> "ibuf_" <> int n <> "_" <> baseOfValType t'

--- a/src/Icicle/Source/Lexer/Lexer.hs
+++ b/src/Icicle/Source/Lexer/Lexer.hs
@@ -142,8 +142,12 @@ lexerPositions ts
    = C.isAlphaNum c || c == '_' || c == '$' || c == '\''
 
   isOperator c
+   = elem c ("/*+^-<>=!&|," :: [Char])
+   {-
    =  not (isVarRest c)
    && not (C.isSpace c)
    && c /= '(' && c /= ')'
+   && c /= '"' && c /= '`'
+   -}
 
 

--- a/test/Icicle/Test/Avalanche/Flatten.hs
+++ b/test/Icicle/Test/Avalanche/Flatten.hs
@@ -121,5 +121,5 @@ tests :: IO Bool
 -- tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 10000, maxSize = 10})
 -- tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxDiscardRatio = 10000})
 -- Need a larger discard ratio sometimes
-tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 1000, maxSize = 100, maxDiscardRatio = 10000})
+tests = $forAllProperties $ quickCheckWithResult (stdArgs {maxSuccess = 100, maxSize = 10, maxDiscardRatio = 10000})
 

--- a/test/Icicle/Test/Sea/Seaworthy.hs
+++ b/test/Icicle/Test/Sea/Seaworthy.hs
@@ -42,6 +42,7 @@ prop_seaworthy wt
        Left err
         -> counterexample (show $ pretty err)
         $  counterexample (show $ pretty (wtCore wt))
+        $  counterexample (show $ pretty (wtAvalanche wt))
         $  failed
  where
   go p

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -24,20 +24,20 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Tim
     (\reify$3$conv$8@{Bool} reify$3$conv$8) anf$1)
   {
     write acc$conv$10 = pair#@{(Sum Error Int), ((Sum Error Int), Time)} anf$0 conv$0;
-    read aval$1 = acc$conv$10 [((Sum Error Int), ((Sum Error Int), Time))];
-    read aval$0 = acc$c$conv$11 [(Sum Error Int)];
-    let anf$3 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} aval$1;
+    read conv$10$aval$1 = acc$conv$10 [((Sum Error Int), ((Sum Error Int), Time))];
+    read c$conv$11$aval$0 = acc$c$conv$11 [(Sum Error Int)];
+    let anf$3 = fst#@{(Sum Error Int), ((Sum Error Int), Time)} conv$10$aval$1;
     write acc$c$conv$11 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
       (\reify$6$conv$12@{Error} left#@{Error, Int} reify$6$conv$12) 
       (\reify$7$conv$13@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
         (\reify$8$conv$17@{Error} left#@{Error, Int} reify$8$conv$17) 
         (\reify$9$conv$18@{Int} right#@{Error, Int} reify$9$conv$18) (Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
         (\reify$4$conv$14@{Error} left#@{Error, Int} reify$4$conv$14) 
-        (\reify$5$conv$15@{Int} right#@{Error, Int} (add#@{Int} reify$5$conv$15 (1@{Int}))) aval$0)) anf$3;
+        (\reify$5$conv$15@{Int} right#@{Error, Int} (add#@{Int} reify$5$conv$15 (1@{Int}))) c$conv$11$aval$0)) anf$3;
   }
-  read aval$2 = acc$conv$26 [Buf 3 (Sum Error Int)];
+  read conv$26$aval$2 = acc$conv$26 [Buf 3 (Sum Error Int)];
   let anf$4 = anf$0;
-  write acc$conv$26 = Latest_push#@{Buf 3 (Sum Error Int)} aval$2 conv$1 anf$4;
+  write acc$conv$26 = Latest_push#@{Buf 3 (Sum Error Int)} conv$26$aval$2 conv$1 anf$4;
 }
 save_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
 save_resumable@{(Sum Error Int)} acc$c$conv$11;
@@ -66,11 +66,11 @@ init acc$conv$4@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (B
 load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
-  read aval$0 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
+  read conv$4$aval$0 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
   let anf$0 = Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0;
   let anf$1 = snd#@{(Sum Error Int), Time} conv$0;
   write acc$conv$4 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
-    (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 aval$0;
+    (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 conv$4$aval$0;
 }
 save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
 read conv$4 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -10,9 +10,9 @@ conv$3 = TIME
 init acc$conv$10$simp$16@{Error} = ExceptNotAnError@{Error};
 init acc$c$conv$11$simp$21@{Error} = ExceptNotAnError@{Error};
 init acc$c$conv$11$simp$22@{Int} = 0@{Int};
-init acc$conv$26$simp$23@{Buf 3 FactIdentifier} = Buf []@{Buf 3 FactIdentifier};
-init acc$conv$26$simp$24@{Buf 3 Error} = Buf []@{Buf 3 Error};
-init acc$conv$26$simp$25@{Buf 3 Int} = Buf []@{Buf 3 Int};
+init acc$conv$26$simp$23@{Buf 3 FactIdentifier} = Buf_make#@{Buf 3 FactIdentifier} (()@{Unit});
+init acc$conv$26$simp$24@{Buf 3 Error} = Buf_make#@{Buf 3 Error} (()@{Unit});
+init acc$conv$26$simp$25@{Buf 3 Int} = Buf_make#@{Buf 3 Int} (()@{Unit});
 load_resumable@{Buf 3 FactIdentifier} acc$conv$26$simp$23;
 load_resumable@{Buf 3 Error} acc$conv$26$simp$24;
 load_resumable@{Buf 3 Int} acc$conv$26$simp$25;
@@ -121,8 +121,8 @@ read c$conv$11$simp$58 = acc$c$conv$11$simp$21 [Error];
 read c$conv$11$simp$59 = acc$c$conv$11$simp$22 [Int];
 init flat$23$simp$60@{Error} = ExceptNotAnError@{Error};
 init flat$23$simp$61@{Int} = 0@{Int};
-init flat$23$simp$62@{Array Error} = []@{Array Error};
-init flat$23$simp$63@{Array Int} = []@{Array Int};
+init flat$23$simp$62@{Array Error} = unsafe_Array_create#@{Error} (0@{Int});
+init flat$23$simp$63@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
 if (eq#@{Error} c$conv$11$simp$58 (ExceptNotAnError@{Error}))
 {
   write flat$23$simp$60 = ExceptNotAnError@{Error};
@@ -150,10 +150,10 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$23$simp$64@{Error},
 > > -- Something involves the abstract buffer type
 > - Flattened:
 conv$3 = TIME
-init acc$conv$4$simp$40@{Array Time} = []@{Array Time};
-init acc$conv$4$simp$41@{Array (Buf 2 FactIdentifier)} = []@{Array (Buf 2 FactIdentifier)};
-init acc$conv$4$simp$42@{Array (Buf 2 Error)} = []@{Array (Buf 2 Error)};
-init acc$conv$4$simp$43@{Array (Buf 2 Int)} = []@{Array (Buf 2 Int)};
+init acc$conv$4$simp$40@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init acc$conv$4$simp$41@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
+init acc$conv$4$simp$42@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
+init acc$conv$4$simp$43@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
 load_resumable@{Array Time} acc$conv$4$simp$40;
 load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$4$simp$41;
 load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$42;
@@ -243,8 +243,8 @@ read conv$4$simp$71 = acc$conv$4$simp$40 [Array Time];
 read conv$4$simp$73 = acc$conv$4$simp$42 [Array (Buf 2 Error)];
 read conv$4$simp$74 = acc$conv$4$simp$43 [Array (Buf 2 Int)];
 init flat$23$simp$76@{Error} = ExceptNotAnError@{Error};
-init flat$23$simp$77@{Array Time} = []@{Array Time};
-init flat$23$simp$78@{Array Int} = []@{Array Int};
+init flat$23$simp$77@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init flat$23$simp$78@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
 foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$71)
 {
   read flat$23$simp$79 = flat$23$simp$76 [Error];
@@ -254,8 +254,8 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$71)
   let simp$453 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$73 flat$24;
   let simp$455 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$74 flat$24;
   init flat$26$simp$82@{Error} = ExceptNotAnError@{Error};
-  init flat$26$simp$83@{Array Time} = []@{Array Time};
-  init flat$26$simp$84@{Array Int} = []@{Array Int};
+  init flat$26$simp$83@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+  init flat$26$simp$84@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
   if (eq#@{Error} flat$23$simp$79 (ExceptNotAnError@{Error}))
   {
     let simp$489 = Buf_read#@{Array Error} simp$453;
@@ -302,8 +302,8 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$71)
     read flat$30$simp$103 = flat$30$simp$87 [Error];
     read flat$30$simp$104 = flat$30$simp$88 [Int];
     init flat$31$simp$105@{Error} = ExceptNotAnError@{Error};
-    init flat$31$simp$106@{Array Time} = []@{Array Time};
-    init flat$31$simp$107@{Array Int} = []@{Array Int};
+    init flat$31$simp$106@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+    init flat$31$simp$107@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
     if (eq#@{Error} flat$30$simp$103 (ExceptNotAnError@{Error}))
     {
       init flat$34@{Bool} = False@{Bool};

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -150,51 +150,51 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$23$simp$64@{Error},
 > > -- Something involves the abstract buffer type
 > - Flattened:
 conv$3 = TIME
-init acc$conv$4$simp$32@{Array Time} = []@{Array Time};
-init acc$conv$4$simp$33@{Array (Buf 2 FactIdentifier)} = []@{Array (Buf 2 FactIdentifier)};
-init acc$conv$4$simp$34@{Array (Buf 2 Error)} = []@{Array (Buf 2 Error)};
-init acc$conv$4$simp$35@{Array (Buf 2 Int)} = []@{Array (Buf 2 Int)};
-load_resumable@{Array Time} acc$conv$4$simp$32;
-load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$4$simp$33;
-load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$34;
-load_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$35;
-for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$104@{Error}, conv$0$simp$105@{Int}, conv$0$simp$106@{Time}) in new
+init acc$conv$4$simp$40@{Array Time} = []@{Array Time};
+init acc$conv$4$simp$41@{Array (Buf 2 FactIdentifier)} = []@{Array (Buf 2 FactIdentifier)};
+init acc$conv$4$simp$42@{Array (Buf 2 Error)} = []@{Array (Buf 2 Error)};
+init acc$conv$4$simp$43@{Array (Buf 2 Int)} = []@{Array (Buf 2 Int)};
+load_resumable@{Array Time} acc$conv$4$simp$40;
+load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$4$simp$41;
+load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$42;
+load_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$43;
+for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$117@{Error}, conv$0$simp$118@{Int}, conv$0$simp$119@{Time}) in new
 {
-  read conv$4$aval$0$simp$37 = acc$conv$4$simp$32 [Array Time];
-  read conv$4$aval$0$simp$38 = acc$conv$4$simp$33 [Array (Buf 2 FactIdentifier)];
-  read conv$4$aval$0$simp$39 = acc$conv$4$simp$34 [Array (Buf 2 Error)];
-  read conv$4$aval$0$simp$40 = acc$conv$4$simp$35 [Array (Buf 2 Int)];
-  let simp$486 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
-  let simp$271 = Buf_push#@{Buf 2 FactIdentifier} simp$486 conv$1;
-  let simp$488 = Buf_make#@{Buf 2 Error} (()@{Unit});
-  let simp$274 = Buf_push#@{Buf 2 Error} simp$488 conv$0$simp$104;
-  let simp$490 = Buf_make#@{Buf 2 Int} (()@{Unit});
-  let simp$277 = Buf_push#@{Buf 2 Int} simp$490 conv$0$simp$105;
+  read conv$4$aval$0$simp$45 = acc$conv$4$simp$40 [Array Time];
+  read conv$4$aval$0$simp$46 = acc$conv$4$simp$41 [Array (Buf 2 FactIdentifier)];
+  read conv$4$aval$0$simp$47 = acc$conv$4$simp$42 [Array (Buf 2 Error)];
+  read conv$4$aval$0$simp$48 = acc$conv$4$simp$43 [Array (Buf 2 Int)];
+  let simp$543 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
+  let simp$292 = Buf_push#@{Buf 2 FactIdentifier} simp$543 conv$1;
+  let simp$545 = Buf_make#@{Buf 2 Error} (()@{Unit});
+  let simp$295 = Buf_push#@{Buf 2 Error} simp$545 conv$0$simp$117;
+  let simp$547 = Buf_make#@{Buf 2 Int} (()@{Unit});
+  let simp$298 = Buf_push#@{Buf 2 Int} simp$547 conv$0$simp$118;
   init flat$1@{Bool} = False@{Bool};
-  init flat$2@{Array Time} = conv$4$aval$0$simp$37;
-  init flat$3$simp$42@{Array (Buf 2 FactIdentifier)} = conv$4$aval$0$simp$38;
-  init flat$3$simp$43@{Array (Buf 2 Error)} = conv$4$aval$0$simp$39;
-  init flat$3$simp$44@{Array (Buf 2 Int)} = conv$4$aval$0$simp$40;
+  init flat$2@{Array Time} = conv$4$aval$0$simp$45;
+  init flat$3$simp$50@{Array (Buf 2 FactIdentifier)} = conv$4$aval$0$simp$46;
+  init flat$3$simp$51@{Array (Buf 2 Error)} = conv$4$aval$0$simp$47;
+  init flat$3$simp$52@{Array (Buf 2 Int)} = conv$4$aval$0$simp$48;
   read flat$2 = flat$2 [Array Time];
   let flat$4 = Array_length#@{Time} flat$2;
   foreach (flat$5 in 0@{Int} .. flat$4)
   {
     read flat$2 = flat$2 [Array Time];
-    read flat$3$simp$46 = flat$3$simp$42 [Array (Buf 2 FactIdentifier)];
-    read flat$3$simp$47 = flat$3$simp$43 [Array (Buf 2 Error)];
-    read flat$3$simp$48 = flat$3$simp$44 [Array (Buf 2 Int)];
-    let simp$133 = unsafe_Array_index#@{Time} flat$2 flat$5;
-    if (eq#@{Time} simp$133 conv$0$simp$106)
+    read flat$3$simp$54 = flat$3$simp$50 [Array (Buf 2 FactIdentifier)];
+    read flat$3$simp$55 = flat$3$simp$51 [Array (Buf 2 Error)];
+    read flat$3$simp$56 = flat$3$simp$52 [Array (Buf 2 Int)];
+    let simp$146 = unsafe_Array_index#@{Time} flat$2 flat$5;
+    if (eq#@{Time} simp$146 conv$0$simp$119)
     {
-      let simp$294 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$46 flat$5;
-      let simp$296 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$47 flat$5;
-      let simp$298 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$48 flat$5;
-      let simp$319 = Buf_push#@{Buf 2 FactIdentifier} simp$294 conv$1;
-      let simp$322 = Buf_push#@{Buf 2 Error} simp$296 conv$0$simp$104;
-      let simp$325 = Buf_push#@{Buf 2 Int} simp$298 conv$0$simp$105;
-      write flat$3$simp$42 = Array_put#@{Buf 2 FactIdentifier} flat$3$simp$46 flat$5 simp$319;
-      write flat$3$simp$43 = Array_put#@{Buf 2 Error} flat$3$simp$47 flat$5 simp$322;
-      write flat$3$simp$44 = Array_put#@{Buf 2 Int} flat$3$simp$48 flat$5 simp$325;
+      let simp$315 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$54 flat$5;
+      let simp$317 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$55 flat$5;
+      let simp$319 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$56 flat$5;
+      let simp$340 = Buf_push#@{Buf 2 FactIdentifier} simp$315 conv$1;
+      let simp$343 = Buf_push#@{Buf 2 Error} simp$317 conv$0$simp$117;
+      let simp$346 = Buf_push#@{Buf 2 Int} simp$319 conv$0$simp$118;
+      write flat$3$simp$50 = Array_put#@{Buf 2 FactIdentifier} flat$3$simp$54 flat$5 simp$340;
+      write flat$3$simp$51 = Array_put#@{Buf 2 Error} flat$3$simp$55 flat$5 simp$343;
+      write flat$3$simp$52 = Array_put#@{Buf 2 Int} flat$3$simp$56 flat$5 simp$346;
       write flat$1 = True@{Bool};
     }
   }
@@ -206,163 +206,173 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$104@{Error}, conv
   else
   {
     read flat$8 = flat$2 [Array Time];
-    let simp$158 = Array_length#@{Time} flat$8;
-    write flat$2 = Array_put#@{Time} flat$8 simp$158 conv$0$simp$106;
-    read flat$9$simp$50 = flat$3$simp$42 [Array (Buf 2 FactIdentifier)];
-    read flat$9$simp$51 = flat$3$simp$43 [Array (Buf 2 Error)];
-    read flat$9$simp$52 = flat$3$simp$44 [Array (Buf 2 Int)];
-    let simp$163 = Array_length#@{Buf 2 FactIdentifier} flat$9$simp$50;
-    write flat$3$simp$42 = Array_put#@{Buf 2 FactIdentifier} flat$9$simp$50 simp$163 simp$271;
-    write flat$3$simp$43 = Array_put#@{Buf 2 Error} flat$9$simp$51 simp$163 simp$274;
-    write flat$3$simp$44 = Array_put#@{Buf 2 Int} flat$9$simp$52 simp$163 simp$277;
+    let simp$171 = Array_length#@{Time} flat$8;
+    write flat$2 = Array_put#@{Time} flat$8 simp$171 conv$0$simp$119;
+    read flat$9$simp$58 = flat$3$simp$50 [Array (Buf 2 FactIdentifier)];
+    read flat$9$simp$59 = flat$3$simp$51 [Array (Buf 2 Error)];
+    read flat$9$simp$60 = flat$3$simp$52 [Array (Buf 2 Int)];
+    let simp$176 = Array_length#@{Buf 2 FactIdentifier} flat$9$simp$58;
+    write flat$3$simp$50 = Array_put#@{Buf 2 FactIdentifier} flat$9$simp$58 simp$176 simp$292;
+    write flat$3$simp$51 = Array_put#@{Buf 2 Error} flat$9$simp$59 simp$176 simp$295;
+    write flat$3$simp$52 = Array_put#@{Buf 2 Int} flat$9$simp$60 simp$176 simp$298;
   }
   read flat$2 = flat$2 [Array Time];
-  read flat$3$simp$54 = flat$3$simp$42 [Array (Buf 2 FactIdentifier)];
-  read flat$3$simp$55 = flat$3$simp$43 [Array (Buf 2 Error)];
-  read flat$3$simp$56 = flat$3$simp$44 [Array (Buf 2 Int)];
-  write acc$conv$4$simp$32 = flat$2;
-  write acc$conv$4$simp$33 = flat$3$simp$54;
-  write acc$conv$4$simp$34 = flat$3$simp$55;
-  write acc$conv$4$simp$35 = flat$3$simp$56;
+  read flat$3$simp$62 = flat$3$simp$50 [Array (Buf 2 FactIdentifier)];
+  read flat$3$simp$63 = flat$3$simp$51 [Array (Buf 2 Error)];
+  read flat$3$simp$64 = flat$3$simp$52 [Array (Buf 2 Int)];
+  write acc$conv$4$simp$40 = flat$2;
+  write acc$conv$4$simp$41 = flat$3$simp$62;
+  write acc$conv$4$simp$42 = flat$3$simp$63;
+  write acc$conv$4$simp$43 = flat$3$simp$64;
 }
-save_resumable@{Array Time} acc$conv$4$simp$32;
-save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$4$simp$33;
-save_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$34;
-save_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$35;
-read conv$4$simp$58 = acc$conv$4$simp$32 [Array Time];
-read conv$4$simp$60 = acc$conv$4$simp$34 [Array (Buf 2 Error)];
-read conv$4$simp$61 = acc$conv$4$simp$35 [Array (Buf 2 Int)];
-init flat$17$simp$63@{Error} = ExceptNotAnError@{Error};
-init flat$17$simp$64@{Array Time} = []@{Array Time};
-init flat$17$simp$65@{Array Int} = []@{Array Int};
-foreach (flat$18 in 0@{Int} .. Array_length#@{Time} conv$4$simp$58)
+read acc$conv$4$flat$11$simp$67 = acc$conv$4$simp$41 [Array (Buf 2 FactIdentifier)];
+foreach (flat$13 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$67)
 {
-  read flat$17$simp$66 = flat$17$simp$63 [Error];
-  read flat$17$simp$67 = flat$17$simp$64 [Array Time];
-  read flat$17$simp$68 = flat$17$simp$65 [Array Int];
-  let simp$392 = unsafe_Array_index#@{Time} conv$4$simp$58 flat$18;
-  let simp$396 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$60 flat$18;
-  let simp$398 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$61 flat$18;
-  init flat$20$simp$69@{Error} = ExceptNotAnError@{Error};
-  init flat$20$simp$70@{Array Time} = []@{Array Time};
-  init flat$20$simp$71@{Array Int} = []@{Array Int};
-  if (eq#@{Error} flat$17$simp$66 (ExceptNotAnError@{Error}))
+  let simp$417 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$67 flat$13;
+  let flat$14 = Buf_read#@{Array FactIdentifier} simp$417;
+  foreach (flat$15 in 0@{Int} .. Array_length#@{FactIdentifier} flat$14)
   {
-    let simp$432 = Buf_read#@{Array Error} simp$396;
-    let simp$434 = Buf_read#@{Array Int} simp$398;
-    init flat$24$simp$74@{Error} = ExceptNotAnError@{Error};
-    init flat$24$simp$75@{Int} = 0@{Int};
-    foreach (flat$37 in 0@{Int} .. Array_length#@{Error} simp$432)
+    keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$14 flat$15;
+  }
+}
+save_resumable@{Array Time} acc$conv$4$simp$40;
+save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$4$simp$41;
+save_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$42;
+save_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$43;
+read conv$4$simp$71 = acc$conv$4$simp$40 [Array Time];
+read conv$4$simp$73 = acc$conv$4$simp$42 [Array (Buf 2 Error)];
+read conv$4$simp$74 = acc$conv$4$simp$43 [Array (Buf 2 Int)];
+init flat$23$simp$76@{Error} = ExceptNotAnError@{Error};
+init flat$23$simp$77@{Array Time} = []@{Array Time};
+init flat$23$simp$78@{Array Int} = []@{Array Int};
+foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$71)
+{
+  read flat$23$simp$79 = flat$23$simp$76 [Error];
+  read flat$23$simp$80 = flat$23$simp$77 [Array Time];
+  read flat$23$simp$81 = flat$23$simp$78 [Array Int];
+  let simp$449 = unsafe_Array_index#@{Time} conv$4$simp$71 flat$24;
+  let simp$453 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$73 flat$24;
+  let simp$455 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$74 flat$24;
+  init flat$26$simp$82@{Error} = ExceptNotAnError@{Error};
+  init flat$26$simp$83@{Array Time} = []@{Array Time};
+  init flat$26$simp$84@{Array Int} = []@{Array Int};
+  if (eq#@{Error} flat$23$simp$79 (ExceptNotAnError@{Error}))
+  {
+    let simp$489 = Buf_read#@{Array Error} simp$453;
+    let simp$491 = Buf_read#@{Array Int} simp$455;
+    init flat$30$simp$87@{Error} = ExceptNotAnError@{Error};
+    init flat$30$simp$88@{Int} = 0@{Int};
+    foreach (flat$43 in 0@{Int} .. Array_length#@{Error} simp$489)
     {
-      read flat$24$simp$78 = flat$24$simp$74 [Error];
-      read flat$24$simp$79 = flat$24$simp$75 [Int];
-      let simp$446 = unsafe_Array_index#@{Error} simp$432 flat$37;
-      let simp$448 = unsafe_Array_index#@{Int} simp$434 flat$37;
-      init flat$39$simp$80@{Error} = ExceptNotAnError@{Error};
-      init flat$39$simp$81@{Int} = 0@{Int};
-      if (eq#@{Error} simp$446 (ExceptNotAnError@{Error}))
+      read flat$30$simp$91 = flat$30$simp$87 [Error];
+      read flat$30$simp$92 = flat$30$simp$88 [Int];
+      let simp$503 = unsafe_Array_index#@{Error} simp$489 flat$43;
+      let simp$505 = unsafe_Array_index#@{Int} simp$491 flat$43;
+      init flat$45$simp$93@{Error} = ExceptNotAnError@{Error};
+      init flat$45$simp$94@{Int} = 0@{Int};
+      if (eq#@{Error} simp$503 (ExceptNotAnError@{Error}))
       {
-        init flat$42$simp$82@{Error} = ExceptNotAnError@{Error};
-        init flat$42$simp$83@{Int} = 0@{Int};
-        if (eq#@{Error} flat$24$simp$78 (ExceptNotAnError@{Error}))
+        init flat$48$simp$95@{Error} = ExceptNotAnError@{Error};
+        init flat$48$simp$96@{Int} = 0@{Int};
+        if (eq#@{Error} flat$30$simp$91 (ExceptNotAnError@{Error}))
         {
-          write flat$42$simp$82 = ExceptNotAnError@{Error};
-          write flat$42$simp$83 = add#@{Int} simp$448 flat$24$simp$79;
+          write flat$48$simp$95 = ExceptNotAnError@{Error};
+          write flat$48$simp$96 = add#@{Int} simp$505 flat$30$simp$92;
         }
         else
         {
-          write flat$42$simp$82 = flat$24$simp$78;
-          write flat$42$simp$83 = 0@{Int};
+          write flat$48$simp$95 = flat$30$simp$91;
+          write flat$48$simp$96 = 0@{Int};
         }
-        read flat$42$simp$84 = flat$42$simp$82 [Error];
-        read flat$42$simp$85 = flat$42$simp$83 [Int];
-        write flat$39$simp$80 = flat$42$simp$84;
-        write flat$39$simp$81 = flat$42$simp$85;
+        read flat$48$simp$97 = flat$48$simp$95 [Error];
+        read flat$48$simp$98 = flat$48$simp$96 [Int];
+        write flat$45$simp$93 = flat$48$simp$97;
+        write flat$45$simp$94 = flat$48$simp$98;
       }
       else
       {
-        write flat$39$simp$80 = simp$446;
-        write flat$39$simp$81 = 0@{Int};
+        write flat$45$simp$93 = simp$503;
+        write flat$45$simp$94 = 0@{Int};
       }
-      read flat$39$simp$86 = flat$39$simp$80 [Error];
-      read flat$39$simp$87 = flat$39$simp$81 [Int];
-      write flat$24$simp$74 = flat$39$simp$86;
-      write flat$24$simp$75 = flat$39$simp$87;
+      read flat$45$simp$99 = flat$45$simp$93 [Error];
+      read flat$45$simp$100 = flat$45$simp$94 [Int];
+      write flat$30$simp$87 = flat$45$simp$99;
+      write flat$30$simp$88 = flat$45$simp$100;
     }
-    read flat$24$simp$90 = flat$24$simp$74 [Error];
-    read flat$24$simp$91 = flat$24$simp$75 [Int];
-    init flat$25$simp$92@{Error} = ExceptNotAnError@{Error};
-    init flat$25$simp$93@{Array Time} = []@{Array Time};
-    init flat$25$simp$94@{Array Int} = []@{Array Int};
-    if (eq#@{Error} flat$24$simp$90 (ExceptNotAnError@{Error}))
+    read flat$30$simp$103 = flat$30$simp$87 [Error];
+    read flat$30$simp$104 = flat$30$simp$88 [Int];
+    init flat$31$simp$105@{Error} = ExceptNotAnError@{Error};
+    init flat$31$simp$106@{Array Time} = []@{Array Time};
+    init flat$31$simp$107@{Array Int} = []@{Array Int};
+    if (eq#@{Error} flat$30$simp$103 (ExceptNotAnError@{Error}))
     {
-      init flat$28@{Bool} = False@{Bool};
-      init flat$29@{Array Time} = flat$17$simp$67;
-      init flat$30@{Array Int} = flat$17$simp$68;
-      read flat$29 = flat$29 [Array Time];
-      let flat$31 = Array_length#@{Time} flat$29;
-      foreach (flat$32 in 0@{Int} .. flat$31)
+      init flat$34@{Bool} = False@{Bool};
+      init flat$35@{Array Time} = flat$23$simp$80;
+      init flat$36@{Array Int} = flat$23$simp$81;
+      read flat$35 = flat$35 [Array Time];
+      let flat$37 = Array_length#@{Time} flat$35;
+      foreach (flat$38 in 0@{Int} .. flat$37)
       {
-        read flat$29 = flat$29 [Array Time];
-        read flat$30 = flat$30 [Array Int];
-        let simp$226 = unsafe_Array_index#@{Time} flat$29 flat$32;
-        if (eq#@{Time} simp$226 simp$392)
+        read flat$35 = flat$35 [Array Time];
+        read flat$36 = flat$36 [Array Int];
+        let simp$247 = unsafe_Array_index#@{Time} flat$35 flat$38;
+        if (eq#@{Time} simp$247 simp$449)
         {
-          let flat$33 = unsafe_Array_index#@{Int} flat$30 flat$32;
-          write flat$30 = Array_put#@{Int} flat$30 flat$32 flat$33;
-          write flat$28 = True@{Bool};
+          let flat$39 = unsafe_Array_index#@{Int} flat$36 flat$38;
+          write flat$36 = Array_put#@{Int} flat$36 flat$38 flat$39;
+          write flat$34 = True@{Bool};
         }
       }
-      read flat$28 = flat$28 [Bool];
-      if (flat$28)
+      read flat$34 = flat$34 [Bool];
+      if (flat$34)
       {
         
       }
       else
       {
-        read flat$34 = flat$29 [Array Time];
-        let simp$227 = Array_length#@{Time} flat$34;
-        write flat$29 = Array_put#@{Time} flat$34 simp$227 simp$392;
-        read flat$35 = flat$30 [Array Int];
-        let simp$228 = Array_length#@{Int} flat$35;
-        write flat$30 = Array_put#@{Int} flat$35 simp$228 flat$24$simp$91;
+        read flat$40 = flat$35 [Array Time];
+        let simp$248 = Array_length#@{Time} flat$40;
+        write flat$35 = Array_put#@{Time} flat$40 simp$248 simp$449;
+        read flat$41 = flat$36 [Array Int];
+        let simp$249 = Array_length#@{Int} flat$41;
+        write flat$36 = Array_put#@{Int} flat$41 simp$249 flat$30$simp$104;
       }
-      read flat$29 = flat$29 [Array Time];
-      read flat$30 = flat$30 [Array Int];
-      write flat$25$simp$92 = ExceptNotAnError@{Error};
-      write flat$25$simp$93 = flat$29;
-      write flat$25$simp$94 = flat$30;
+      read flat$35 = flat$35 [Array Time];
+      read flat$36 = flat$36 [Array Int];
+      write flat$31$simp$105 = ExceptNotAnError@{Error};
+      write flat$31$simp$106 = flat$35;
+      write flat$31$simp$107 = flat$36;
     }
     else
     {
-      write flat$25$simp$92 = flat$24$simp$90;
-      write flat$25$simp$93 = unsafe_Array_create#@{Time} (0@{Int});
-      write flat$25$simp$94 = unsafe_Array_create#@{Int} (0@{Int});
+      write flat$31$simp$105 = flat$30$simp$103;
+      write flat$31$simp$106 = unsafe_Array_create#@{Time} (0@{Int});
+      write flat$31$simp$107 = unsafe_Array_create#@{Int} (0@{Int});
     }
-    read flat$25$simp$95 = flat$25$simp$92 [Error];
-    read flat$25$simp$96 = flat$25$simp$93 [Array Time];
-    read flat$25$simp$97 = flat$25$simp$94 [Array Int];
-    write flat$20$simp$69 = flat$25$simp$95;
-    write flat$20$simp$70 = flat$25$simp$96;
-    write flat$20$simp$71 = flat$25$simp$97;
+    read flat$31$simp$108 = flat$31$simp$105 [Error];
+    read flat$31$simp$109 = flat$31$simp$106 [Array Time];
+    read flat$31$simp$110 = flat$31$simp$107 [Array Int];
+    write flat$26$simp$82 = flat$31$simp$108;
+    write flat$26$simp$83 = flat$31$simp$109;
+    write flat$26$simp$84 = flat$31$simp$110;
   }
   else
   {
-    write flat$20$simp$69 = flat$17$simp$66;
-    write flat$20$simp$70 = unsafe_Array_create#@{Time} (0@{Int});
-    write flat$20$simp$71 = unsafe_Array_create#@{Int} (0@{Int});
+    write flat$26$simp$82 = flat$23$simp$79;
+    write flat$26$simp$83 = unsafe_Array_create#@{Time} (0@{Int});
+    write flat$26$simp$84 = unsafe_Array_create#@{Int} (0@{Int});
   }
-  read flat$20$simp$98 = flat$20$simp$69 [Error];
-  read flat$20$simp$99 = flat$20$simp$70 [Array Time];
-  read flat$20$simp$100 = flat$20$simp$71 [Array Int];
-  write flat$17$simp$63 = flat$20$simp$98;
-  write flat$17$simp$64 = flat$20$simp$99;
-  write flat$17$simp$65 = flat$20$simp$100;
+  read flat$26$simp$111 = flat$26$simp$82 [Error];
+  read flat$26$simp$112 = flat$26$simp$83 [Array Time];
+  read flat$26$simp$113 = flat$26$simp$84 [Array Int];
+  write flat$23$simp$76 = flat$26$simp$111;
+  write flat$23$simp$77 = flat$26$simp$112;
+  write flat$23$simp$78 = flat$26$simp$113;
 }
-read flat$17$simp$101 = flat$17$simp$63 [Error];
-read flat$17$simp$102 = flat$17$simp$64 [Array Time];
-read flat$17$simp$103 = flat$17$simp$65 [Array Int];
-output@{(Sum Error (Map Time Int))} repl (flat$17$simp$101@{Error}, flat$17$simp$102@{Array Time}, flat$17$simp$103@{Array Int});
+read flat$23$simp$114 = flat$23$simp$76 [Error];
+read flat$23$simp$115 = flat$23$simp$77 [Array Time];
+read flat$23$simp$116 = flat$23$simp$78 [Array Int];
+output@{(Sum Error (Map Time Int))} repl (flat$23$simp$114@{Error}, flat$23$simp$115@{Array Time}, flat$23$simp$116@{Array Int});
 
 - Core evaluation:
 [homer, [(1989-12-17,100)

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -7,36 +7,38 @@ ok, flatten is now on
 > > -- A rather complicated feature to convert to Avalanche
 > - Flattened:
 conv$3 = TIME
-init acc$conv$10$simp$14@{Error} = ExceptNotAnError@{Error};
-init acc$c$conv$11$simp$19@{Error} = ExceptNotAnError@{Error};
-init acc$c$conv$11$simp$20@{Int} = 0@{Int};
-init acc$conv$26$simp$22@{Buf 3 Error} = Buf []@{Buf 3 Error};
-init acc$conv$26$simp$23@{Buf 3 Int} = Buf []@{Buf 3 Int};
-load_resumable@{Buf 3 Error} acc$conv$26$simp$22;
-load_resumable@{Buf 3 Int} acc$conv$26$simp$23;
-load_resumable@{Error} acc$c$conv$11$simp$19;
-load_resumable@{Int} acc$c$conv$11$simp$20;
-load_resumable@{Error} acc$conv$10$simp$14;
-for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$63@{Error}, conv$0$simp$64@{Int}, conv$0$simp$65@{Time}) in new
+init acc$conv$10$simp$16@{Error} = ExceptNotAnError@{Error};
+init acc$c$conv$11$simp$21@{Error} = ExceptNotAnError@{Error};
+init acc$c$conv$11$simp$22@{Int} = 0@{Int};
+init acc$conv$26$simp$23@{Buf 3 FactIdentifier} = Buf []@{Buf 3 FactIdentifier};
+init acc$conv$26$simp$24@{Buf 3 Error} = Buf []@{Buf 3 Error};
+init acc$conv$26$simp$25@{Buf 3 Int} = Buf []@{Buf 3 Int};
+load_resumable@{Buf 3 FactIdentifier} acc$conv$26$simp$23;
+load_resumable@{Buf 3 Error} acc$conv$26$simp$24;
+load_resumable@{Buf 3 Int} acc$conv$26$simp$25;
+load_resumable@{Error} acc$c$conv$11$simp$21;
+load_resumable@{Int} acc$c$conv$11$simp$22;
+load_resumable@{Error} acc$conv$10$simp$16;
+for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$68@{Error}, conv$0$simp$69@{Int}, conv$0$simp$70@{Time}) in new
 {
-  init flat$0$simp$24@{Error} = ExceptNotAnError@{Error};
-  init flat$0$simp$25@{Bool} = False@{Bool};
-  if (eq#@{Error} conv$0$simp$63 (ExceptNotAnError@{Error}))
+  init flat$0$simp$26@{Error} = ExceptNotAnError@{Error};
+  init flat$0$simp$27@{Bool} = False@{Bool};
+  if (eq#@{Error} conv$0$simp$68 (ExceptNotAnError@{Error}))
   {
-    write flat$0$simp$24 = ExceptNotAnError@{Error};
-    write flat$0$simp$25 = gt#@{Int} conv$0$simp$64 (10@{Int});
+    write flat$0$simp$26 = ExceptNotAnError@{Error};
+    write flat$0$simp$27 = gt#@{Int} conv$0$simp$69 (10@{Int});
   }
   else
   {
-    write flat$0$simp$24 = conv$0$simp$63;
-    write flat$0$simp$25 = False@{Bool};
+    write flat$0$simp$26 = conv$0$simp$68;
+    write flat$0$simp$27 = False@{Bool};
   }
-  read flat$0$simp$26 = flat$0$simp$24 [Error];
-  read flat$0$simp$27 = flat$0$simp$25 [Bool];
+  read flat$0$simp$28 = flat$0$simp$26 [Error];
+  read flat$0$simp$29 = flat$0$simp$27 [Bool];
   init flat$1@{Bool} = False@{Bool};
-  if (eq#@{Error} flat$0$simp$26 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} flat$0$simp$28 (ExceptNotAnError@{Error}))
   {
-    write flat$1 = flat$0$simp$27;
+    write flat$1 = flat$0$simp$29;
   }
   else
   {
@@ -45,92 +47,101 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$63@{Error}, conv$
   read flat$1 = flat$1 [Bool];
   if (flat$1)
   {
-    write acc$conv$10$simp$14 = conv$0$simp$63;
-    read aval$1$simp$28 = acc$conv$10$simp$14 [Error];
-    read aval$0$simp$33 = acc$c$conv$11$simp$19 [Error];
-    read aval$0$simp$34 = acc$c$conv$11$simp$20 [Int];
-    init flat$2$simp$35@{Error} = ExceptNotAnError@{Error};
-    init flat$2$simp$36@{Int} = 0@{Int};
-    if (eq#@{Error} aval$1$simp$28 (ExceptNotAnError@{Error}))
+    write acc$conv$10$simp$16 = conv$0$simp$68;
+    read conv$10$aval$1$simp$30 = acc$conv$10$simp$16 [Error];
+    read c$conv$11$aval$0$simp$35 = acc$c$conv$11$simp$21 [Error];
+    read c$conv$11$aval$0$simp$36 = acc$c$conv$11$simp$22 [Int];
+    init flat$2$simp$37@{Error} = ExceptNotAnError@{Error};
+    init flat$2$simp$38@{Int} = 0@{Int};
+    if (eq#@{Error} conv$10$aval$1$simp$30 (ExceptNotAnError@{Error}))
     {
-      init flat$5$simp$37@{Error} = ExceptNotAnError@{Error};
-      init flat$5$simp$38@{Int} = 0@{Int};
-      if (eq#@{Error} aval$0$simp$33 (ExceptNotAnError@{Error}))
+      init flat$5$simp$39@{Error} = ExceptNotAnError@{Error};
+      init flat$5$simp$40@{Int} = 0@{Int};
+      if (eq#@{Error} c$conv$11$aval$0$simp$35 (ExceptNotAnError@{Error}))
       {
-        write flat$5$simp$37 = ExceptNotAnError@{Error};
-        write flat$5$simp$38 = add#@{Int} aval$0$simp$34 (1@{Int});
+        write flat$5$simp$39 = ExceptNotAnError@{Error};
+        write flat$5$simp$40 = add#@{Int} c$conv$11$aval$0$simp$36 (1@{Int});
       }
       else
       {
-        write flat$5$simp$37 = aval$0$simp$33;
-        write flat$5$simp$38 = 0@{Int};
+        write flat$5$simp$39 = c$conv$11$aval$0$simp$35;
+        write flat$5$simp$40 = 0@{Int};
       }
-      read flat$5$simp$39 = flat$5$simp$37 [Error];
-      read flat$5$simp$40 = flat$5$simp$38 [Int];
-      init flat$6$simp$41@{Error} = ExceptNotAnError@{Error};
-      init flat$6$simp$42@{Int} = 0@{Int};
-      if (eq#@{Error} flat$5$simp$39 (ExceptNotAnError@{Error}))
+      read flat$5$simp$41 = flat$5$simp$39 [Error];
+      read flat$5$simp$42 = flat$5$simp$40 [Int];
+      init flat$6$simp$43@{Error} = ExceptNotAnError@{Error};
+      init flat$6$simp$44@{Int} = 0@{Int};
+      if (eq#@{Error} flat$5$simp$41 (ExceptNotAnError@{Error}))
       {
-        write flat$6$simp$41 = ExceptNotAnError@{Error};
-        write flat$6$simp$42 = flat$5$simp$40;
+        write flat$6$simp$43 = ExceptNotAnError@{Error};
+        write flat$6$simp$44 = flat$5$simp$42;
       }
       else
       {
-        write flat$6$simp$41 = flat$5$simp$39;
-        write flat$6$simp$42 = 0@{Int};
+        write flat$6$simp$43 = flat$5$simp$41;
+        write flat$6$simp$44 = 0@{Int};
       }
-      read flat$6$simp$43 = flat$6$simp$41 [Error];
-      read flat$6$simp$44 = flat$6$simp$42 [Int];
-      write flat$2$simp$35 = flat$6$simp$43;
-      write flat$2$simp$36 = flat$6$simp$44;
+      read flat$6$simp$45 = flat$6$simp$43 [Error];
+      read flat$6$simp$46 = flat$6$simp$44 [Int];
+      write flat$2$simp$37 = flat$6$simp$45;
+      write flat$2$simp$38 = flat$6$simp$46;
     }
     else
     {
-      write flat$2$simp$35 = aval$1$simp$28;
-      write flat$2$simp$36 = 0@{Int};
+      write flat$2$simp$37 = conv$10$aval$1$simp$30;
+      write flat$2$simp$38 = 0@{Int};
     }
-    read flat$2$simp$45 = flat$2$simp$35 [Error];
-    read flat$2$simp$46 = flat$2$simp$36 [Int];
-    write acc$c$conv$11$simp$19 = flat$2$simp$45;
-    write acc$c$conv$11$simp$20 = flat$2$simp$46;
+    read flat$2$simp$47 = flat$2$simp$37 [Error];
+    read flat$2$simp$48 = flat$2$simp$38 [Int];
+    write acc$c$conv$11$simp$21 = flat$2$simp$47;
+    write acc$c$conv$11$simp$22 = flat$2$simp$48;
   }
-  read acc$conv$26$simp$22 = acc$conv$26$simp$22 [Buf 3 Error];
-  write acc$conv$26$simp$22 = Buf_push#@{Buf 3 Error} acc$conv$26$simp$22 conv$0$simp$63;
-  read acc$conv$26$simp$23 = acc$conv$26$simp$23 [Buf 3 Int];
-  write acc$conv$26$simp$23 = Buf_push#@{Buf 3 Int} acc$conv$26$simp$23 conv$0$simp$64;
+  read acc$conv$26$simp$23 = acc$conv$26$simp$23 [Buf 3 FactIdentifier];
+  write acc$conv$26$simp$23 = Buf_push#@{Buf 3 FactIdentifier} acc$conv$26$simp$23 conv$1;
+  read acc$conv$26$simp$24 = acc$conv$26$simp$24 [Buf 3 Error];
+  write acc$conv$26$simp$24 = Buf_push#@{Buf 3 Error} acc$conv$26$simp$24 conv$0$simp$68;
+  read acc$conv$26$simp$25 = acc$conv$26$simp$25 [Buf 3 Int];
+  write acc$conv$26$simp$25 = Buf_push#@{Buf 3 Int} acc$conv$26$simp$25 conv$0$simp$69;
 }
-save_resumable@{Buf 3 Error} acc$conv$26$simp$22;
-save_resumable@{Buf 3 Int} acc$conv$26$simp$23;
-save_resumable@{Error} acc$c$conv$11$simp$19;
-save_resumable@{Int} acc$c$conv$11$simp$20;
-save_resumable@{Error} acc$conv$10$simp$14;
-read conv$26$simp$51 = acc$conv$26$simp$22 [Buf 3 Error];
-read conv$26$simp$52 = acc$conv$26$simp$23 [Buf 3 Int];
-read c$conv$11$simp$53 = acc$c$conv$11$simp$19 [Error];
-read c$conv$11$simp$54 = acc$c$conv$11$simp$20 [Int];
-init flat$16$simp$55@{Error} = ExceptNotAnError@{Error};
-init flat$16$simp$56@{Int} = 0@{Int};
-init flat$16$simp$57@{Array Error} = []@{Array Error};
-init flat$16$simp$58@{Array Int} = []@{Array Int};
-if (eq#@{Error} c$conv$11$simp$53 (ExceptNotAnError@{Error}))
+read acc$conv$26$flat$16$simp$52 = acc$conv$26$simp$23 [Buf 3 FactIdentifier];
+let flat$17 = Buf_read#@{Array FactIdentifier} acc$conv$26$flat$16$simp$52;
+foreach (flat$18 in 0@{Int} .. Array_length#@{FactIdentifier} flat$17)
 {
-  write flat$16$simp$55 = ExceptNotAnError@{Error};
-  write flat$16$simp$56 = c$conv$11$simp$54;
-  write flat$16$simp$57 = Buf_read#@{Array Error} conv$26$simp$51;
-  write flat$16$simp$58 = Buf_read#@{Array Int} conv$26$simp$52;
+  keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$17 flat$18;
+}
+save_resumable@{Buf 3 FactIdentifier} acc$conv$26$simp$23;
+save_resumable@{Buf 3 Error} acc$conv$26$simp$24;
+save_resumable@{Buf 3 Int} acc$conv$26$simp$25;
+save_resumable@{Error} acc$c$conv$11$simp$21;
+save_resumable@{Int} acc$c$conv$11$simp$22;
+save_resumable@{Error} acc$conv$10$simp$16;
+read conv$26$simp$56 = acc$conv$26$simp$24 [Buf 3 Error];
+read conv$26$simp$57 = acc$conv$26$simp$25 [Buf 3 Int];
+read c$conv$11$simp$58 = acc$c$conv$11$simp$21 [Error];
+read c$conv$11$simp$59 = acc$c$conv$11$simp$22 [Int];
+init flat$23$simp$60@{Error} = ExceptNotAnError@{Error};
+init flat$23$simp$61@{Int} = 0@{Int};
+init flat$23$simp$62@{Array Error} = []@{Array Error};
+init flat$23$simp$63@{Array Int} = []@{Array Int};
+if (eq#@{Error} c$conv$11$simp$58 (ExceptNotAnError@{Error}))
+{
+  write flat$23$simp$60 = ExceptNotAnError@{Error};
+  write flat$23$simp$61 = c$conv$11$simp$59;
+  write flat$23$simp$62 = Buf_read#@{Array Error} conv$26$simp$56;
+  write flat$23$simp$63 = Buf_read#@{Array Int} conv$26$simp$57;
 }
 else
 {
-  write flat$16$simp$55 = c$conv$11$simp$53;
-  write flat$16$simp$56 = 0@{Int};
-  write flat$16$simp$57 = unsafe_Array_create#@{Error} (0@{Int});
-  write flat$16$simp$58 = unsafe_Array_create#@{Int} (0@{Int});
+  write flat$23$simp$60 = c$conv$11$simp$58;
+  write flat$23$simp$61 = 0@{Int};
+  write flat$23$simp$62 = unsafe_Array_create#@{Error} (0@{Int});
+  write flat$23$simp$63 = unsafe_Array_create#@{Int} (0@{Int});
 }
-read flat$16$simp$59 = flat$16$simp$55 [Error];
-read flat$16$simp$60 = flat$16$simp$56 [Int];
-read flat$16$simp$61 = flat$16$simp$57 [Array Error];
-read flat$16$simp$62 = flat$16$simp$58 [Array Int];
-output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$16$simp$59@{Error}, flat$16$simp$60@{Int}, flat$16$simp$61@{Array Error}, flat$16$simp$62@{Array Int});
+read flat$23$simp$64 = flat$23$simp$60 [Error];
+read flat$23$simp$65 = flat$23$simp$61 [Int];
+read flat$23$simp$66 = flat$23$simp$62 [Array Error];
+read flat$23$simp$67 = flat$23$simp$63 [Array Int];
+output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$23$simp$64@{Error}, flat$23$simp$65@{Int}, flat$23$simp$66@{Array Error}, flat$23$simp$67@{Array Int});
 
 - Core evaluation:
 [homer, (5,[300,400,500])
@@ -149,10 +160,10 @@ load_resumable@{Array (Buf 2 Error)} acc$conv$4$simp$34;
 load_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$35;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$104@{Error}, conv$0$simp$105@{Int}, conv$0$simp$106@{Time}) in new
 {
-  read aval$0$simp$37 = acc$conv$4$simp$32 [Array Time];
-  read aval$0$simp$38 = acc$conv$4$simp$33 [Array (Buf 2 FactIdentifier)];
-  read aval$0$simp$39 = acc$conv$4$simp$34 [Array (Buf 2 Error)];
-  read aval$0$simp$40 = acc$conv$4$simp$35 [Array (Buf 2 Int)];
+  read conv$4$aval$0$simp$37 = acc$conv$4$simp$32 [Array Time];
+  read conv$4$aval$0$simp$38 = acc$conv$4$simp$33 [Array (Buf 2 FactIdentifier)];
+  read conv$4$aval$0$simp$39 = acc$conv$4$simp$34 [Array (Buf 2 Error)];
+  read conv$4$aval$0$simp$40 = acc$conv$4$simp$35 [Array (Buf 2 Int)];
   let simp$486 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
   let simp$271 = Buf_push#@{Buf 2 FactIdentifier} simp$486 conv$1;
   let simp$488 = Buf_make#@{Buf 2 Error} (()@{Unit});
@@ -160,10 +171,10 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$104@{Error}, conv
   let simp$490 = Buf_make#@{Buf 2 Int} (()@{Unit});
   let simp$277 = Buf_push#@{Buf 2 Int} simp$490 conv$0$simp$105;
   init flat$1@{Bool} = False@{Bool};
-  init flat$2@{Array Time} = aval$0$simp$37;
-  init flat$3$simp$42@{Array (Buf 2 FactIdentifier)} = aval$0$simp$38;
-  init flat$3$simp$43@{Array (Buf 2 Error)} = aval$0$simp$39;
-  init flat$3$simp$44@{Array (Buf 2 Int)} = aval$0$simp$40;
+  init flat$2@{Array Time} = conv$4$aval$0$simp$37;
+  init flat$3$simp$42@{Array (Buf 2 FactIdentifier)} = conv$4$aval$0$simp$38;
+  init flat$3$simp$43@{Array (Buf 2 Error)} = conv$4$aval$0$simp$39;
+  init flat$3$simp$44@{Array (Buf 2 Int)} = conv$4$aval$0$simp$40;
   read flat$2 = flat$2 [Array Time];
   let flat$4 = Array_length#@{Time} flat$2;
   foreach (flat$5 in 0@{Int} .. flat$4)
@@ -221,137 +232,137 @@ save_resumable@{Array (Buf 2 Int)} acc$conv$4$simp$35;
 read conv$4$simp$58 = acc$conv$4$simp$32 [Array Time];
 read conv$4$simp$60 = acc$conv$4$simp$34 [Array (Buf 2 Error)];
 read conv$4$simp$61 = acc$conv$4$simp$35 [Array (Buf 2 Int)];
-init flat$16$simp$63@{Error} = ExceptNotAnError@{Error};
-init flat$16$simp$64@{Array Time} = []@{Array Time};
-init flat$16$simp$65@{Array Int} = []@{Array Int};
-foreach (flat$17 in 0@{Int} .. Array_length#@{Time} conv$4$simp$58)
+init flat$17$simp$63@{Error} = ExceptNotAnError@{Error};
+init flat$17$simp$64@{Array Time} = []@{Array Time};
+init flat$17$simp$65@{Array Int} = []@{Array Int};
+foreach (flat$18 in 0@{Int} .. Array_length#@{Time} conv$4$simp$58)
 {
-  read flat$16$simp$66 = flat$16$simp$63 [Error];
-  read flat$16$simp$67 = flat$16$simp$64 [Array Time];
-  read flat$16$simp$68 = flat$16$simp$65 [Array Int];
-  let simp$392 = unsafe_Array_index#@{Time} conv$4$simp$58 flat$17;
-  let simp$396 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$60 flat$17;
-  let simp$398 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$61 flat$17;
-  init flat$19$simp$69@{Error} = ExceptNotAnError@{Error};
-  init flat$19$simp$70@{Array Time} = []@{Array Time};
-  init flat$19$simp$71@{Array Int} = []@{Array Int};
-  if (eq#@{Error} flat$16$simp$66 (ExceptNotAnError@{Error}))
+  read flat$17$simp$66 = flat$17$simp$63 [Error];
+  read flat$17$simp$67 = flat$17$simp$64 [Array Time];
+  read flat$17$simp$68 = flat$17$simp$65 [Array Int];
+  let simp$392 = unsafe_Array_index#@{Time} conv$4$simp$58 flat$18;
+  let simp$396 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$60 flat$18;
+  let simp$398 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$61 flat$18;
+  init flat$20$simp$69@{Error} = ExceptNotAnError@{Error};
+  init flat$20$simp$70@{Array Time} = []@{Array Time};
+  init flat$20$simp$71@{Array Int} = []@{Array Int};
+  if (eq#@{Error} flat$17$simp$66 (ExceptNotAnError@{Error}))
   {
     let simp$432 = Buf_read#@{Array Error} simp$396;
     let simp$434 = Buf_read#@{Array Int} simp$398;
-    init flat$23$simp$74@{Error} = ExceptNotAnError@{Error};
-    init flat$23$simp$75@{Int} = 0@{Int};
-    foreach (flat$36 in 0@{Int} .. Array_length#@{Error} simp$432)
+    init flat$24$simp$74@{Error} = ExceptNotAnError@{Error};
+    init flat$24$simp$75@{Int} = 0@{Int};
+    foreach (flat$37 in 0@{Int} .. Array_length#@{Error} simp$432)
     {
-      read flat$23$simp$78 = flat$23$simp$74 [Error];
-      read flat$23$simp$79 = flat$23$simp$75 [Int];
-      let simp$446 = unsafe_Array_index#@{Error} simp$432 flat$36;
-      let simp$448 = unsafe_Array_index#@{Int} simp$434 flat$36;
-      init flat$38$simp$80@{Error} = ExceptNotAnError@{Error};
-      init flat$38$simp$81@{Int} = 0@{Int};
+      read flat$24$simp$78 = flat$24$simp$74 [Error];
+      read flat$24$simp$79 = flat$24$simp$75 [Int];
+      let simp$446 = unsafe_Array_index#@{Error} simp$432 flat$37;
+      let simp$448 = unsafe_Array_index#@{Int} simp$434 flat$37;
+      init flat$39$simp$80@{Error} = ExceptNotAnError@{Error};
+      init flat$39$simp$81@{Int} = 0@{Int};
       if (eq#@{Error} simp$446 (ExceptNotAnError@{Error}))
       {
-        init flat$41$simp$82@{Error} = ExceptNotAnError@{Error};
-        init flat$41$simp$83@{Int} = 0@{Int};
-        if (eq#@{Error} flat$23$simp$78 (ExceptNotAnError@{Error}))
+        init flat$42$simp$82@{Error} = ExceptNotAnError@{Error};
+        init flat$42$simp$83@{Int} = 0@{Int};
+        if (eq#@{Error} flat$24$simp$78 (ExceptNotAnError@{Error}))
         {
-          write flat$41$simp$82 = ExceptNotAnError@{Error};
-          write flat$41$simp$83 = add#@{Int} simp$448 flat$23$simp$79;
+          write flat$42$simp$82 = ExceptNotAnError@{Error};
+          write flat$42$simp$83 = add#@{Int} simp$448 flat$24$simp$79;
         }
         else
         {
-          write flat$41$simp$82 = flat$23$simp$78;
-          write flat$41$simp$83 = 0@{Int};
+          write flat$42$simp$82 = flat$24$simp$78;
+          write flat$42$simp$83 = 0@{Int};
         }
-        read flat$41$simp$84 = flat$41$simp$82 [Error];
-        read flat$41$simp$85 = flat$41$simp$83 [Int];
-        write flat$38$simp$80 = flat$41$simp$84;
-        write flat$38$simp$81 = flat$41$simp$85;
+        read flat$42$simp$84 = flat$42$simp$82 [Error];
+        read flat$42$simp$85 = flat$42$simp$83 [Int];
+        write flat$39$simp$80 = flat$42$simp$84;
+        write flat$39$simp$81 = flat$42$simp$85;
       }
       else
       {
-        write flat$38$simp$80 = simp$446;
-        write flat$38$simp$81 = 0@{Int};
+        write flat$39$simp$80 = simp$446;
+        write flat$39$simp$81 = 0@{Int};
       }
-      read flat$38$simp$86 = flat$38$simp$80 [Error];
-      read flat$38$simp$87 = flat$38$simp$81 [Int];
-      write flat$23$simp$74 = flat$38$simp$86;
-      write flat$23$simp$75 = flat$38$simp$87;
+      read flat$39$simp$86 = flat$39$simp$80 [Error];
+      read flat$39$simp$87 = flat$39$simp$81 [Int];
+      write flat$24$simp$74 = flat$39$simp$86;
+      write flat$24$simp$75 = flat$39$simp$87;
     }
-    read flat$23$simp$90 = flat$23$simp$74 [Error];
-    read flat$23$simp$91 = flat$23$simp$75 [Int];
-    init flat$24$simp$92@{Error} = ExceptNotAnError@{Error};
-    init flat$24$simp$93@{Array Time} = []@{Array Time};
-    init flat$24$simp$94@{Array Int} = []@{Array Int};
-    if (eq#@{Error} flat$23$simp$90 (ExceptNotAnError@{Error}))
+    read flat$24$simp$90 = flat$24$simp$74 [Error];
+    read flat$24$simp$91 = flat$24$simp$75 [Int];
+    init flat$25$simp$92@{Error} = ExceptNotAnError@{Error};
+    init flat$25$simp$93@{Array Time} = []@{Array Time};
+    init flat$25$simp$94@{Array Int} = []@{Array Int};
+    if (eq#@{Error} flat$24$simp$90 (ExceptNotAnError@{Error}))
     {
-      init flat$27@{Bool} = False@{Bool};
-      init flat$28@{Array Time} = flat$16$simp$67;
-      init flat$29@{Array Int} = flat$16$simp$68;
-      read flat$28 = flat$28 [Array Time];
-      let flat$30 = Array_length#@{Time} flat$28;
-      foreach (flat$31 in 0@{Int} .. flat$30)
+      init flat$28@{Bool} = False@{Bool};
+      init flat$29@{Array Time} = flat$17$simp$67;
+      init flat$30@{Array Int} = flat$17$simp$68;
+      read flat$29 = flat$29 [Array Time];
+      let flat$31 = Array_length#@{Time} flat$29;
+      foreach (flat$32 in 0@{Int} .. flat$31)
       {
-        read flat$28 = flat$28 [Array Time];
-        read flat$29 = flat$29 [Array Int];
-        let simp$226 = unsafe_Array_index#@{Time} flat$28 flat$31;
+        read flat$29 = flat$29 [Array Time];
+        read flat$30 = flat$30 [Array Int];
+        let simp$226 = unsafe_Array_index#@{Time} flat$29 flat$32;
         if (eq#@{Time} simp$226 simp$392)
         {
-          let flat$32 = unsafe_Array_index#@{Int} flat$29 flat$31;
-          write flat$29 = Array_put#@{Int} flat$29 flat$31 flat$32;
-          write flat$27 = True@{Bool};
+          let flat$33 = unsafe_Array_index#@{Int} flat$30 flat$32;
+          write flat$30 = Array_put#@{Int} flat$30 flat$32 flat$33;
+          write flat$28 = True@{Bool};
         }
       }
-      read flat$27 = flat$27 [Bool];
-      if (flat$27)
+      read flat$28 = flat$28 [Bool];
+      if (flat$28)
       {
         
       }
       else
       {
-        read flat$33 = flat$28 [Array Time];
-        let simp$227 = Array_length#@{Time} flat$33;
-        write flat$28 = Array_put#@{Time} flat$33 simp$227 simp$392;
-        read flat$34 = flat$29 [Array Int];
-        let simp$228 = Array_length#@{Int} flat$34;
-        write flat$29 = Array_put#@{Int} flat$34 simp$228 flat$23$simp$91;
+        read flat$34 = flat$29 [Array Time];
+        let simp$227 = Array_length#@{Time} flat$34;
+        write flat$29 = Array_put#@{Time} flat$34 simp$227 simp$392;
+        read flat$35 = flat$30 [Array Int];
+        let simp$228 = Array_length#@{Int} flat$35;
+        write flat$30 = Array_put#@{Int} flat$35 simp$228 flat$24$simp$91;
       }
-      read flat$28 = flat$28 [Array Time];
-      read flat$29 = flat$29 [Array Int];
-      write flat$24$simp$92 = ExceptNotAnError@{Error};
-      write flat$24$simp$93 = flat$28;
-      write flat$24$simp$94 = flat$29;
+      read flat$29 = flat$29 [Array Time];
+      read flat$30 = flat$30 [Array Int];
+      write flat$25$simp$92 = ExceptNotAnError@{Error};
+      write flat$25$simp$93 = flat$29;
+      write flat$25$simp$94 = flat$30;
     }
     else
     {
-      write flat$24$simp$92 = flat$23$simp$90;
-      write flat$24$simp$93 = unsafe_Array_create#@{Time} (0@{Int});
-      write flat$24$simp$94 = unsafe_Array_create#@{Int} (0@{Int});
+      write flat$25$simp$92 = flat$24$simp$90;
+      write flat$25$simp$93 = unsafe_Array_create#@{Time} (0@{Int});
+      write flat$25$simp$94 = unsafe_Array_create#@{Int} (0@{Int});
     }
-    read flat$24$simp$95 = flat$24$simp$92 [Error];
-    read flat$24$simp$96 = flat$24$simp$93 [Array Time];
-    read flat$24$simp$97 = flat$24$simp$94 [Array Int];
-    write flat$19$simp$69 = flat$24$simp$95;
-    write flat$19$simp$70 = flat$24$simp$96;
-    write flat$19$simp$71 = flat$24$simp$97;
+    read flat$25$simp$95 = flat$25$simp$92 [Error];
+    read flat$25$simp$96 = flat$25$simp$93 [Array Time];
+    read flat$25$simp$97 = flat$25$simp$94 [Array Int];
+    write flat$20$simp$69 = flat$25$simp$95;
+    write flat$20$simp$70 = flat$25$simp$96;
+    write flat$20$simp$71 = flat$25$simp$97;
   }
   else
   {
-    write flat$19$simp$69 = flat$16$simp$66;
-    write flat$19$simp$70 = unsafe_Array_create#@{Time} (0@{Int});
-    write flat$19$simp$71 = unsafe_Array_create#@{Int} (0@{Int});
+    write flat$20$simp$69 = flat$17$simp$66;
+    write flat$20$simp$70 = unsafe_Array_create#@{Time} (0@{Int});
+    write flat$20$simp$71 = unsafe_Array_create#@{Int} (0@{Int});
   }
-  read flat$19$simp$98 = flat$19$simp$69 [Error];
-  read flat$19$simp$99 = flat$19$simp$70 [Array Time];
-  read flat$19$simp$100 = flat$19$simp$71 [Array Int];
-  write flat$16$simp$63 = flat$19$simp$98;
-  write flat$16$simp$64 = flat$19$simp$99;
-  write flat$16$simp$65 = flat$19$simp$100;
+  read flat$20$simp$98 = flat$20$simp$69 [Error];
+  read flat$20$simp$99 = flat$20$simp$70 [Array Time];
+  read flat$20$simp$100 = flat$20$simp$71 [Array Int];
+  write flat$17$simp$63 = flat$20$simp$98;
+  write flat$17$simp$64 = flat$20$simp$99;
+  write flat$17$simp$65 = flat$20$simp$100;
 }
-read flat$16$simp$101 = flat$16$simp$63 [Error];
-read flat$16$simp$102 = flat$16$simp$64 [Array Time];
-read flat$16$simp$103 = flat$16$simp$65 [Array Int];
-output@{(Sum Error (Map Time Int))} repl (flat$16$simp$101@{Error}, flat$16$simp$102@{Array Time}, flat$16$simp$103@{Array Int});
+read flat$17$simp$101 = flat$17$simp$63 [Error];
+read flat$17$simp$102 = flat$17$simp$64 [Array Time];
+read flat$17$simp$103 = flat$17$simp$65 [Array Int];
+output@{(Sum Error (Map Time Int))} repl (flat$17$simp$101@{Error}, flat$17$simp$102@{Array Time}, flat$17$simp$103@{Array Int});
 
 - Core evaluation:
 [homer, [(1989-12-17,100)

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -91,49 +91,49 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
   read flat$1$simp$118 = flat$1$simp$116 [Double];
   write acc$conv$7$simp$66 = flat$1$simp$117;
   write acc$conv$7$simp$67 = flat$1$simp$118;
-  read aval$0$simp$119 = acc$conv$7$simp$66 [Error];
-  read aval$0$simp$120 = acc$conv$7$simp$67 [Double];
+  read conv$7$aval$0$simp$119 = acc$conv$7$simp$66 [Error];
+  read conv$7$aval$0$simp$120 = acc$conv$7$simp$67 [Double];
   init flat$2$simp$125@{Error} = ExceptNotAnError@{Error};
   init flat$2$simp$126@{Double} = 0.0@{Double};
-  if (eq#@{Error} aval$0$simp$119 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} conv$7$aval$0$simp$119 (ExceptNotAnError@{Error}))
   {
     write flat$2$simp$125 = ExceptNotAnError@{Error};
-    write flat$2$simp$126 = aval$0$simp$120;
+    write flat$2$simp$126 = conv$7$aval$0$simp$120;
   }
   else
   {
-    write flat$2$simp$125 = aval$0$simp$119;
+    write flat$2$simp$125 = conv$7$aval$0$simp$119;
     write flat$2$simp$126 = 0.0@{Double};
   }
   read flat$2$simp$127 = flat$2$simp$125 [Error];
   read flat$2$simp$128 = flat$2$simp$126 [Double];
   write acc$conv$11$simp$72 = flat$2$simp$127;
   write acc$conv$11$simp$73 = flat$2$simp$128;
-  read aval$2$simp$129 = acc$conv$11$simp$72 [Error];
-  read aval$2$simp$130 = acc$conv$11$simp$73 [Double];
-  read aval$1$simp$137 = acc$s$reify$6$conv$12$simp$80 [Error];
-  read aval$1$simp$138 = acc$s$reify$6$conv$12$simp$81 [Double];
-  read aval$1$simp$139 = acc$s$reify$6$conv$12$simp$82 [Double];
+  read conv$11$aval$2$simp$129 = acc$conv$11$simp$72 [Error];
+  read conv$11$aval$2$simp$130 = acc$conv$11$simp$73 [Double];
+  read s$reify$6$conv$12$aval$1$simp$137 = acc$s$reify$6$conv$12$simp$80 [Error];
+  read s$reify$6$conv$12$aval$1$simp$138 = acc$s$reify$6$conv$12$simp$81 [Double];
+  read s$reify$6$conv$12$aval$1$simp$139 = acc$s$reify$6$conv$12$simp$82 [Double];
   init flat$3$simp$140@{Error} = ExceptNotAnError@{Error};
   init flat$3$simp$141@{Double} = 0.0@{Double};
   init flat$3$simp$142@{Double} = 0.0@{Double};
-  if (eq#@{Error} aval$1$simp$137 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} s$reify$6$conv$12$aval$1$simp$137 (ExceptNotAnError@{Error}))
   {
     init flat$10$simp$143@{Error} = ExceptNotAnError@{Error};
     init flat$10$simp$144@{Double} = 0.0@{Double};
     init flat$10$simp$145@{Double} = 0.0@{Double};
-    if (eq#@{Error} aval$1$simp$137 (ExceptNotAnError@{Error}))
+    if (eq#@{Error} s$reify$6$conv$12$aval$1$simp$137 (ExceptNotAnError@{Error}))
     {
       init flat$13$simp$146@{Error} = ExceptNotAnError@{Error};
       init flat$13$simp$147@{Double} = 0.0@{Double};
-      if (eq#@{Error} aval$2$simp$129 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} conv$11$aval$2$simp$129 (ExceptNotAnError@{Error}))
       {
         write flat$13$simp$146 = ExceptNotAnError@{Error};
-        write flat$13$simp$147 = sub#@{Double} aval$2$simp$130 aval$1$simp$138;
+        write flat$13$simp$147 = sub#@{Double} conv$11$aval$2$simp$130 s$reify$6$conv$12$aval$1$simp$138;
       }
       else
       {
-        write flat$13$simp$146 = aval$2$simp$129;
+        write flat$13$simp$146 = conv$11$aval$2$simp$129;
         write flat$13$simp$147 = 0.0@{Double};
       }
       read flat$13$simp$148 = flat$13$simp$146 [Error];
@@ -143,7 +143,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       if (eq#@{Error} flat$13$simp$148 (ExceptNotAnError@{Error}))
       {
         write flat$14$simp$150 = ExceptNotAnError@{Error};
-        let simp$443 = add#@{Double} aval$1$simp$139 (1.0@{Double});
+        let simp$443 = add#@{Double} s$reify$6$conv$12$aval$1$simp$139 (1.0@{Double});
         write flat$14$simp$151 = div# flat$13$simp$149 simp$443;
       }
       else
@@ -158,7 +158,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       if (eq#@{Error} flat$14$simp$152 (ExceptNotAnError@{Error}))
       {
         write flat$15$simp$154 = ExceptNotAnError@{Error};
-        write flat$15$simp$155 = add#@{Double} aval$1$simp$138 flat$14$simp$153;
+        write flat$15$simp$155 = add#@{Double} s$reify$6$conv$12$aval$1$simp$138 flat$14$simp$153;
       }
       else
       {
@@ -174,7 +174,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       {
         write flat$16$simp$158 = ExceptNotAnError@{Error};
         write flat$16$simp$159 = flat$15$simp$157;
-        write flat$16$simp$160 = add#@{Double} aval$1$simp$139 (1.0@{Double});
+        write flat$16$simp$160 = add#@{Double} s$reify$6$conv$12$aval$1$simp$139 (1.0@{Double});
       }
       else
       {
@@ -191,7 +191,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
     }
     else
     {
-      write flat$10$simp$143 = aval$1$simp$137;
+      write flat$10$simp$143 = s$reify$6$conv$12$aval$1$simp$137;
       write flat$10$simp$144 = 0.0@{Double};
       write flat$10$simp$145 = 0.0@{Double};
     }
@@ -207,20 +207,20 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
     init flat$6$simp$167@{Error} = ExceptNotAnError@{Error};
     init flat$6$simp$168@{Double} = 0.0@{Double};
     init flat$6$simp$169@{Double} = 0.0@{Double};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) aval$1$simp$137)
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s$reify$6$conv$12$aval$1$simp$137)
     {
       init flat$7$simp$170@{Error} = ExceptNotAnError@{Error};
       init flat$7$simp$171@{Double} = 0.0@{Double};
       init flat$7$simp$172@{Double} = 0.0@{Double};
-      if (eq#@{Error} aval$2$simp$129 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} conv$11$aval$2$simp$129 (ExceptNotAnError@{Error}))
       {
         write flat$7$simp$170 = ExceptNotAnError@{Error};
-        write flat$7$simp$171 = aval$2$simp$130;
+        write flat$7$simp$171 = conv$11$aval$2$simp$130;
         write flat$7$simp$172 = 1.0@{Double};
       }
       else
       {
-        write flat$7$simp$170 = aval$2$simp$129;
+        write flat$7$simp$170 = conv$11$aval$2$simp$129;
         write flat$7$simp$171 = 0.0@{Double};
         write flat$7$simp$172 = 0.0@{Double};
       }
@@ -233,7 +233,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
     }
     else
     {
-      write flat$6$simp$167 = aval$1$simp$137;
+      write flat$6$simp$167 = s$reify$6$conv$12$aval$1$simp$137;
       write flat$6$simp$168 = 0.0@{Double};
       write flat$6$simp$169 = 0.0@{Double};
     }
@@ -306,51 +306,51 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
     read flat$28$simp$193 = flat$28$simp$191 [Int];
     write acc$conv$57$simp$83 = flat$28$simp$192;
     write acc$conv$57$simp$84 = flat$28$simp$193;
-    read aval$3$simp$194 = acc$conv$57$simp$83 [Error];
-    read aval$3$simp$195 = acc$conv$57$simp$84 [Int];
-    write acc$conv$58$simp$89 = aval$3$simp$194;
-    write acc$conv$58$simp$90 = aval$3$simp$195;
-    read aval$4$simp$200 = acc$conv$58$simp$89 [Error];
-    read aval$4$simp$201 = acc$conv$58$simp$90 [Int];
+    read conv$57$aval$3$simp$194 = acc$conv$57$simp$83 [Error];
+    read conv$57$aval$3$simp$195 = acc$conv$57$simp$84 [Int];
+    write acc$conv$58$simp$89 = conv$57$aval$3$simp$194;
+    write acc$conv$58$simp$90 = conv$57$aval$3$simp$195;
+    read conv$58$aval$4$simp$200 = acc$conv$58$simp$89 [Error];
+    read conv$58$aval$4$simp$201 = acc$conv$58$simp$90 [Int];
     init flat$29$simp$208@{Error} = ExceptNotAnError@{Error};
     init flat$29$simp$209@{Double} = 0.0@{Double};
-    if (eq#@{Error} aval$4$simp$200 (ExceptNotAnError@{Error}))
+    if (eq#@{Error} conv$58$aval$4$simp$200 (ExceptNotAnError@{Error}))
     {
       write flat$29$simp$208 = ExceptNotAnError@{Error};
-      write flat$29$simp$209 = doubleOfInt# aval$4$simp$201;
+      write flat$29$simp$209 = doubleOfInt# conv$58$aval$4$simp$201;
     }
     else
     {
-      write flat$29$simp$208 = aval$4$simp$200;
+      write flat$29$simp$208 = conv$58$aval$4$simp$200;
       write flat$29$simp$209 = 0.0@{Double};
     }
     read flat$29$simp$210 = flat$29$simp$208 [Error];
     read flat$29$simp$211 = flat$29$simp$209 [Double];
     write acc$conv$62$simp$97 = flat$29$simp$210;
     write acc$conv$62$simp$98 = flat$29$simp$211;
-    read aval$6$simp$212 = acc$conv$62$simp$97 [Error];
-    read aval$6$simp$213 = acc$conv$62$simp$98 [Double];
-    read aval$5$simp$222 = acc$a$conv$63$simp$107 [Error];
-    read aval$5$simp$223 = acc$a$conv$63$simp$108 [Double];
-    read aval$5$simp$224 = acc$a$conv$63$simp$109 [Double];
-    read aval$5$simp$225 = acc$a$conv$63$simp$110 [Double];
+    read conv$62$aval$6$simp$212 = acc$conv$62$simp$97 [Error];
+    read conv$62$aval$6$simp$213 = acc$conv$62$simp$98 [Double];
+    read a$conv$63$aval$5$simp$222 = acc$a$conv$63$simp$107 [Error];
+    read a$conv$63$aval$5$simp$223 = acc$a$conv$63$simp$108 [Double];
+    read a$conv$63$aval$5$simp$224 = acc$a$conv$63$simp$109 [Double];
+    read a$conv$63$aval$5$simp$225 = acc$a$conv$63$simp$110 [Double];
     init flat$30$simp$226@{Error} = ExceptNotAnError@{Error};
     init flat$30$simp$227@{Double} = 0.0@{Double};
     init flat$30$simp$228@{Double} = 0.0@{Double};
     init flat$30$simp$229@{Double} = 0.0@{Double};
-    if (eq#@{Error} aval$5$simp$222 (ExceptNotAnError@{Error}))
+    if (eq#@{Error} a$conv$63$aval$5$simp$222 (ExceptNotAnError@{Error}))
     {
-      let nn$conv$70 = add#@{Double} aval$5$simp$223 (1.0@{Double});
+      let nn$conv$70 = add#@{Double} a$conv$63$aval$5$simp$223 (1.0@{Double});
       init flat$33$simp$230@{Error} = ExceptNotAnError@{Error};
       init flat$33$simp$231@{Double} = 0.0@{Double};
-      if (eq#@{Error} aval$6$simp$212 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} conv$62$aval$6$simp$212 (ExceptNotAnError@{Error}))
       {
         write flat$33$simp$230 = ExceptNotAnError@{Error};
-        write flat$33$simp$231 = sub#@{Double} aval$6$simp$213 aval$5$simp$224;
+        write flat$33$simp$231 = sub#@{Double} conv$62$aval$6$simp$213 a$conv$63$aval$5$simp$224;
       }
       else
       {
-        write flat$33$simp$230 = aval$6$simp$212;
+        write flat$33$simp$230 = conv$62$aval$6$simp$212;
         write flat$33$simp$231 = 0.0@{Double};
       }
       read flat$33$simp$232 = flat$33$simp$230 [Error];
@@ -374,7 +374,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       if (eq#@{Error} flat$34$simp$236 (ExceptNotAnError@{Error}))
       {
         write flat$35$simp$238 = ExceptNotAnError@{Error};
-        write flat$35$simp$239 = add#@{Double} aval$5$simp$224 flat$34$simp$237;
+        write flat$35$simp$239 = add#@{Double} a$conv$63$aval$5$simp$224 flat$34$simp$237;
       }
       else
       {
@@ -389,14 +389,14 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       {
         init flat$51$simp$244@{Error} = ExceptNotAnError@{Error};
         init flat$51$simp$245@{Double} = 0.0@{Double};
-        if (eq#@{Error} aval$6$simp$212 (ExceptNotAnError@{Error}))
+        if (eq#@{Error} conv$62$aval$6$simp$212 (ExceptNotAnError@{Error}))
         {
           init flat$57$simp$246@{Error} = ExceptNotAnError@{Error};
           init flat$57$simp$247@{Double} = 0.0@{Double};
           if (eq#@{Error} flat$35$simp$240 (ExceptNotAnError@{Error}))
           {
             write flat$57$simp$246 = ExceptNotAnError@{Error};
-            write flat$57$simp$247 = sub#@{Double} aval$6$simp$213 flat$35$simp$241;
+            write flat$57$simp$247 = sub#@{Double} conv$62$aval$6$simp$213 flat$35$simp$241;
           }
           else
           {
@@ -410,7 +410,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
         }
         else
         {
-          write flat$51$simp$244 = aval$6$simp$212;
+          write flat$51$simp$244 = conv$62$aval$6$simp$212;
           write flat$51$simp$245 = 0.0@{Double};
         }
         read flat$51$simp$250 = flat$51$simp$244 [Error];
@@ -444,7 +444,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       if (eq#@{Error} flat$36$simp$256 (ExceptNotAnError@{Error}))
       {
         write flat$37$simp$258 = ExceptNotAnError@{Error};
-        write flat$37$simp$259 = add#@{Double} aval$5$simp$225 flat$36$simp$257;
+        write flat$37$simp$259 = add#@{Double} a$conv$63$aval$5$simp$225 flat$36$simp$257;
       }
       else
       {
@@ -459,7 +459,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
       if (eq#@{Error} flat$35$simp$240 (ExceptNotAnError@{Error}))
       {
         write flat$38$simp$262 = ExceptNotAnError@{Error};
-        write flat$38$simp$263 = add#@{Double} aval$5$simp$223 (1.0@{Double});
+        write flat$38$simp$263 = add#@{Double} a$conv$63$aval$5$simp$223 (1.0@{Double});
         write flat$38$simp$264 = flat$35$simp$241;
       }
       else
@@ -522,7 +522,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$315@{Error}, conv
     }
     else
     {
-      write flat$30$simp$226 = aval$5$simp$222;
+      write flat$30$simp$226 = a$conv$63$aval$5$simp$222;
       write flat$30$simp$227 = 0.0@{Double};
       write flat$30$simp$228 = 0.0@{Double};
       write flat$30$simp$229 = 0.0@{Double};
@@ -559,79 +559,79 @@ read a$conv$63$simp$289 = acc$a$conv$63$simp$108 [Double];
 read a$conv$63$simp$291 = acc$a$conv$63$simp$110 [Double];
 read s$reify$6$conv$12$simp$292 = acc$s$reify$6$conv$12$simp$80 [Error];
 read s$reify$6$conv$12$simp$293 = acc$s$reify$6$conv$12$simp$81 [Double];
-init flat$82$simp$295@{Error} = ExceptNotAnError@{Error};
-init flat$82$simp$296@{Double} = 0.0@{Double};
+init flat$89$simp$295@{Error} = ExceptNotAnError@{Error};
+init flat$89$simp$296@{Double} = 0.0@{Double};
 if (eq#@{Error} s$reify$6$conv$12$simp$292 (ExceptNotAnError@{Error}))
 {
-  write flat$82$simp$295 = ExceptNotAnError@{Error};
-  write flat$82$simp$296 = s$reify$6$conv$12$simp$293;
+  write flat$89$simp$295 = ExceptNotAnError@{Error};
+  write flat$89$simp$296 = s$reify$6$conv$12$simp$293;
 }
 else
 {
-  write flat$82$simp$295 = s$reify$6$conv$12$simp$292;
-  write flat$82$simp$296 = 0.0@{Double};
+  write flat$89$simp$295 = s$reify$6$conv$12$simp$292;
+  write flat$89$simp$296 = 0.0@{Double};
 }
-read flat$82$simp$297 = flat$82$simp$295 [Error];
-read flat$82$simp$298 = flat$82$simp$296 [Double];
-init flat$83$simp$299@{Error} = ExceptNotAnError@{Error};
-init flat$83$simp$300@{Double} = 0.0@{Double};
-if (eq#@{Error} flat$82$simp$297 (ExceptNotAnError@{Error}))
+read flat$89$simp$297 = flat$89$simp$295 [Error];
+read flat$89$simp$298 = flat$89$simp$296 [Double];
+init flat$90$simp$299@{Error} = ExceptNotAnError@{Error};
+init flat$90$simp$300@{Double} = 0.0@{Double};
+if (eq#@{Error} flat$89$simp$297 (ExceptNotAnError@{Error}))
 {
-  init flat$86$simp$301@{Error} = ExceptNotAnError@{Error};
-  init flat$86$simp$302@{Double} = 0.0@{Double};
+  init flat$93$simp$301@{Error} = ExceptNotAnError@{Error};
+  init flat$93$simp$302@{Double} = 0.0@{Double};
   if (eq#@{Error} a$conv$63$simp$288 (ExceptNotAnError@{Error}))
   {
     let conv$118 = sub#@{Double} a$conv$63$simp$289 (1.0@{Double});
     let simp$1186 = div# a$conv$63$simp$291 conv$118;
-    write flat$86$simp$301 = ExceptNotAnError@{Error};
-    write flat$86$simp$302 = simp$1186;
+    write flat$93$simp$301 = ExceptNotAnError@{Error};
+    write flat$93$simp$302 = simp$1186;
   }
   else
   {
-    write flat$86$simp$301 = a$conv$63$simp$288;
-    write flat$86$simp$302 = 0.0@{Double};
+    write flat$93$simp$301 = a$conv$63$simp$288;
+    write flat$93$simp$302 = 0.0@{Double};
   }
-  read flat$86$simp$303 = flat$86$simp$301 [Error];
-  read flat$86$simp$304 = flat$86$simp$302 [Double];
-  init flat$87$simp$305@{Error} = ExceptNotAnError@{Error};
-  init flat$87$simp$306@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$86$simp$303 (ExceptNotAnError@{Error}))
+  read flat$93$simp$303 = flat$93$simp$301 [Error];
+  read flat$93$simp$304 = flat$93$simp$302 [Double];
+  init flat$94$simp$305@{Error} = ExceptNotAnError@{Error};
+  init flat$94$simp$306@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat$93$simp$303 (ExceptNotAnError@{Error}))
   {
-    write flat$87$simp$305 = ExceptNotAnError@{Error};
-    write flat$87$simp$306 = sqrt# flat$86$simp$304;
+    write flat$94$simp$305 = ExceptNotAnError@{Error};
+    write flat$94$simp$306 = sqrt# flat$93$simp$304;
   }
   else
   {
-    write flat$87$simp$305 = flat$86$simp$303;
-    write flat$87$simp$306 = 0.0@{Double};
+    write flat$94$simp$305 = flat$93$simp$303;
+    write flat$94$simp$306 = 0.0@{Double};
   }
-  read flat$87$simp$307 = flat$87$simp$305 [Error];
-  read flat$87$simp$308 = flat$87$simp$306 [Double];
-  init flat$88$simp$309@{Error} = ExceptNotAnError@{Error};
-  init flat$88$simp$310@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat$87$simp$307 (ExceptNotAnError@{Error}))
+  read flat$94$simp$307 = flat$94$simp$305 [Error];
+  read flat$94$simp$308 = flat$94$simp$306 [Double];
+  init flat$95$simp$309@{Error} = ExceptNotAnError@{Error};
+  init flat$95$simp$310@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat$94$simp$307 (ExceptNotAnError@{Error}))
   {
-    write flat$88$simp$309 = ExceptNotAnError@{Error};
-    write flat$88$simp$310 = mul#@{Double} flat$82$simp$298 flat$87$simp$308;
+    write flat$95$simp$309 = ExceptNotAnError@{Error};
+    write flat$95$simp$310 = mul#@{Double} flat$89$simp$298 flat$94$simp$308;
   }
   else
   {
-    write flat$88$simp$309 = flat$87$simp$307;
-    write flat$88$simp$310 = 0.0@{Double};
+    write flat$95$simp$309 = flat$94$simp$307;
+    write flat$95$simp$310 = 0.0@{Double};
   }
-  read flat$88$simp$311 = flat$88$simp$309 [Error];
-  read flat$88$simp$312 = flat$88$simp$310 [Double];
-  write flat$83$simp$299 = flat$88$simp$311;
-  write flat$83$simp$300 = flat$88$simp$312;
+  read flat$95$simp$311 = flat$95$simp$309 [Error];
+  read flat$95$simp$312 = flat$95$simp$310 [Double];
+  write flat$90$simp$299 = flat$95$simp$311;
+  write flat$90$simp$300 = flat$95$simp$312;
 }
 else
 {
-  write flat$83$simp$299 = flat$82$simp$297;
-  write flat$83$simp$300 = 0.0@{Double};
+  write flat$90$simp$299 = flat$89$simp$297;
+  write flat$90$simp$300 = 0.0@{Double};
 }
-read flat$83$simp$313 = flat$83$simp$299 [Error];
-read flat$83$simp$314 = flat$83$simp$300 [Double];
-output@{(Sum Error Double)} repl (flat$83$simp$313@{Error}, flat$83$simp$314@{Double});
+read flat$90$simp$313 = flat$90$simp$299 [Error];
+read flat$90$simp$314 = flat$90$simp$300 [Double];
+output@{(Sum Error Double)} repl (flat$90$simp$313@{Error}, flat$90$simp$314@{Double});
 
 - C:
 #line 1 "state definition #0 - repl"
@@ -715,6 +715,7 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_10_simp_166;
     ierror_t         flat_29_simp_210;
     idouble_t        flat_29_simp_211;
+    idouble_t        conv_7_aval_0_simp_120;
     ierror_t         flat_1_simp_117;
     ierror_t         flat_1_simp_115;
     idouble_t        flat_1_simp_116;
@@ -741,6 +742,7 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_15_simp_157;
     ierror_t         flat_16_simp_158;
     idouble_t        flat_16_simp_159;
+    idouble_t        conv_11_aval_2_simp_130;
     idouble_t        flat_13_simp_149;
     ierror_t         flat_13_simp_148;
     ierror_t         flat_13_simp_146;
@@ -763,6 +765,7 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         acc_a_conv_63_simp_107;
     idouble_t        acc_a_conv_63_simp_109;
     idouble_t        acc_a_conv_63_simp_108;
+    ierror_t         conv_11_aval_2_simp_129;
     idouble_t        flat_6_simp_169;
     idouble_t        flat_6_simp_168;
     ierror_t         flat_6_simp_167;
@@ -810,6 +813,7 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_34_simp_235;
     ierror_t         flat_34_simp_236;
     idouble_t        flat_34_simp_237;
+    ierror_t         conv_7_aval_0_simp_119;
     idouble_t        acc_s_reify_6_conv_12_simp_82;
     ierror_t         acc_s_reify_6_conv_12_simp_80;
     idouble_t        acc_s_reify_6_conv_12_simp_81;
@@ -819,44 +823,43 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_2_simp_128;
     idouble_t        acc_conv_7_simp_67;
     ierror_t         acc_conv_7_simp_66;
-    idouble_t        flat_83_simp_314;
-    ierror_t         flat_83_simp_313;
-    ierror_t         flat_88_simp_311;
-    idouble_t        flat_88_simp_310;
-    idouble_t        flat_88_simp_312;
+    ierror_t         flat_95_simp_309;
+    ierror_t         flat_94_simp_305;
+    idouble_t        flat_94_simp_306;
+    ierror_t         flat_94_simp_307;
+    idouble_t        flat_94_simp_308;
+    ierror_t         flat_93_simp_303;
+    ierror_t         flat_93_simp_301;
+    idouble_t        flat_93_simp_302;
+    idouble_t        flat_93_simp_304;
+    idouble_t        flat_90_simp_300;
     idouble_t        flat_3_simp_181;
     idouble_t        flat_3_simp_180;
     idouble_t        acc_conv_62_simp_98;
     ierror_t         acc_conv_62_simp_97;
+    ierror_t         flat_90_simp_299;
     idouble_t        acc_conv_11_simp_73;
     ierror_t         acc_conv_11_simp_72;
-    iint_t           aval_3_simp_195;
-    ierror_t         aval_3_simp_194;
-    ierror_t         flat_83_simp_299;
-    ierror_t         flat_82_simp_297;
-    ierror_t         flat_82_simp_295;
-    idouble_t        flat_82_simp_296;
-    idouble_t        flat_82_simp_298;
-    idouble_t        aval_6_simp_213;
-    ierror_t         aval_6_simp_212;
-    ierror_t         flat_87_simp_307;
-    ierror_t         flat_87_simp_305;
-    idouble_t        flat_87_simp_306;
-    idouble_t        flat_87_simp_308;
-    ierror_t         flat_86_simp_301;
-    idouble_t        flat_86_simp_302;
-    ierror_t         flat_86_simp_303;
-    idouble_t        flat_86_simp_304;
-    idouble_t        flat_83_simp_300;
-    ierror_t         flat_88_simp_309;
-    iint_t           aval_4_simp_201;
-    ierror_t         aval_4_simp_200;
-    idouble_t        aval_5_simp_223;
-    ierror_t         aval_5_simp_222;
-    idouble_t        aval_5_simp_225;
-    idouble_t        aval_5_simp_224;
+    ierror_t         flat_89_simp_295;
+    idouble_t        flat_89_simp_296;
+    idouble_t        flat_89_simp_298;
+    ierror_t         flat_89_simp_297;
+    idouble_t        a_conv_63_aval_5_simp_224;
+    idouble_t        a_conv_63_aval_5_simp_225;
+    ierror_t         a_conv_63_aval_5_simp_222;
+    idouble_t        a_conv_63_aval_5_simp_223;
+    idouble_t        flat_90_simp_314;
+    ierror_t         flat_90_simp_313;
+    idouble_t        flat_95_simp_312;
+    ierror_t         flat_95_simp_311;
+    idouble_t        flat_95_simp_310;
     ierror_t         s_reify_6_conv_12_simp_292;
     idouble_t        s_reify_6_conv_12_simp_293;
+    idouble_t        s_reify_6_conv_12_aval_1_simp_138;
+    idouble_t        s_reify_6_conv_12_aval_1_simp_139;
+    ierror_t         s_reify_6_conv_12_aval_1_simp_137;
+    ierror_t         conv_62_aval_6_simp_212;
+    idouble_t        conv_62_aval_6_simp_213;
     idouble_t        flat_42_simp_279;
     idouble_t        flat_42_simp_278;
     idouble_t        flat_42_simp_275;
@@ -871,20 +874,17 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_52_simp_255;
     idouble_t        flat_51_simp_251;
     ierror_t         flat_51_simp_250;
-    ierror_t         aval_2_simp_129;
-    idouble_t        aval_0_simp_120;
     ierror_t         flat_57_simp_248;
     idouble_t        flat_57_simp_249;
     ierror_t         flat_57_simp_246;
     idouble_t        flat_57_simp_247;
     idouble_t        flat_51_simp_245;
     ierror_t         flat_51_simp_244;
-    ierror_t         aval_0_simp_119;
+    ierror_t         conv_58_aval_4_simp_200;
+    iint_t           conv_58_aval_4_simp_201;
+    ierror_t         conv_57_aval_3_simp_194;
+    iint_t           conv_57_aval_3_simp_195;
     ibool_t          flat_27;
-    idouble_t        aval_2_simp_130;
-    ierror_t         aval_1_simp_137;
-    idouble_t        aval_1_simp_138;
-    idouble_t        aval_1_simp_139;
     idouble_t        a_conv_63_simp_291;
     ierror_t         a_conv_63_simp_288;
     idouble_t        a_conv_63_simp_289;
@@ -985,7 +985,7 @@ void iprogram_0(iprogram_0_t *s)
     const itime_t   *const new_conv_0_simp_318 = s->new_conv_0_simp_318;
     
     for (iint_t i = 0; i < new_count; i++) {
-        iint_t           conv_1               = i;
+        ifactid_t        conv_1               = i;
         itime_t          conv_2               = new_conv_0_simp_318[i];
         ierror_t         conv_0_simp_315      = new_conv_0_simp_315[i];
         istring_t        conv_0_simp_316      = new_conv_0_simp_316[i];
@@ -1019,16 +1019,16 @@ void iprogram_0(iprogram_0_t *s)
         flat_1_simp_118                       = flat_1_simp_116;                      /* read */
         acc_conv_7_simp_66                    = flat_1_simp_117;                      /* write */
         acc_conv_7_simp_67                    = flat_1_simp_118;                      /* write */
-        aval_0_simp_119                       = acc_conv_7_simp_66;                   /* read */
-        aval_0_simp_120                       = acc_conv_7_simp_67;                   /* read */
+        conv_7_aval_0_simp_119                = acc_conv_7_simp_66;                   /* read */
+        conv_7_aval_0_simp_120                = acc_conv_7_simp_67;                   /* read */
         flat_2_simp_125                       = ierror_not_an_error;                  /* init */
         flat_2_simp_126                       = 0.0;                                  /* init */
         
-        if (ierror_eq (aval_0_simp_119, ierror_not_an_error)) {
+        if (ierror_eq (conv_7_aval_0_simp_119, ierror_not_an_error)) {
             flat_2_simp_125                   = ierror_not_an_error;                  /* write */
-            flat_2_simp_126                   = aval_0_simp_120;                      /* write */
+            flat_2_simp_126                   = conv_7_aval_0_simp_120;               /* write */
         } else {
-            flat_2_simp_125                   = aval_0_simp_119;                      /* write */
+            flat_2_simp_125                   = conv_7_aval_0_simp_119;               /* write */
             flat_2_simp_126                   = 0.0;                                  /* write */
         }
         
@@ -1036,29 +1036,29 @@ void iprogram_0(iprogram_0_t *s)
         flat_2_simp_128                       = flat_2_simp_126;                      /* read */
         acc_conv_11_simp_72                   = flat_2_simp_127;                      /* write */
         acc_conv_11_simp_73                   = flat_2_simp_128;                      /* write */
-        aval_2_simp_129                       = acc_conv_11_simp_72;                  /* read */
-        aval_2_simp_130                       = acc_conv_11_simp_73;                  /* read */
-        aval_1_simp_137                       = acc_s_reify_6_conv_12_simp_80;        /* read */
-        aval_1_simp_138                       = acc_s_reify_6_conv_12_simp_81;        /* read */
-        aval_1_simp_139                       = acc_s_reify_6_conv_12_simp_82;        /* read */
+        conv_11_aval_2_simp_129               = acc_conv_11_simp_72;                  /* read */
+        conv_11_aval_2_simp_130               = acc_conv_11_simp_73;                  /* read */
+        s_reify_6_conv_12_aval_1_simp_137     = acc_s_reify_6_conv_12_simp_80;        /* read */
+        s_reify_6_conv_12_aval_1_simp_138     = acc_s_reify_6_conv_12_simp_81;        /* read */
+        s_reify_6_conv_12_aval_1_simp_139     = acc_s_reify_6_conv_12_simp_82;        /* read */
         flat_3_simp_140                       = ierror_not_an_error;                  /* init */
         flat_3_simp_141                       = 0.0;                                  /* init */
         flat_3_simp_142                       = 0.0;                                  /* init */
         
-        if (ierror_eq (aval_1_simp_137, ierror_not_an_error)) {
+        if (ierror_eq (s_reify_6_conv_12_aval_1_simp_137, ierror_not_an_error)) {
             flat_10_simp_143                  = ierror_not_an_error;                  /* init */
             flat_10_simp_144                  = 0.0;                                  /* init */
             flat_10_simp_145                  = 0.0;                                  /* init */
             
-            if (ierror_eq (aval_1_simp_137, ierror_not_an_error)) {
+            if (ierror_eq (s_reify_6_conv_12_aval_1_simp_137, ierror_not_an_error)) {
                 flat_13_simp_146              = ierror_not_an_error;                  /* init */
                 flat_13_simp_147              = 0.0;                                  /* init */
                 
-                if (ierror_eq (aval_2_simp_129, ierror_not_an_error)) {
+                if (ierror_eq (conv_11_aval_2_simp_129, ierror_not_an_error)) {
                     flat_13_simp_146          = ierror_not_an_error;                  /* write */
-                    flat_13_simp_147          = idouble_sub (aval_2_simp_130, aval_1_simp_138); /* write */
+                    flat_13_simp_147          = idouble_sub (conv_11_aval_2_simp_130, s_reify_6_conv_12_aval_1_simp_138); /* write */
                 } else {
-                    flat_13_simp_146          = aval_2_simp_129;                      /* write */
+                    flat_13_simp_146          = conv_11_aval_2_simp_129;              /* write */
                     flat_13_simp_147          = 0.0;                                  /* write */
                 }
                 
@@ -1069,7 +1069,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_13_simp_148, ierror_not_an_error)) {
                     flat_14_simp_150          = ierror_not_an_error;                  /* write */
-                    idouble_t        simp_443 = idouble_add (aval_1_simp_139, 1.0);   /* let */
+                    idouble_t        simp_443 = idouble_add (s_reify_6_conv_12_aval_1_simp_139, 1.0); /* let */
                     flat_14_simp_151          = idouble_div (flat_13_simp_149, simp_443); /* write */
                 } else {
                     flat_14_simp_150          = flat_13_simp_148;                     /* write */
@@ -1083,7 +1083,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_14_simp_152, ierror_not_an_error)) {
                     flat_15_simp_154          = ierror_not_an_error;                  /* write */
-                    flat_15_simp_155          = idouble_add (aval_1_simp_138, flat_14_simp_153); /* write */
+                    flat_15_simp_155          = idouble_add (s_reify_6_conv_12_aval_1_simp_138, flat_14_simp_153); /* write */
                 } else {
                     flat_15_simp_154          = flat_14_simp_152;                     /* write */
                     flat_15_simp_155          = 0.0;                                  /* write */
@@ -1098,7 +1098,7 @@ void iprogram_0(iprogram_0_t *s)
                 if (ierror_eq (flat_15_simp_156, ierror_not_an_error)) {
                     flat_16_simp_158          = ierror_not_an_error;                  /* write */
                     flat_16_simp_159          = flat_15_simp_157;                     /* write */
-                    flat_16_simp_160          = idouble_add (aval_1_simp_139, 1.0);   /* write */
+                    flat_16_simp_160          = idouble_add (s_reify_6_conv_12_aval_1_simp_139, 1.0); /* write */
                 } else {
                     flat_16_simp_158          = flat_15_simp_156;                     /* write */
                     flat_16_simp_159          = 0.0;                                  /* write */
@@ -1112,7 +1112,7 @@ void iprogram_0(iprogram_0_t *s)
                 flat_10_simp_144              = flat_16_simp_162;                     /* write */
                 flat_10_simp_145              = flat_16_simp_163;                     /* write */
             } else {
-                flat_10_simp_143              = aval_1_simp_137;                      /* write */
+                flat_10_simp_143              = s_reify_6_conv_12_aval_1_simp_137;    /* write */
                 flat_10_simp_144              = 0.0;                                  /* write */
                 flat_10_simp_145              = 0.0;                                  /* write */
             }
@@ -1128,17 +1128,17 @@ void iprogram_0(iprogram_0_t *s)
             flat_6_simp_168                   = 0.0;                                  /* init */
             flat_6_simp_169                   = 0.0;                                  /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, aval_1_simp_137)) {
+            if (ierror_eq (ierror_fold1_no_value, s_reify_6_conv_12_aval_1_simp_137)) {
                 flat_7_simp_170               = ierror_not_an_error;                  /* init */
                 flat_7_simp_171               = 0.0;                                  /* init */
                 flat_7_simp_172               = 0.0;                                  /* init */
                 
-                if (ierror_eq (aval_2_simp_129, ierror_not_an_error)) {
+                if (ierror_eq (conv_11_aval_2_simp_129, ierror_not_an_error)) {
                     flat_7_simp_170           = ierror_not_an_error;                  /* write */
-                    flat_7_simp_171           = aval_2_simp_130;                      /* write */
+                    flat_7_simp_171           = conv_11_aval_2_simp_130;              /* write */
                     flat_7_simp_172           = 1.0;                                  /* write */
                 } else {
-                    flat_7_simp_170           = aval_2_simp_129;                      /* write */
+                    flat_7_simp_170           = conv_11_aval_2_simp_129;              /* write */
                     flat_7_simp_171           = 0.0;                                  /* write */
                     flat_7_simp_172           = 0.0;                                  /* write */
                 }
@@ -1150,7 +1150,7 @@ void iprogram_0(iprogram_0_t *s)
                 flat_6_simp_168               = flat_7_simp_174;                      /* write */
                 flat_6_simp_169               = flat_7_simp_175;                      /* write */
             } else {
-                flat_6_simp_167               = aval_1_simp_137;                      /* write */
+                flat_6_simp_167               = s_reify_6_conv_12_aval_1_simp_137;    /* write */
                 flat_6_simp_168               = 0.0;                                  /* write */
                 flat_6_simp_169               = 0.0;                                  /* write */
             }
@@ -1221,20 +1221,20 @@ void iprogram_0(iprogram_0_t *s)
             flat_28_simp_193                  = flat_28_simp_191;                     /* read */
             acc_conv_57_simp_83               = flat_28_simp_192;                     /* write */
             acc_conv_57_simp_84               = flat_28_simp_193;                     /* write */
-            aval_3_simp_194                   = acc_conv_57_simp_83;                  /* read */
-            aval_3_simp_195                   = acc_conv_57_simp_84;                  /* read */
-            acc_conv_58_simp_89               = aval_3_simp_194;                      /* write */
-            acc_conv_58_simp_90               = aval_3_simp_195;                      /* write */
-            aval_4_simp_200                   = acc_conv_58_simp_89;                  /* read */
-            aval_4_simp_201                   = acc_conv_58_simp_90;                  /* read */
+            conv_57_aval_3_simp_194           = acc_conv_57_simp_83;                  /* read */
+            conv_57_aval_3_simp_195           = acc_conv_57_simp_84;                  /* read */
+            acc_conv_58_simp_89               = conv_57_aval_3_simp_194;              /* write */
+            acc_conv_58_simp_90               = conv_57_aval_3_simp_195;              /* write */
+            conv_58_aval_4_simp_200           = acc_conv_58_simp_89;                  /* read */
+            conv_58_aval_4_simp_201           = acc_conv_58_simp_90;                  /* read */
             flat_29_simp_208                  = ierror_not_an_error;                  /* init */
             flat_29_simp_209                  = 0.0;                                  /* init */
             
-            if (ierror_eq (aval_4_simp_200, ierror_not_an_error)) {
+            if (ierror_eq (conv_58_aval_4_simp_200, ierror_not_an_error)) {
                 flat_29_simp_208              = ierror_not_an_error;                  /* write */
-                flat_29_simp_209              = iint_extend (aval_4_simp_201);        /* write */
+                flat_29_simp_209              = iint_extend (conv_58_aval_4_simp_201); /* write */
             } else {
-                flat_29_simp_208              = aval_4_simp_200;                      /* write */
+                flat_29_simp_208              = conv_58_aval_4_simp_200;              /* write */
                 flat_29_simp_209              = 0.0;                                  /* write */
             }
             
@@ -1242,27 +1242,27 @@ void iprogram_0(iprogram_0_t *s)
             flat_29_simp_211                  = flat_29_simp_209;                     /* read */
             acc_conv_62_simp_97               = flat_29_simp_210;                     /* write */
             acc_conv_62_simp_98               = flat_29_simp_211;                     /* write */
-            aval_6_simp_212                   = acc_conv_62_simp_97;                  /* read */
-            aval_6_simp_213                   = acc_conv_62_simp_98;                  /* read */
-            aval_5_simp_222                   = acc_a_conv_63_simp_107;               /* read */
-            aval_5_simp_223                   = acc_a_conv_63_simp_108;               /* read */
-            aval_5_simp_224                   = acc_a_conv_63_simp_109;               /* read */
-            aval_5_simp_225                   = acc_a_conv_63_simp_110;               /* read */
+            conv_62_aval_6_simp_212           = acc_conv_62_simp_97;                  /* read */
+            conv_62_aval_6_simp_213           = acc_conv_62_simp_98;                  /* read */
+            a_conv_63_aval_5_simp_222         = acc_a_conv_63_simp_107;               /* read */
+            a_conv_63_aval_5_simp_223         = acc_a_conv_63_simp_108;               /* read */
+            a_conv_63_aval_5_simp_224         = acc_a_conv_63_simp_109;               /* read */
+            a_conv_63_aval_5_simp_225         = acc_a_conv_63_simp_110;               /* read */
             flat_30_simp_226                  = ierror_not_an_error;                  /* init */
             flat_30_simp_227                  = 0.0;                                  /* init */
             flat_30_simp_228                  = 0.0;                                  /* init */
             flat_30_simp_229                  = 0.0;                                  /* init */
             
-            if (ierror_eq (aval_5_simp_222, ierror_not_an_error)) {
-                idouble_t        nn_conv_70   = idouble_add (aval_5_simp_223, 1.0);   /* let */
+            if (ierror_eq (a_conv_63_aval_5_simp_222, ierror_not_an_error)) {
+                idouble_t        nn_conv_70   = idouble_add (a_conv_63_aval_5_simp_223, 1.0); /* let */
                 flat_33_simp_230              = ierror_not_an_error;                  /* init */
                 flat_33_simp_231              = 0.0;                                  /* init */
                 
-                if (ierror_eq (aval_6_simp_212, ierror_not_an_error)) {
+                if (ierror_eq (conv_62_aval_6_simp_212, ierror_not_an_error)) {
                     flat_33_simp_230          = ierror_not_an_error;                  /* write */
-                    flat_33_simp_231          = idouble_sub (aval_6_simp_213, aval_5_simp_224); /* write */
+                    flat_33_simp_231          = idouble_sub (conv_62_aval_6_simp_213, a_conv_63_aval_5_simp_224); /* write */
                 } else {
-                    flat_33_simp_230          = aval_6_simp_212;                      /* write */
+                    flat_33_simp_230          = conv_62_aval_6_simp_212;              /* write */
                     flat_33_simp_231          = 0.0;                                  /* write */
                 }
                 
@@ -1286,7 +1286,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_34_simp_236, ierror_not_an_error)) {
                     flat_35_simp_238          = ierror_not_an_error;                  /* write */
-                    flat_35_simp_239          = idouble_add (aval_5_simp_224, flat_34_simp_237); /* write */
+                    flat_35_simp_239          = idouble_add (a_conv_63_aval_5_simp_224, flat_34_simp_237); /* write */
                 } else {
                     flat_35_simp_238          = flat_34_simp_236;                     /* write */
                     flat_35_simp_239          = 0.0;                                  /* write */
@@ -1301,13 +1301,13 @@ void iprogram_0(iprogram_0_t *s)
                     flat_51_simp_244          = ierror_not_an_error;                  /* init */
                     flat_51_simp_245          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (aval_6_simp_212, ierror_not_an_error)) {
+                    if (ierror_eq (conv_62_aval_6_simp_212, ierror_not_an_error)) {
                         flat_57_simp_246      = ierror_not_an_error;                  /* init */
                         flat_57_simp_247      = 0.0;                                  /* init */
                         
                         if (ierror_eq (flat_35_simp_240, ierror_not_an_error)) {
                             flat_57_simp_246  = ierror_not_an_error;                  /* write */
-                            flat_57_simp_247  = idouble_sub (aval_6_simp_213, flat_35_simp_241); /* write */
+                            flat_57_simp_247  = idouble_sub (conv_62_aval_6_simp_213, flat_35_simp_241); /* write */
                         } else {
                             flat_57_simp_246  = flat_35_simp_240;                     /* write */
                             flat_57_simp_247  = 0.0;                                  /* write */
@@ -1318,7 +1318,7 @@ void iprogram_0(iprogram_0_t *s)
                         flat_51_simp_244      = flat_57_simp_248;                     /* write */
                         flat_51_simp_245      = flat_57_simp_249;                     /* write */
                     } else {
-                        flat_51_simp_244      = aval_6_simp_212;                      /* write */
+                        flat_51_simp_244      = conv_62_aval_6_simp_212;              /* write */
                         flat_51_simp_245      = 0.0;                                  /* write */
                     }
                     
@@ -1351,7 +1351,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_36_simp_256, ierror_not_an_error)) {
                     flat_37_simp_258          = ierror_not_an_error;                  /* write */
-                    flat_37_simp_259          = idouble_add (aval_5_simp_225, flat_36_simp_257); /* write */
+                    flat_37_simp_259          = idouble_add (a_conv_63_aval_5_simp_225, flat_36_simp_257); /* write */
                 } else {
                     flat_37_simp_258          = flat_36_simp_256;                     /* write */
                     flat_37_simp_259          = 0.0;                                  /* write */
@@ -1365,7 +1365,7 @@ void iprogram_0(iprogram_0_t *s)
                 
                 if (ierror_eq (flat_35_simp_240, ierror_not_an_error)) {
                     flat_38_simp_262          = ierror_not_an_error;                  /* write */
-                    flat_38_simp_263          = idouble_add (aval_5_simp_223, 1.0);   /* write */
+                    flat_38_simp_263          = idouble_add (a_conv_63_aval_5_simp_223, 1.0); /* write */
                     flat_38_simp_264          = flat_35_simp_241;                     /* write */
                 } else {
                     flat_38_simp_262          = flat_35_simp_240;                     /* write */
@@ -1423,7 +1423,7 @@ void iprogram_0(iprogram_0_t *s)
                 flat_30_simp_228              = flat_39_simp_282;                     /* write */
                 flat_30_simp_229              = flat_39_simp_283;                     /* write */
             } else {
-                flat_30_simp_226              = aval_5_simp_222;                      /* write */
+                flat_30_simp_226              = a_conv_63_aval_5_simp_222;            /* write */
                 flat_30_simp_227              = 0.0;                                  /* write */
                 flat_30_simp_228              = 0.0;                                  /* write */
                 flat_30_simp_229              = 0.0;                                  /* write */
@@ -1497,75 +1497,75 @@ void iprogram_0(iprogram_0_t *s)
     a_conv_63_simp_291                        = acc_a_conv_63_simp_110;               /* read */
     s_reify_6_conv_12_simp_292                = acc_s_reify_6_conv_12_simp_80;        /* read */
     s_reify_6_conv_12_simp_293                = acc_s_reify_6_conv_12_simp_81;        /* read */
-    flat_82_simp_295                          = ierror_not_an_error;                  /* init */
-    flat_82_simp_296                          = 0.0;                                  /* init */
+    flat_89_simp_295                          = ierror_not_an_error;                  /* init */
+    flat_89_simp_296                          = 0.0;                                  /* init */
     
     if (ierror_eq (s_reify_6_conv_12_simp_292, ierror_not_an_error)) {
-        flat_82_simp_295                      = ierror_not_an_error;                  /* write */
-        flat_82_simp_296                      = s_reify_6_conv_12_simp_293;           /* write */
+        flat_89_simp_295                      = ierror_not_an_error;                  /* write */
+        flat_89_simp_296                      = s_reify_6_conv_12_simp_293;           /* write */
     } else {
-        flat_82_simp_295                      = s_reify_6_conv_12_simp_292;           /* write */
-        flat_82_simp_296                      = 0.0;                                  /* write */
+        flat_89_simp_295                      = s_reify_6_conv_12_simp_292;           /* write */
+        flat_89_simp_296                      = 0.0;                                  /* write */
     }
     
-    flat_82_simp_297                          = flat_82_simp_295;                     /* read */
-    flat_82_simp_298                          = flat_82_simp_296;                     /* read */
-    flat_83_simp_299                          = ierror_not_an_error;                  /* init */
-    flat_83_simp_300                          = 0.0;                                  /* init */
+    flat_89_simp_297                          = flat_89_simp_295;                     /* read */
+    flat_89_simp_298                          = flat_89_simp_296;                     /* read */
+    flat_90_simp_299                          = ierror_not_an_error;                  /* init */
+    flat_90_simp_300                          = 0.0;                                  /* init */
     
-    if (ierror_eq (flat_82_simp_297, ierror_not_an_error)) {
-        flat_86_simp_301                      = ierror_not_an_error;                  /* init */
-        flat_86_simp_302                      = 0.0;                                  /* init */
+    if (ierror_eq (flat_89_simp_297, ierror_not_an_error)) {
+        flat_93_simp_301                      = ierror_not_an_error;                  /* init */
+        flat_93_simp_302                      = 0.0;                                  /* init */
         
         if (ierror_eq (a_conv_63_simp_288, ierror_not_an_error)) {
             idouble_t        conv_118         = idouble_sub (a_conv_63_simp_289, 1.0); /* let */
             idouble_t        simp_1186        = idouble_div (a_conv_63_simp_291, conv_118); /* let */
-            flat_86_simp_301                  = ierror_not_an_error;                  /* write */
-            flat_86_simp_302                  = simp_1186;                            /* write */
+            flat_93_simp_301                  = ierror_not_an_error;                  /* write */
+            flat_93_simp_302                  = simp_1186;                            /* write */
         } else {
-            flat_86_simp_301                  = a_conv_63_simp_288;                   /* write */
-            flat_86_simp_302                  = 0.0;                                  /* write */
+            flat_93_simp_301                  = a_conv_63_simp_288;                   /* write */
+            flat_93_simp_302                  = 0.0;                                  /* write */
         }
         
-        flat_86_simp_303                      = flat_86_simp_301;                     /* read */
-        flat_86_simp_304                      = flat_86_simp_302;                     /* read */
-        flat_87_simp_305                      = ierror_not_an_error;                  /* init */
-        flat_87_simp_306                      = 0.0;                                  /* init */
+        flat_93_simp_303                      = flat_93_simp_301;                     /* read */
+        flat_93_simp_304                      = flat_93_simp_302;                     /* read */
+        flat_94_simp_305                      = ierror_not_an_error;                  /* init */
+        flat_94_simp_306                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_86_simp_303, ierror_not_an_error)) {
-            flat_87_simp_305                  = ierror_not_an_error;                  /* write */
-            flat_87_simp_306                  = idouble_sqrt (flat_86_simp_304);      /* write */
+        if (ierror_eq (flat_93_simp_303, ierror_not_an_error)) {
+            flat_94_simp_305                  = ierror_not_an_error;                  /* write */
+            flat_94_simp_306                  = idouble_sqrt (flat_93_simp_304);      /* write */
         } else {
-            flat_87_simp_305                  = flat_86_simp_303;                     /* write */
-            flat_87_simp_306                  = 0.0;                                  /* write */
+            flat_94_simp_305                  = flat_93_simp_303;                     /* write */
+            flat_94_simp_306                  = 0.0;                                  /* write */
         }
         
-        flat_87_simp_307                      = flat_87_simp_305;                     /* read */
-        flat_87_simp_308                      = flat_87_simp_306;                     /* read */
-        flat_88_simp_309                      = ierror_not_an_error;                  /* init */
-        flat_88_simp_310                      = 0.0;                                  /* init */
+        flat_94_simp_307                      = flat_94_simp_305;                     /* read */
+        flat_94_simp_308                      = flat_94_simp_306;                     /* read */
+        flat_95_simp_309                      = ierror_not_an_error;                  /* init */
+        flat_95_simp_310                      = 0.0;                                  /* init */
         
-        if (ierror_eq (flat_87_simp_307, ierror_not_an_error)) {
-            flat_88_simp_309                  = ierror_not_an_error;                  /* write */
-            flat_88_simp_310                  = idouble_mul (flat_82_simp_298, flat_87_simp_308); /* write */
+        if (ierror_eq (flat_94_simp_307, ierror_not_an_error)) {
+            flat_95_simp_309                  = ierror_not_an_error;                  /* write */
+            flat_95_simp_310                  = idouble_mul (flat_89_simp_298, flat_94_simp_308); /* write */
         } else {
-            flat_88_simp_309                  = flat_87_simp_307;                     /* write */
-            flat_88_simp_310                  = 0.0;                                  /* write */
+            flat_95_simp_309                  = flat_94_simp_307;                     /* write */
+            flat_95_simp_310                  = 0.0;                                  /* write */
         }
         
-        flat_88_simp_311                      = flat_88_simp_309;                     /* read */
-        flat_88_simp_312                      = flat_88_simp_310;                     /* read */
-        flat_83_simp_299                      = flat_88_simp_311;                     /* write */
-        flat_83_simp_300                      = flat_88_simp_312;                     /* write */
+        flat_95_simp_311                      = flat_95_simp_309;                     /* read */
+        flat_95_simp_312                      = flat_95_simp_310;                     /* read */
+        flat_90_simp_299                      = flat_95_simp_311;                     /* write */
+        flat_90_simp_300                      = flat_95_simp_312;                     /* write */
     } else {
-        flat_83_simp_299                      = flat_82_simp_297;                     /* write */
-        flat_83_simp_300                      = 0.0;                                  /* write */
+        flat_90_simp_299                      = flat_89_simp_297;                     /* write */
+        flat_90_simp_300                      = 0.0;                                  /* write */
     }
     
-    flat_83_simp_313                          = flat_83_simp_299;                     /* read */
-    flat_83_simp_314                          = flat_83_simp_300;                     /* read */
-    s->repl_ix_0                              = flat_83_simp_313;                     /* output */
-    s->repl_ix_1                              = flat_83_simp_314;                     /* output */
+    flat_90_simp_313                          = flat_90_simp_299;                     /* read */
+    flat_90_simp_314                          = flat_90_simp_300;                     /* read */
+    s->repl_ix_0                              = flat_90_simp_313;                     /* output */
+    s->repl_ix_1                              = flat_90_simp_314;                     /* output */
 }
 
 - C evaluation:
@@ -1588,21 +1588,21 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$26@{Error}, conv$
   let anf$1 = Time_daysDifference# (1980-01-06@{Time}) conv$0$simp$28;
   let anf$2 = negate#@{Int} anf$1;
   write acc$conv$4$simp$4 = Time_minusDays# (2000-01-01@{Time}) anf$2;
-  read aval$1$simp$10 = acc$conv$4$simp$4 [Time];
-  read aval$0$simp$14 = acc$s$reify$2$conv$5$simp$8 [Error];
-  read aval$0$simp$15 = acc$s$reify$2$conv$5$simp$9 [Time];
+  read conv$4$aval$1$simp$10 = acc$conv$4$simp$4 [Time];
+  read s$reify$2$conv$5$aval$0$simp$14 = acc$s$reify$2$conv$5$simp$8 [Error];
+  read s$reify$2$conv$5$aval$0$simp$15 = acc$s$reify$2$conv$5$simp$9 [Time];
   init flat$0$simp$16@{Error} = ExceptNotAnError@{Error};
   init flat$0$simp$17@{Time} = 1858-11-17@{Time};
-  if (eq#@{Error} aval$0$simp$14 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} s$reify$2$conv$5$aval$0$simp$14 (ExceptNotAnError@{Error}))
   {
     init flat$4@{Time} = 1858-11-17@{Time};
-    if (gt#@{Time} aval$1$simp$10 aval$0$simp$15)
+    if (gt#@{Time} conv$4$aval$1$simp$10 s$reify$2$conv$5$aval$0$simp$15)
     {
-      write flat$4 = aval$1$simp$10;
+      write flat$4 = conv$4$aval$1$simp$10;
     }
     else
     {
-      write flat$4 = aval$0$simp$15;
+      write flat$4 = s$reify$2$conv$5$aval$0$simp$15;
     }
     read flat$4 = flat$4 [Time];
     write flat$0$simp$16 = ExceptNotAnError@{Error};
@@ -1612,14 +1612,14 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$26@{Error}, conv$
   {
     init flat$3$simp$18@{Error} = ExceptNotAnError@{Error};
     init flat$3$simp$19@{Time} = 1858-11-17@{Time};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) aval$0$simp$14)
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s$reify$2$conv$5$aval$0$simp$14)
     {
       write flat$3$simp$18 = ExceptNotAnError@{Error};
-      write flat$3$simp$19 = aval$1$simp$10;
+      write flat$3$simp$19 = conv$4$aval$1$simp$10;
     }
     else
     {
-      write flat$3$simp$18 = aval$0$simp$14;
+      write flat$3$simp$18 = s$reify$2$conv$5$aval$0$simp$14;
       write flat$3$simp$19 = 1858-11-17@{Time};
     }
     read flat$3$simp$20 = flat$3$simp$18 [Error];
@@ -1676,11 +1676,11 @@ void iprogram_0(iprogram_0_t *s)
     itime_t          flat_4;
     itime_t          acc_s_reify_2_conv_5_simp_9;
     ierror_t         acc_s_reify_2_conv_5_simp_8;
+    itime_t          s_reify_2_conv_5_aval_0_simp_15;
+    ierror_t         s_reify_2_conv_5_aval_0_simp_14;
     ierror_t         s_reify_2_conv_5_simp_24;
     itime_t          s_reify_2_conv_5_simp_25;
-    itime_t          aval_1_simp_10;
-    ierror_t         aval_0_simp_14;
-    itime_t          aval_0_simp_15;
+    itime_t          conv_4_aval_1_simp_10;
     itime_t          flat_0_simp_23;
     ierror_t         flat_0_simp_22;
     ierror_t         flat_3_simp_20;
@@ -1716,7 +1716,7 @@ void iprogram_0(iprogram_0_t *s)
     const itime_t   *const new_conv_0_simp_28 = s->new_conv_0_simp_28;
     
     for (iint_t i = 0; i < new_count; i++) {
-        iint_t           conv_1               = i;
+        ifactid_t        conv_1               = i;
         itime_t          conv_2               = new_conv_0_simp_28[i];
         ierror_t         conv_0_simp_26       = new_conv_0_simp_26[i];
         iint_t           conv_0_simp_27       = new_conv_0_simp_27[i];
@@ -1724,19 +1724,19 @@ void iprogram_0(iprogram_0_t *s)
         iint_t           anf_1                = itime_days_diff (0x7bc010600000000, conv_0_simp_28); /* let */
         iint_t           anf_2                = iint_neg (anf_1);                     /* let */
         acc_conv_4_simp_4                     = itime_minus_days (0x7d0010100000000, anf_2); /* write */
-        aval_1_simp_10                        = acc_conv_4_simp_4;                    /* read */
-        aval_0_simp_14                        = acc_s_reify_2_conv_5_simp_8;          /* read */
-        aval_0_simp_15                        = acc_s_reify_2_conv_5_simp_9;          /* read */
+        conv_4_aval_1_simp_10                 = acc_conv_4_simp_4;                    /* read */
+        s_reify_2_conv_5_aval_0_simp_14       = acc_s_reify_2_conv_5_simp_8;          /* read */
+        s_reify_2_conv_5_aval_0_simp_15       = acc_s_reify_2_conv_5_simp_9;          /* read */
         flat_0_simp_16                        = ierror_not_an_error;                  /* init */
         flat_0_simp_17                        = 0x7420b1100000000;                    /* init */
         
-        if (ierror_eq (aval_0_simp_14, ierror_not_an_error)) {
+        if (ierror_eq (s_reify_2_conv_5_aval_0_simp_14, ierror_not_an_error)) {
             flat_4                            = 0x7420b1100000000;                    /* init */
             
-            if (itime_gt (aval_1_simp_10, aval_0_simp_15)) {
-                flat_4                        = aval_1_simp_10;                       /* write */
+            if (itime_gt (conv_4_aval_1_simp_10, s_reify_2_conv_5_aval_0_simp_15)) {
+                flat_4                        = conv_4_aval_1_simp_10;                /* write */
             } else {
-                flat_4                        = aval_0_simp_15;                       /* write */
+                flat_4                        = s_reify_2_conv_5_aval_0_simp_15;      /* write */
             }
             
             flat_4                            = flat_4;                               /* read */
@@ -1746,11 +1746,11 @@ void iprogram_0(iprogram_0_t *s)
             flat_3_simp_18                    = ierror_not_an_error;                  /* init */
             flat_3_simp_19                    = 0x7420b1100000000;                    /* init */
             
-            if (ierror_eq (ierror_fold1_no_value, aval_0_simp_14)) {
+            if (ierror_eq (ierror_fold1_no_value, s_reify_2_conv_5_aval_0_simp_14)) {
                 flat_3_simp_18                = ierror_not_an_error;                  /* write */
-                flat_3_simp_19                = aval_1_simp_10;                       /* write */
+                flat_3_simp_19                = conv_4_aval_1_simp_10;                /* write */
             } else {
-                flat_3_simp_18                = aval_0_simp_14;                       /* write */
+                flat_3_simp_18                = s_reify_2_conv_5_aval_0_simp_14;      /* write */
                 flat_3_simp_19                = 0x7420b1100000000;                    /* write */
             }
             

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -56,9 +56,9 @@ iint_t size_of_state_iprogram_0 ()
 void iprogram_0(iprogram_0_t *s)
 {
     idouble_t        acc_perhaps_conv_4_simp_10;
-    iint_t           aval_0_simp_12;
-    idouble_t        aval_0_simp_13;
-    ibool_t          aval_0_simp_11;
+    idouble_t        perhaps_conv_4_aval_0_simp_13;
+    ibool_t          perhaps_conv_4_aval_0_simp_11;
+    iint_t           perhaps_conv_4_aval_0_simp_12;
     ibool_t          acc_perhaps_conv_4_simp_8;
     iint_t           acc_perhaps_conv_4_simp_9;
     ibool_t          flat_0_simp_14;
@@ -96,27 +96,27 @@ void iprogram_0(iprogram_0_t *s)
     const itime_t   *const new_conv_0_simp_25 = s->new_conv_0_simp_25;
     
     for (iint_t i = 0; i < new_count; i++) {
-        iint_t           conv_1               = i;
+        ifactid_t        conv_1               = i;
         itime_t          conv_2               = new_conv_0_simp_25[i];
         ierror_t         conv_0_simp_23       = new_conv_0_simp_23[i];
         iint_t           conv_0_simp_24       = new_conv_0_simp_24[i];
         itime_t          conv_0_simp_25       = new_conv_0_simp_25[i];
-        aval_0_simp_11                        = acc_perhaps_conv_4_simp_8;            /* read */
-        aval_0_simp_12                        = acc_perhaps_conv_4_simp_9;            /* read */
-        aval_0_simp_13                        = acc_perhaps_conv_4_simp_10;           /* read */
+        perhaps_conv_4_aval_0_simp_11         = acc_perhaps_conv_4_simp_8;            /* read */
+        perhaps_conv_4_aval_0_simp_12         = acc_perhaps_conv_4_simp_9;            /* read */
+        perhaps_conv_4_aval_0_simp_13         = acc_perhaps_conv_4_simp_10;           /* read */
         flat_0_simp_14                        = ifalse;                               /* init */
         flat_0_simp_15                        = 0;                                    /* init */
         flat_0_simp_16                        = 0.0;                                  /* init */
         
-        if (aval_0_simp_11) {
+        if (perhaps_conv_4_aval_0_simp_11) {
             flat_0_simp_14                    = ifalse;                               /* write */
-            iint_t           simp_35          = idouble_trunc (aval_0_simp_13);       /* let */
+            iint_t           simp_35          = idouble_trunc (perhaps_conv_4_aval_0_simp_13); /* let */
             flat_0_simp_15                    = iint_add (simp_35, 1);                /* write */
             flat_0_simp_16                    = 0.0;                                  /* write */
         } else {
             flat_0_simp_14                    = itrue;                                /* write */
             flat_0_simp_15                    = 0;                                    /* write */
-            idouble_t        simp_53          = iint_extend (aval_0_simp_12);         /* let */
+            idouble_t        simp_53          = iint_extend (perhaps_conv_4_aval_0_simp_12); /* let */
             flat_0_simp_16                    = idouble_add (simp_53, 1.0);           /* write */
         }
         


### PR DESCRIPTION
This change affects flatten.
Flatten keeps track of all the accumulators in scope, and after the ForeachFacts loop, digs down into all the accumulators and pulls out any FactIdentifiers inside buffers.
We might want to add an option to disable this, since these loops are not necessary for Ice.