### PR TITLE
Standardise the prelude

### DIFF
--- a/data/libs/prelude.icicle
+++ b/data/libs/prelude.icicle
@@ -2,23 +2,37 @@
 ### Base ###
 ############
 
+# mod, relying on rounding.
+mod x y
+  = x - (trunc (double x / double y) * y).
+
 # Time statements
 newest v = latest 1 ~> fold1 s = v : v ~> s.
 oldest v = fold1 s = v : s ~> s.
 
+# check if a day is a weekend.
+is_weekend v
+  =  let day = mod (days v) 7
+  ~> day == 3 || day == 4.
+
+# starting at epoch 1600/01/03, identify the week that containing this day.
+week_of_day d
+  = trunc (double (days d) / 7).
+
 # Boolean statements
 not a = case a | True -> False | False -> True end.
 
-isSome a = case a | Some a' -> True  | None -> False end.
-isNone a = case a | Some a' -> False | None -> True  end.
+is_some a = case a | Some a' -> True  | None -> False end.
+is_none a = case a | Some a' -> False | None -> True  end.
 
-getOrElse default a  = case a | Some a' -> a' | None -> default end.
+get_or_else default a  = case a | Some a' -> a' | None -> default end.
 
 fst x = case x | (a,b) -> a end.
 snd x = case x | (a,b) -> b end.
 
-group_keys k     = keys (group k ~> 0).
-group_values k v = vals (group k ~> v).
+group_keys k = keys (group k ~> 0).
+
+return v = newest v.
 
 ##################
 ### Statistics ###
@@ -35,11 +49,12 @@ mean v = let v_ = double v
 max v = fold1 s = v : case v > s | True -> v | False -> s end ~> s.
 min v = fold1 s = v : case v < s | True -> v | False -> s end ~> s.
 
-minby a b = fold1 s = (a, b)
+
+min_by a b = fold1 s = (a, b)
    :  case s | (a1, b1) -> (case a < a1 | True -> (a,b) | False -> (a1,b1) end) end
    ~> case s | (a1, b1) -> b1 end.
 
-maxby a b = fold1 s = (a, b)
+max_by a b = fold1 s = (a, b)
    :  case s | (a1, b1) -> (case a > a1 | True -> (a,b) | False -> (a1,b1) end) end
    ~> case s | (a1, b1) -> b1 end.
 
@@ -96,3 +111,15 @@ numflips' v t
                                end )
           end
  ~> case s | (s0,i) -> i end.
+
+###############################
+### Backwards Compatibility ###
+###############################
+
+isSome a = is_some a.
+isNone a = is_none a.
+
+getOrElse d a = get_or_else d a.
+
+minby a b = min_by a b.
+maxby a b = max_by a b.

--- a/test/cli/repl/t01-sanity/expected
+++ b/test/cli/repl/t01-sanity/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Try a simple sum. Expect 1500 and 30.
 > - Core evaluation:

--- a/test/cli/repl/t02-groups/expected
+++ b/test/cli/repl/t02-groups/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Simplest group-by there is
 > - Core evaluation:

--- a/test/cli/repl/t03-distinct/expected
+++ b/test/cli/repl/t03-distinct/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Distinct by value. Expect 5 and 3
 > - Core evaluation:

--- a/test/cli/repl/t04-lets/expected
+++ b/test/cli/repl/t04-lets/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Elem/Scalar lets
 > - Core evaluation:

--- a/test/cli/repl/t05-nested-queries/expected
+++ b/test/cli/repl/t05-nested-queries/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- The ratio of > 300 to all?
 > - Core evaluation:

--- a/test/cli/repl/t06-custom-folds/expected
+++ b/test/cli/repl/t06-custom-folds/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Rolling average
 > - Core evaluation:

--- a/test/cli/repl/t07-possiblies/expected
+++ b/test/cli/repl/t07-possiblies/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Divisions return Possibles.
 > -- Try with group:

--- a/test/cli/repl/t08-randomly/expected
+++ b/test/cli/repl/t08-randomly/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- These two were failing before, but should pass now.
 > -- Not that they are particularly interesting.

--- a/test/cli/repl/t09-group-folds/expected
+++ b/test/cli/repl/t09-group-folds/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Count unique times, this is equivalent to `distinct time ~> count`
 > - Core evaluation:

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core-simp is now on

--- a/test/cli/repl/t10.2-core/expected
+++ b/test/cli/repl/t10.2-core/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core is now on

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core-simp is now on

--- a/test/cli/repl/t11-nested-dictionaries/expected
+++ b/test/cli/repl/t11-nested-dictionaries/expected
@@ -1,6 +1,6 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Load dictionary
-> ok, loaded dictionary with 7 features and 24 functions
+> ok, loaded dictionary with 7 features and 32 functions
 > 

--- a/test/cli/repl/t12-broken-dictionaries/expected
+++ b/test/cli/repl/t12-broken-dictionaries/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Load dictionary
 > Dictionary load error:

--- a/test/cli/repl/t13-cases-either/expected
+++ b/test/cli/repl/t13-cases-either/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, type is now on
 > - Type:

--- a/test/cli/repl/t14-dates/expected
+++ b/test/cli/repl/t14-dates/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, time set to 2010-01-01
 > > - Core evaluation:

--- a/test/cli/repl/t15-tombstones/expected
+++ b/test/cli/repl/t15-tombstones/expected
@@ -1,7 +1,7 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
-> ok, loaded dictionary with 1 features and 24 functions
+> ok, loaded dictionary with 1 features and 32 functions
 > ok, loaded test/cli/repl/t15-tombstones/data.psv, 5 rows
 > > - Core evaluation:
 [gonzo, [("a",False)

--- a/test/cli/repl/t16-prelude/expected
+++ b/test/cli/repl/t16-prelude/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Sum example
 > - Core evaluation:

--- a/test/cli/repl/t17-latest/expected
+++ b/test/cli/repl/t17-latest/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, type is now on
 > > -- Latests of groups

--- a/test/cli/repl/t18-nested-structs/expected
+++ b/test/cli/repl/t18-nested-structs/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, core evaluation is now on
 > ok, c evaluation now on
@@ -19,7 +19,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                    |  \_((_(_)|/(_)
                                    \             (
                                     \_____________)
-> > ok, loaded dictionary with 1 features and 24 functions
+> > ok, loaded dictionary with 1 features and 32 functions
 > ok, loaded test/cli/repl/t18-nested-structs/data.psv, 4 rows
 > > - C evaluation:
 [(homer,[(1,1.5),(2,6.5)])

--- a/test/cli/repl/t20-lexer/expected
+++ b/test/cli/repl/t20-lexer/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Numbers
 > - Core evaluation:
@@ -29,8 +29,8 @@ Check error:
       max                  : Element a -> Aggregate Possibly a
       mean                 : (Num a) => Element a -> Aggregate Possibly Double
       exp                  : Double -> Double
-      fst                  : (b, a) -> b
-      snd                  : (a, b) -> b
+      fst                  : (a, b) -> a
+      snd                  : (b, a) -> a
 
 > > -- Expect a parse error on unterminated string
 >                  λλλλ

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, flatten is now on

--- a/test/cli/repl/t30.1-eval/expected
+++ b/test/cli/repl/t30.1-eval/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on

--- a/test/cli/repl/t30.2-array-strings/expected
+++ b/test/cli/repl/t30.2-array-strings/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on
@@ -19,7 +19,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                    |  \_((_(_)|/(_)
                                    \             (
                                     \_____________)
-> > ok, loaded dictionary with 2 features and 24 functions
+> > ok, loaded dictionary with 2 features and 32 functions
 > ok, loaded test/cli/repl/t30.2-array-strings/data.psv, 5 rows
 > > - C evaluation:
 [(ID00000000,2)

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on

--- a/test/cli/repl/t31-builtin/expected
+++ b/test/cli/repl/t31-builtin/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 24 functions from data/libs/prelude.icicle
+ok, loaded 32 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, core evaluation is now on
 > ok, c evaluation now on
@@ -24,11 +24,5 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 
 - Core evaluation:
 [homer, ["arm","head","torso"]]
-
-> > - C evaluation:
-[(homer,[1,1,1])]
-
-- Core evaluation:
-[homer, [1,1,1]]
 
 > 

--- a/test/cli/repl/t31-builtin/script
+++ b/test/cli/repl/t31-builtin/script
@@ -2,5 +2,3 @@
 :set +c-eval
 
 feature injury ~> group_keys location
-
-feature injury ~> group_values location (newest severity)


### PR DESCRIPTION
* group_values is gone because it's silly (higher order functions!!!)
* snake case
* `return` which just promotes `Pure` to `Aggregate` at the query top level

@amosr 