### PR TITLE
Some speed things

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -75,10 +75,11 @@ library
                        Icicle.Avalanche.Annot
                        Icicle.Avalanche.Statement.Statement
                        Icicle.Avalanche.Statement.Simp
+                       Icicle.Avalanche.Statement.Simp.Constructor
                        Icicle.Avalanche.Statement.Simp.Dead
                        Icicle.Avalanche.Statement.Simp.Eval
                        Icicle.Avalanche.Statement.Simp.ExpEnv
-                       Icicle.Avalanche.Statement.Simp.Constructor
+                       Icicle.Avalanche.Statement.Simp.ThreshOrd
                        Icicle.Avalanche.Statement.Simp.Melt
                        Icicle.Avalanche.Statement.Simp.Mutate
                        Icicle.Avalanche.Statement.Flatten

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -315,7 +315,7 @@ substXinS a_fresh name payload statements
       _
        -> return (True, s)
 
-  sub = subst a_fresh name payload
+  sub = subst a_fresh (Map.singleton name payload)
   sub1 x f
    = do x' <- sub x
         return (True, f x')

--- a/src/Icicle/Avalanche/Statement/Simp/Dead.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Dead.hs
@@ -30,7 +30,6 @@ data Usage n
  { usageAcc :: Set (Name n)
  , usageExp :: Set (Name n)
  }
- deriving Eq
 
 instance Eq n => Monoid (Usage n) where
  mempty = Usage Set.empty Set.empty
@@ -119,10 +118,17 @@ deadS us statements
 deadLoop :: (Hashable n, Eq n) => Usage n -> Statement a n p -> (Usage n, Statement a n p)
 deadLoop us ss
  = let (sU, sS) = deadS us ss
-   in  if   sU == us
+   in  if   sU `eqUsage` us
        then (sU, sS)
        -- Make sure to use the original statements
        else deadLoop sU ss
+ where
+  -- We can cheat when checking 'equality' of the usage sets:
+  -- if they are the same size, they must contain the same elements.
+  -- (Because one is obtained by only inserting elements to the other)
+  eqUsage a b
+   =  Set.size (usageAcc a) == Set.size (usageAcc b)
+   && Set.size (usageExp a) == Set.size (usageExp b)
 
 
 usageX :: (Hashable n, Eq n) => Exp a n p -> Usage n

--- a/src/Icicle/Avalanche/Statement/Simp/ThreshOrd.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/ThreshOrd.hs
@@ -1,0 +1,124 @@
+-- | Special "Ord" instance for Thresher transform.
+-- Faster.
+{-# LANGUAGE NoImplicitPrelude #-}
+module Icicle.Avalanche.Statement.Simp.ThreshOrd (
+    ThreshMapOrd(..)
+  ) where
+
+import              Icicle.Avalanche.Prim.Flat
+import qualified    Icicle.Common.Exp.Prim.Minimal as Min
+
+import              Icicle.Common.Exp
+
+import              P
+
+import              Data.Hashable (Hashable)
+
+-- | Ord instance specifically for Thresher.
+-- The original Ord instance checks equality on types, annotations, and all sorts of junk.
+-- This isn't necessary most of the time, because if you have "plus" applied to two arguments,
+-- it doesn't matter what the type is: it only matters if the two arguments are the same.
+newtype ThreshMapOrd a n
+ = ThreshMapOrd (Exp a n Prim)
+
+instance (Ord a, Hashable n, Eq n) => Eq (ThreshMapOrd a n) where
+ (==) a b = (compare a b) == EQ
+
+instance (Ord a, Hashable n, Eq n) => Ord (ThreshMapOrd a n) where
+ compare (ThreshMapOrd topx) (ThreshMapOrd topy) = goX topx topy
+  where
+   goX x y
+    = case (x, y) of
+      (XVar _ n, XVar _ n')
+       -> compare n n'
+      (XPrim _ p, XPrim _ p')
+       -> goP p p'
+      (XValue{}, XValue{})
+       -> compare x y -- compare v v'
+      (XApp _ p q, XApp _ p' q')
+       -> case goX p p' of
+           LT -> LT
+           EQ -> goX q q'
+           GT -> GT
+
+      -- Lambdas and lets should not occur, so we can defer to slow case for those
+      _ -> compare x y
+
+   goP x y
+    = case (x, y) of
+       (PrimMinimal p, PrimMinimal p')-> goPm p p'
+       (PrimProject p, PrimProject p')-> goPr p p'
+       (PrimUnsafe p, PrimUnsafe p')  -> goPu p p'
+       (PrimArray p,  PrimArray p')   -> goPa p p'
+       (PrimMelt p,   PrimMelt p')    -> goPMe p p'
+       (PrimMap p,    PrimMap p')     -> goPMa p p'
+       (PrimBuf p,    PrimBuf p')     -> goPB p p'
+       (_, _) -> compare x y
+
+   goPm x y
+    = case (x, y) of
+       (Min.PrimArithUnary p _, Min.PrimArithUnary p' _) -> compare p p'
+       (Min.PrimArithBinary p _, Min.PrimArithBinary p' _) -> compare p p'
+       (Min.PrimToString _, Min.PrimToString _) -> EQ
+       (Min.PrimRelation p _, Min.PrimRelation p' _) -> compare p p'
+       (Min.PrimLogical p, Min.PrimLogical p') -> compare p p'
+       -- Constructors actually do matter what their type is.
+       -- > left [Int] [Bool] 0
+       -- can't be replaced with
+       -- > left [Int] [big thing] 0
+       -- can it?
+       (Min.PrimConst p, Min.PrimConst p') ->  compare p p'
+       (Min.PrimPair Min.PrimPairFst{}, Min.PrimPair Min.PrimPairFst{}) -> EQ
+       (Min.PrimPair Min.PrimPairSnd{}, Min.PrimPair Min.PrimPairSnd{}) -> EQ
+       (Min.PrimStruct (Min.PrimStructGet p _ _), Min.PrimStruct (Min.PrimStructGet p' _ _)) -> compare p p'
+       (Min.PrimTime p, Min.PrimTime p') -> compare p p'
+       (Min.PrimBuiltinFun p, Min.PrimBuiltinFun p') -> compare p p'
+
+       (_, _) -> compare x y
+
+   goPr x y
+    = case (x, y) of
+       (PrimProjectArrayLength{}, PrimProjectArrayLength{}) -> EQ
+       (PrimProjectOptionIsSome{}, PrimProjectOptionIsSome{}) -> EQ
+       (PrimProjectSumIsRight{}, PrimProjectSumIsRight{}) -> EQ
+       (_, _) -> compare x y
+
+   goPu x y
+    = case (x, y) of
+       (PrimUnsafeArrayIndex{}, PrimUnsafeArrayIndex{}) -> EQ
+       (PrimUnsafeArrayCreate{}, PrimUnsafeArrayCreate{}) -> compare x y
+       (PrimUnsafeSumGetLeft{}, PrimUnsafeSumGetLeft{}) -> EQ
+       (PrimUnsafeSumGetRight{}, PrimUnsafeSumGetRight{}) -> EQ
+       (PrimUnsafeOptionGet{}, PrimUnsafeOptionGet{}) -> EQ
+
+       (_, _) -> compare x y
+
+   goPa x y
+    = case (x, y) of
+       (PrimArrayPutMutable{}, PrimArrayPutMutable{}) -> EQ
+       (PrimArrayPutImmutable{}, PrimArrayPutImmutable{}) -> EQ
+       (PrimArrayZip{}, PrimArrayZip{}) -> EQ
+       (_, _) -> compare x y
+
+   goPMe x y
+    = case (x, y) of
+       (PrimMeltPack{}, PrimMeltPack{}) -> EQ
+       (PrimMeltUnpack i _, PrimMeltUnpack i' _) -> compare i i'
+       (_, _) -> compare x y
+
+   goPMa x y
+    = case (x, y) of
+       (PrimMapPack{}, PrimMapPack{}) -> EQ
+       (PrimMapUnpackKeys{}, PrimMapUnpackKeys{}) -> EQ
+       (PrimMapUnpackValues{}, PrimMapUnpackValues{}) -> EQ
+       (_, _) -> compare x y
+
+   goPB x y
+    = case (x, y) of
+       (PrimBufMake{}, PrimBufMake{}) -> compare x y
+       (PrimBufPush{}, PrimBufPush{}) -> EQ
+       (PrimBufRead{}, PrimBufRead{}) -> EQ
+       (_, _) -> compare x y
+
+
+

--- a/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Statement.hs
@@ -68,13 +68,6 @@ data Statement a n p
 
 instance Monoid (Statement a n p) where
  mempty = Block []
-
- mappend (Block ps) (Block qs)
-        = Block (ps <> qs)
- mappend (Block ps) q
-        = Block (ps <> [q])
- mappend p (Block qs)
-        = Block (p : qs)
  mappend p q
         = Block [p, q]
 

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -234,6 +234,9 @@ subst :: (Hashable n, Eq n)
       -> Exp a n p
       -> Fresh n (Exp a n p)
 subst a_fresh env into
+ | Map.null env
+ = return into
+ | otherwise
  = subst' a_fresh env (Set.unions $ Map.elems $ Map.map freevars env) into
 
 subst'  :: (Hashable n, Eq n)

--- a/src/Icicle/Common/Exp/Compounds.hs
+++ b/src/Icicle/Common/Exp/Compounds.hs
@@ -14,6 +14,7 @@ module Icicle.Common.Exp.Compounds (
     , allvars
     , allvarsExp
     , substMaybe
+    , subst1
     , subst
     , reannotX
     , eraseAnnotX
@@ -216,21 +217,38 @@ substMaybe name payload into
 
 -- | Substitute an expression in,
 -- using fresh names to avoid capture
-subst :: (Hashable n, Eq n)
+subst1 :: (Hashable n, Eq n)
       => a
       -> Name n
       -> Exp a n p
       -> Exp a n p
       -> Fresh n (Exp a n p)
-subst a_fresh name payload into
+subst1 a_fresh name payload into
+ = subst a_fresh (Map.singleton name payload) into
+
+-- | Substitute an expression in,
+-- using fresh names to avoid capture
+subst :: (Hashable n, Eq n)
+      => a
+      -> Map.Map (Name n) (Exp a n p)
+      -> Exp a n p
+      -> Fresh n (Exp a n p)
+subst a_fresh env into
+ = subst' a_fresh env (Set.unions $ Map.elems $ Map.map freevars env) into
+
+subst'  :: (Hashable n, Eq n)
+        => a
+        -> Map.Map (Name n) (Exp a n p)
+        -> Set.Set (Name n)
+        -> Exp a n p
+        -> Fresh n (Exp a n p)
+subst' a_fresh env frees into
  = go into
  where
-  payload_free = freevars payload
-
   go xx
    = case xx of
       XVar _ n
-       | n == name
+       | Just payload <- Map.lookup n env
        -> return payload
        | otherwise
        -> return xx
@@ -243,28 +261,30 @@ subst a_fresh name payload into
        -> return xx
 
       XLam a n t x
-       -- If the name clashes, we need to rename n
-       | (n `Set.member` payload_free) || n == name
-       -> do    n' <- fresh
-                x' <- subst a_fresh n (XVar a_fresh n') x
-                XLam a n' t <$> go x'
+       -- If the name is in the free set of all payloads or it *has* a payload,
+       -- might as well rename it.
+       | n `Set.member` frees || n `Map.member` env
+       -> do  -- Generate fresh name and add to environment
+              -- We do not actually need to insert n' into the free set
+              -- because it is fresh, and cannot occur in the expression.
+              n' <- fresh
+              let env' = Map.insert n (XVar a_fresh n') env
+              XLam a n' t <$> subst' a_fresh env' frees x
 
        -- Name is mentioned and no clashes, so proceed
        | otherwise
        -> XLam a n t <$> go x
 
       XLet a n x1 x2
-       -- If the let's name clashes with the substitution we're trying to make,
-       -- we need to rename
-       | (n `Set.member` payload_free) || n == name
-       -> do    n'  <- fresh
-                x2' <- subst a_fresh n (XVar a_fresh n') x2
-                XLet a n' <$> go x1 <*> go x2'
+       -- As with lambda
+       | n `Set.member` frees || n `Map.member` env
+       -> do  n'  <- fresh
+              let env' = Map.insert n (XVar a_fresh n') env
+              XLet a n' <$> go x1 <*> subst' a_fresh env' frees x2
 
        -- Proceed as usual
        | otherwise
        -> XLet a n <$> go x1 <*> go x2
-
 
 reannotX :: (a -> a') -> Exp a n p -> Exp a' n  p
 reannotX f xx

--- a/src/Icicle/Common/Exp/Simp/ANormal.hs
+++ b/src/Icicle/Common/Exp/Simp/ANormal.hs
@@ -101,7 +101,7 @@ anormalAllVars a_fresh xx
         let a_fresh' = (a_fresh, allNames)
         let lets = makeLets a_fresh' bs x
         -- Substitute with the new name
-        lets' <- subst a_fresh' n (XVar a_fresh' n') lets
+        lets' <- subst1 a_fresh' n (XVar a_fresh' n') lets
 
         -- It's silly, but we need to pull back out to a list of bindings again.
         -- We could save some work by going backwards, but this way seems simpler for now.

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -13,6 +13,7 @@ init acc$conv$26@{Buf 3 (Sum Error Int)} = Buf []@{Buf 3 (Sum Error Int)};
 load_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
 load_resumable@{(Sum Error Int)} acc$c$conv$11;
 load_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
+
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
   let anf$0 = fst#@{(Sum Error Int), Time} conv$0;
@@ -42,6 +43,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Tim
 save_resumable@{Buf 3 (Sum Error Int)} acc$conv$26;
 save_resumable@{(Sum Error Int)} acc$c$conv$11;
 save_resumable@{((Sum Error Int), ((Sum Error Int), Time))} acc$conv$10;
+
 read conv$26 = acc$conv$26 [Buf 3 (Sum Error Int)];
 read c$conv$11 = acc$c$conv$11 [(Sum Error Int)];
 let conv$31 = Sum_fold#@{(Error,Int)}@{(Sum Error (Int, Array (Sum Error Int)))} 
@@ -64,6 +66,7 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$31@{(Sum Error (Int
 conv$3 = TIME
 init acc$conv$4@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
 load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
+
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
   read conv$4$aval$0 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
@@ -73,6 +76,7 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Tim
     (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 conv$4$aval$0;
 }
 save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$4;
+
 read conv$4 = acc$conv$4 [Map Time (Buf 2 ((Sum Error Int), Time))];
 let conv$39 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
   (\conv$36@{(Sum Error (Map Time Int))} \conv$31@{Time} \conv$33@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -97,11 +97,20 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$60@{Error}, conv$
     write acc$c$conv$11$simp$14 = flat$2$simp$40;
   }
   read acc$conv$26$simp$15 = acc$conv$26$simp$15 [Buf 3 FactIdentifier];
+  
   write acc$conv$26$simp$15 = Buf_push#@{Buf 3 FactIdentifier} acc$conv$26$simp$15 conv$1;
   read acc$conv$26$simp$16 = acc$conv$26$simp$16 [Buf 3 Error];
+  
+  
   write acc$conv$26$simp$16 = Buf_push#@{Buf 3 Error} acc$conv$26$simp$16 conv$0$simp$60;
   read acc$conv$26$simp$17 = acc$conv$26$simp$17 [Buf 3 Int];
+  
+  
   write acc$conv$26$simp$17 = Buf_push#@{Buf 3 Int} acc$conv$26$simp$17 conv$0$simp$61;
+  
+  
+  
+  
 }
 read acc$conv$26$flat$16$simp$44 = acc$conv$26$simp$15 [Buf 3 FactIdentifier];
 let flat$17 = Buf_read#@{Array FactIdentifier} acc$conv$26$flat$16$simp$44;
@@ -109,6 +118,7 @@ foreach (flat$18 in 0@{Int} .. Array_length#@{FactIdentifier} flat$17)
 {
   keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$17 flat$18;
 }
+
 save_resumable@{Buf 3 FactIdentifier} acc$conv$26$simp$15;
 save_resumable@{Buf 3 Error} acc$conv$26$simp$16;
 save_resumable@{Buf 3 Int} acc$conv$26$simp$17;

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -114,427 +114,427 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$282@{Error}, conv
   read s$reify$6$conv$12$aval$1$simp$104 = acc$s$reify$6$conv$12$simp$47 [Error];
   read s$reify$6$conv$12$aval$1$simp$105 = acc$s$reify$6$conv$12$simp$48 [Double];
   read s$reify$6$conv$12$aval$1$simp$106 = acc$s$reify$6$conv$12$simp$49 [Double];
-  init flat$3$simp$107@{Error} = ExceptNotAnError@{Error};
-  init flat$3$simp$108@{Double} = 0.0@{Double};
-  init flat$3$simp$109@{Double} = 0.0@{Double};
+  init flat$9$simp$107@{Error} = ExceptNotAnError@{Error};
+  init flat$9$simp$108@{Double} = 0.0@{Double};
+  init flat$9$simp$109@{Double} = 0.0@{Double};
   if (eq#@{Error} s$reify$6$conv$12$aval$1$simp$104 (ExceptNotAnError@{Error}))
   {
-    init flat$10$simp$110@{Error} = ExceptNotAnError@{Error};
-    init flat$10$simp$111@{Double} = 0.0@{Double};
-    init flat$10$simp$112@{Double} = 0.0@{Double};
+    init flat$16$simp$110@{Error} = ExceptNotAnError@{Error};
+    init flat$16$simp$111@{Double} = 0.0@{Double};
+    init flat$16$simp$112@{Double} = 0.0@{Double};
     if (eq#@{Error} s$reify$6$conv$12$aval$1$simp$104 (ExceptNotAnError@{Error}))
     {
-      init flat$13$simp$113@{Error} = ExceptNotAnError@{Error};
-      init flat$13$simp$114@{Double} = 0.0@{Double};
+      init flat$19$simp$113@{Error} = ExceptNotAnError@{Error};
+      init flat$19$simp$114@{Double} = 0.0@{Double};
       if (eq#@{Error} conv$11$aval$2$simp$96 (ExceptNotAnError@{Error}))
       {
-        write flat$13$simp$113 = ExceptNotAnError@{Error};
-        write flat$13$simp$114 = sub#@{Double} conv$11$aval$2$simp$97 s$reify$6$conv$12$aval$1$simp$105;
+        write flat$19$simp$113 = ExceptNotAnError@{Error};
+        write flat$19$simp$114 = sub#@{Double} conv$11$aval$2$simp$97 s$reify$6$conv$12$aval$1$simp$105;
       }
       else
       {
-        write flat$13$simp$113 = conv$11$aval$2$simp$96;
-        write flat$13$simp$114 = 0.0@{Double};
+        write flat$19$simp$113 = conv$11$aval$2$simp$96;
+        write flat$19$simp$114 = 0.0@{Double};
       }
-      read flat$13$simp$115 = flat$13$simp$113 [Error];
-      read flat$13$simp$116 = flat$13$simp$114 [Double];
-      init flat$14$simp$117@{Error} = ExceptNotAnError@{Error};
-      init flat$14$simp$118@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$13$simp$115 (ExceptNotAnError@{Error}))
+      read flat$19$simp$115 = flat$19$simp$113 [Error];
+      read flat$19$simp$116 = flat$19$simp$114 [Double];
+      init flat$20$simp$117@{Error} = ExceptNotAnError@{Error};
+      init flat$20$simp$118@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$19$simp$115 (ExceptNotAnError@{Error}))
       {
-        write flat$14$simp$117 = ExceptNotAnError@{Error};
+        write flat$20$simp$117 = ExceptNotAnError@{Error};
         let simp$354 = add#@{Double} s$reify$6$conv$12$aval$1$simp$106 (1.0@{Double});
-        write flat$14$simp$118 = div# flat$13$simp$116 simp$354;
+        write flat$20$simp$118 = div# flat$19$simp$116 simp$354;
       }
       else
       {
-        write flat$14$simp$117 = flat$13$simp$115;
-        write flat$14$simp$118 = 0.0@{Double};
+        write flat$20$simp$117 = flat$19$simp$115;
+        write flat$20$simp$118 = 0.0@{Double};
       }
-      read flat$14$simp$119 = flat$14$simp$117 [Error];
-      read flat$14$simp$120 = flat$14$simp$118 [Double];
-      init flat$15$simp$121@{Error} = ExceptNotAnError@{Error};
-      init flat$15$simp$122@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$14$simp$119 (ExceptNotAnError@{Error}))
+      read flat$20$simp$119 = flat$20$simp$117 [Error];
+      read flat$20$simp$120 = flat$20$simp$118 [Double];
+      init flat$21$simp$121@{Error} = ExceptNotAnError@{Error};
+      init flat$21$simp$122@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$20$simp$119 (ExceptNotAnError@{Error}))
       {
-        write flat$15$simp$121 = ExceptNotAnError@{Error};
-        write flat$15$simp$122 = add#@{Double} s$reify$6$conv$12$aval$1$simp$105 flat$14$simp$120;
+        write flat$21$simp$121 = ExceptNotAnError@{Error};
+        write flat$21$simp$122 = add#@{Double} s$reify$6$conv$12$aval$1$simp$105 flat$20$simp$120;
       }
       else
       {
-        write flat$15$simp$121 = flat$14$simp$119;
-        write flat$15$simp$122 = 0.0@{Double};
+        write flat$21$simp$121 = flat$20$simp$119;
+        write flat$21$simp$122 = 0.0@{Double};
       }
-      read flat$15$simp$123 = flat$15$simp$121 [Error];
-      read flat$15$simp$124 = flat$15$simp$122 [Double];
-      init flat$16$simp$125@{Error} = ExceptNotAnError@{Error};
-      init flat$16$simp$126@{Double} = 0.0@{Double};
-      init flat$16$simp$127@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$15$simp$123 (ExceptNotAnError@{Error}))
+      read flat$21$simp$123 = flat$21$simp$121 [Error];
+      read flat$21$simp$124 = flat$21$simp$122 [Double];
+      init flat$22$simp$125@{Error} = ExceptNotAnError@{Error};
+      init flat$22$simp$126@{Double} = 0.0@{Double};
+      init flat$22$simp$127@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$21$simp$123 (ExceptNotAnError@{Error}))
       {
-        write flat$16$simp$125 = ExceptNotAnError@{Error};
-        write flat$16$simp$126 = flat$15$simp$124;
-        write flat$16$simp$127 = add#@{Double} s$reify$6$conv$12$aval$1$simp$106 (1.0@{Double});
+        write flat$22$simp$125 = ExceptNotAnError@{Error};
+        write flat$22$simp$126 = flat$21$simp$124;
+        write flat$22$simp$127 = add#@{Double} s$reify$6$conv$12$aval$1$simp$106 (1.0@{Double});
       }
       else
       {
-        write flat$16$simp$125 = flat$15$simp$123;
-        write flat$16$simp$126 = 0.0@{Double};
-        write flat$16$simp$127 = 0.0@{Double};
+        write flat$22$simp$125 = flat$21$simp$123;
+        write flat$22$simp$126 = 0.0@{Double};
+        write flat$22$simp$127 = 0.0@{Double};
       }
-      read flat$16$simp$128 = flat$16$simp$125 [Error];
-      read flat$16$simp$129 = flat$16$simp$126 [Double];
-      read flat$16$simp$130 = flat$16$simp$127 [Double];
-      write flat$10$simp$110 = flat$16$simp$128;
-      write flat$10$simp$111 = flat$16$simp$129;
-      write flat$10$simp$112 = flat$16$simp$130;
+      read flat$22$simp$128 = flat$22$simp$125 [Error];
+      read flat$22$simp$129 = flat$22$simp$126 [Double];
+      read flat$22$simp$130 = flat$22$simp$127 [Double];
+      write flat$16$simp$110 = flat$22$simp$128;
+      write flat$16$simp$111 = flat$22$simp$129;
+      write flat$16$simp$112 = flat$22$simp$130;
     }
     else
     {
-      write flat$10$simp$110 = s$reify$6$conv$12$aval$1$simp$104;
-      write flat$10$simp$111 = 0.0@{Double};
-      write flat$10$simp$112 = 0.0@{Double};
+      write flat$16$simp$110 = s$reify$6$conv$12$aval$1$simp$104;
+      write flat$16$simp$111 = 0.0@{Double};
+      write flat$16$simp$112 = 0.0@{Double};
     }
-    read flat$10$simp$131 = flat$10$simp$110 [Error];
-    read flat$10$simp$132 = flat$10$simp$111 [Double];
-    read flat$10$simp$133 = flat$10$simp$112 [Double];
-    write flat$3$simp$107 = flat$10$simp$131;
-    write flat$3$simp$108 = flat$10$simp$132;
-    write flat$3$simp$109 = flat$10$simp$133;
+    read flat$16$simp$131 = flat$16$simp$110 [Error];
+    read flat$16$simp$132 = flat$16$simp$111 [Double];
+    read flat$16$simp$133 = flat$16$simp$112 [Double];
+    write flat$9$simp$107 = flat$16$simp$131;
+    write flat$9$simp$108 = flat$16$simp$132;
+    write flat$9$simp$109 = flat$16$simp$133;
   }
   else
   {
-    init flat$6$simp$134@{Error} = ExceptNotAnError@{Error};
-    init flat$6$simp$135@{Double} = 0.0@{Double};
-    init flat$6$simp$136@{Double} = 0.0@{Double};
+    init flat$12$simp$134@{Error} = ExceptNotAnError@{Error};
+    init flat$12$simp$135@{Double} = 0.0@{Double};
+    init flat$12$simp$136@{Double} = 0.0@{Double};
     if (eq#@{Error} (ExceptFold1NoValue@{Error}) s$reify$6$conv$12$aval$1$simp$104)
     {
-      init flat$7$simp$137@{Error} = ExceptNotAnError@{Error};
-      init flat$7$simp$138@{Double} = 0.0@{Double};
-      init flat$7$simp$139@{Double} = 0.0@{Double};
+      init flat$13$simp$137@{Error} = ExceptNotAnError@{Error};
+      init flat$13$simp$138@{Double} = 0.0@{Double};
+      init flat$13$simp$139@{Double} = 0.0@{Double};
       if (eq#@{Error} conv$11$aval$2$simp$96 (ExceptNotAnError@{Error}))
       {
-        write flat$7$simp$137 = ExceptNotAnError@{Error};
-        write flat$7$simp$138 = conv$11$aval$2$simp$97;
-        write flat$7$simp$139 = 1.0@{Double};
+        write flat$13$simp$137 = ExceptNotAnError@{Error};
+        write flat$13$simp$138 = conv$11$aval$2$simp$97;
+        write flat$13$simp$139 = 1.0@{Double};
       }
       else
       {
-        write flat$7$simp$137 = conv$11$aval$2$simp$96;
-        write flat$7$simp$138 = 0.0@{Double};
-        write flat$7$simp$139 = 0.0@{Double};
+        write flat$13$simp$137 = conv$11$aval$2$simp$96;
+        write flat$13$simp$138 = 0.0@{Double};
+        write flat$13$simp$139 = 0.0@{Double};
       }
-      read flat$7$simp$140 = flat$7$simp$137 [Error];
-      read flat$7$simp$141 = flat$7$simp$138 [Double];
-      read flat$7$simp$142 = flat$7$simp$139 [Double];
-      write flat$6$simp$134 = flat$7$simp$140;
-      write flat$6$simp$135 = flat$7$simp$141;
-      write flat$6$simp$136 = flat$7$simp$142;
+      read flat$13$simp$140 = flat$13$simp$137 [Error];
+      read flat$13$simp$141 = flat$13$simp$138 [Double];
+      read flat$13$simp$142 = flat$13$simp$139 [Double];
+      write flat$12$simp$134 = flat$13$simp$140;
+      write flat$12$simp$135 = flat$13$simp$141;
+      write flat$12$simp$136 = flat$13$simp$142;
     }
     else
     {
-      write flat$6$simp$134 = s$reify$6$conv$12$aval$1$simp$104;
-      write flat$6$simp$135 = 0.0@{Double};
-      write flat$6$simp$136 = 0.0@{Double};
+      write flat$12$simp$134 = s$reify$6$conv$12$aval$1$simp$104;
+      write flat$12$simp$135 = 0.0@{Double};
+      write flat$12$simp$136 = 0.0@{Double};
     }
-    read flat$6$simp$143 = flat$6$simp$134 [Error];
-    read flat$6$simp$144 = flat$6$simp$135 [Double];
-    read flat$6$simp$145 = flat$6$simp$136 [Double];
-    write flat$3$simp$107 = flat$6$simp$143;
-    write flat$3$simp$108 = flat$6$simp$144;
-    write flat$3$simp$109 = flat$6$simp$145;
+    read flat$12$simp$143 = flat$12$simp$134 [Error];
+    read flat$12$simp$144 = flat$12$simp$135 [Double];
+    read flat$12$simp$145 = flat$12$simp$136 [Double];
+    write flat$9$simp$107 = flat$12$simp$143;
+    write flat$9$simp$108 = flat$12$simp$144;
+    write flat$9$simp$109 = flat$12$simp$145;
   }
-  read flat$3$simp$146 = flat$3$simp$107 [Error];
-  read flat$3$simp$147 = flat$3$simp$108 [Double];
-  read flat$3$simp$148 = flat$3$simp$109 [Double];
-  write acc$s$reify$6$conv$12$simp$47 = flat$3$simp$146;
-  write acc$s$reify$6$conv$12$simp$48 = flat$3$simp$147;
-  write acc$s$reify$6$conv$12$simp$49 = flat$3$simp$148;
-  init flat$25$simp$149@{Error} = ExceptNotAnError@{Error};
-  init flat$25$simp$150@{String} = ""@{String};
+  read flat$9$simp$146 = flat$9$simp$107 [Error];
+  read flat$9$simp$147 = flat$9$simp$108 [Double];
+  read flat$9$simp$148 = flat$9$simp$109 [Double];
+  write acc$s$reify$6$conv$12$simp$47 = flat$9$simp$146;
+  write acc$s$reify$6$conv$12$simp$48 = flat$9$simp$147;
+  write acc$s$reify$6$conv$12$simp$49 = flat$9$simp$148;
+  init flat$31$simp$149@{Error} = ExceptNotAnError@{Error};
+  init flat$31$simp$150@{String} = ""@{String};
   if (eq#@{Error} conv$0$simp$282 (ExceptNotAnError@{Error}))
   {
-    write flat$25$simp$149 = ExceptNotAnError@{Error};
-    write flat$25$simp$150 = conv$0$simp$283;
+    write flat$31$simp$149 = ExceptNotAnError@{Error};
+    write flat$31$simp$150 = conv$0$simp$283;
   }
   else
   {
-    write flat$25$simp$149 = conv$0$simp$282;
-    write flat$25$simp$150 = ""@{String};
+    write flat$31$simp$149 = conv$0$simp$282;
+    write flat$31$simp$150 = ""@{String};
   }
-  read flat$25$simp$151 = flat$25$simp$149 [Error];
-  read flat$25$simp$152 = flat$25$simp$150 [String];
-  init flat$26$simp$153@{Error} = ExceptNotAnError@{Error};
-  init flat$26$simp$154@{Bool} = False@{Bool};
-  if (eq#@{Error} flat$25$simp$151 (ExceptNotAnError@{Error}))
+  read flat$31$simp$151 = flat$31$simp$149 [Error];
+  read flat$31$simp$152 = flat$31$simp$150 [String];
+  init flat$32$simp$153@{Error} = ExceptNotAnError@{Error};
+  init flat$32$simp$154@{Bool} = False@{Bool};
+  if (eq#@{Error} flat$31$simp$151 (ExceptNotAnError@{Error}))
   {
-    write flat$26$simp$153 = ExceptNotAnError@{Error};
-    write flat$26$simp$154 = eq#@{String} flat$25$simp$152 ("torso"@{String});
-  }
-  else
-  {
-    write flat$26$simp$153 = flat$25$simp$151;
-    write flat$26$simp$154 = False@{Bool};
-  }
-  read flat$26$simp$155 = flat$26$simp$153 [Error];
-  read flat$26$simp$156 = flat$26$simp$154 [Bool];
-  init flat$27@{Bool} = False@{Bool};
-  if (eq#@{Error} flat$26$simp$155 (ExceptNotAnError@{Error}))
-  {
-    write flat$27 = flat$26$simp$156;
+    write flat$32$simp$153 = ExceptNotAnError@{Error};
+    write flat$32$simp$154 = eq#@{String} flat$31$simp$152 ("torso"@{String});
   }
   else
   {
-    write flat$27 = True@{Bool};
+    write flat$32$simp$153 = flat$31$simp$151;
+    write flat$32$simp$154 = False@{Bool};
   }
-  read flat$27 = flat$27 [Bool];
-  if (flat$27)
+  read flat$32$simp$155 = flat$32$simp$153 [Error];
+  read flat$32$simp$156 = flat$32$simp$154 [Bool];
+  init flat$33@{Bool} = False@{Bool};
+  if (eq#@{Error} flat$32$simp$155 (ExceptNotAnError@{Error}))
   {
-    init flat$28$simp$157@{Error} = ExceptNotAnError@{Error};
-    init flat$28$simp$158@{Int} = 0@{Int};
+    write flat$33 = flat$32$simp$156;
+  }
+  else
+  {
+    write flat$33 = True@{Bool};
+  }
+  read flat$33 = flat$33 [Bool];
+  if (flat$33)
+  {
+    init flat$34$simp$157@{Error} = ExceptNotAnError@{Error};
+    init flat$34$simp$158@{Int} = 0@{Int};
     if (eq#@{Error} conv$0$simp$282 (ExceptNotAnError@{Error}))
     {
-      write flat$28$simp$157 = ExceptNotAnError@{Error};
-      write flat$28$simp$158 = conv$0$simp$284;
+      write flat$34$simp$157 = ExceptNotAnError@{Error};
+      write flat$34$simp$158 = conv$0$simp$284;
     }
     else
     {
-      write flat$28$simp$157 = conv$0$simp$282;
-      write flat$28$simp$158 = 0@{Int};
+      write flat$34$simp$157 = conv$0$simp$282;
+      write flat$34$simp$158 = 0@{Int};
     }
-    read flat$28$simp$159 = flat$28$simp$157 [Error];
-    read flat$28$simp$160 = flat$28$simp$158 [Int];
-    write acc$conv$57$simp$50 = flat$28$simp$159;
-    write acc$conv$57$simp$51 = flat$28$simp$160;
+    read flat$34$simp$159 = flat$34$simp$157 [Error];
+    read flat$34$simp$160 = flat$34$simp$158 [Int];
+    write acc$conv$57$simp$50 = flat$34$simp$159;
+    write acc$conv$57$simp$51 = flat$34$simp$160;
     read conv$57$aval$3$simp$161 = acc$conv$57$simp$50 [Error];
     read conv$57$aval$3$simp$162 = acc$conv$57$simp$51 [Int];
     write acc$conv$58$simp$56 = conv$57$aval$3$simp$161;
     write acc$conv$58$simp$57 = conv$57$aval$3$simp$162;
     read conv$58$aval$4$simp$167 = acc$conv$58$simp$56 [Error];
     read conv$58$aval$4$simp$168 = acc$conv$58$simp$57 [Int];
-    init flat$29$simp$175@{Error} = ExceptNotAnError@{Error};
-    init flat$29$simp$176@{Double} = 0.0@{Double};
+    init flat$35$simp$175@{Error} = ExceptNotAnError@{Error};
+    init flat$35$simp$176@{Double} = 0.0@{Double};
     if (eq#@{Error} conv$58$aval$4$simp$167 (ExceptNotAnError@{Error}))
     {
-      write flat$29$simp$175 = ExceptNotAnError@{Error};
-      write flat$29$simp$176 = doubleOfInt# conv$58$aval$4$simp$168;
+      write flat$35$simp$175 = ExceptNotAnError@{Error};
+      write flat$35$simp$176 = doubleOfInt# conv$58$aval$4$simp$168;
     }
     else
     {
-      write flat$29$simp$175 = conv$58$aval$4$simp$167;
-      write flat$29$simp$176 = 0.0@{Double};
+      write flat$35$simp$175 = conv$58$aval$4$simp$167;
+      write flat$35$simp$176 = 0.0@{Double};
     }
-    read flat$29$simp$177 = flat$29$simp$175 [Error];
-    read flat$29$simp$178 = flat$29$simp$176 [Double];
-    write acc$conv$62$simp$64 = flat$29$simp$177;
-    write acc$conv$62$simp$65 = flat$29$simp$178;
+    read flat$35$simp$177 = flat$35$simp$175 [Error];
+    read flat$35$simp$178 = flat$35$simp$176 [Double];
+    write acc$conv$62$simp$64 = flat$35$simp$177;
+    write acc$conv$62$simp$65 = flat$35$simp$178;
     read conv$62$aval$6$simp$179 = acc$conv$62$simp$64 [Error];
     read conv$62$aval$6$simp$180 = acc$conv$62$simp$65 [Double];
     read a$conv$63$aval$5$simp$189 = acc$a$conv$63$simp$74 [Error];
     read a$conv$63$aval$5$simp$190 = acc$a$conv$63$simp$75 [Double];
     read a$conv$63$aval$5$simp$191 = acc$a$conv$63$simp$76 [Double];
     read a$conv$63$aval$5$simp$192 = acc$a$conv$63$simp$77 [Double];
-    init flat$30$simp$193@{Error} = ExceptNotAnError@{Error};
-    init flat$30$simp$194@{Double} = 0.0@{Double};
-    init flat$30$simp$195@{Double} = 0.0@{Double};
-    init flat$30$simp$196@{Double} = 0.0@{Double};
+    init flat$36$simp$193@{Error} = ExceptNotAnError@{Error};
+    init flat$36$simp$194@{Double} = 0.0@{Double};
+    init flat$36$simp$195@{Double} = 0.0@{Double};
+    init flat$36$simp$196@{Double} = 0.0@{Double};
     if (eq#@{Error} a$conv$63$aval$5$simp$189 (ExceptNotAnError@{Error}))
     {
       let nn$conv$70 = add#@{Double} a$conv$63$aval$5$simp$190 (1.0@{Double});
-      init flat$33$simp$197@{Error} = ExceptNotAnError@{Error};
-      init flat$33$simp$198@{Double} = 0.0@{Double};
+      init flat$39$simp$197@{Error} = ExceptNotAnError@{Error};
+      init flat$39$simp$198@{Double} = 0.0@{Double};
       if (eq#@{Error} conv$62$aval$6$simp$179 (ExceptNotAnError@{Error}))
       {
-        write flat$33$simp$197 = ExceptNotAnError@{Error};
-        write flat$33$simp$198 = sub#@{Double} conv$62$aval$6$simp$180 a$conv$63$aval$5$simp$191;
+        write flat$39$simp$197 = ExceptNotAnError@{Error};
+        write flat$39$simp$198 = sub#@{Double} conv$62$aval$6$simp$180 a$conv$63$aval$5$simp$191;
       }
       else
       {
-        write flat$33$simp$197 = conv$62$aval$6$simp$179;
-        write flat$33$simp$198 = 0.0@{Double};
+        write flat$39$simp$197 = conv$62$aval$6$simp$179;
+        write flat$39$simp$198 = 0.0@{Double};
       }
-      read flat$33$simp$199 = flat$33$simp$197 [Error];
-      read flat$33$simp$200 = flat$33$simp$198 [Double];
-      init flat$34$simp$201@{Error} = ExceptNotAnError@{Error};
-      init flat$34$simp$202@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$33$simp$199 (ExceptNotAnError@{Error}))
+      read flat$39$simp$199 = flat$39$simp$197 [Error];
+      read flat$39$simp$200 = flat$39$simp$198 [Double];
+      init flat$40$simp$201@{Error} = ExceptNotAnError@{Error};
+      init flat$40$simp$202@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$39$simp$199 (ExceptNotAnError@{Error}))
       {
-        write flat$34$simp$201 = ExceptNotAnError@{Error};
-        write flat$34$simp$202 = div# flat$33$simp$200 nn$conv$70;
-      }
-      else
-      {
-        write flat$34$simp$201 = flat$33$simp$199;
-        write flat$34$simp$202 = 0.0@{Double};
-      }
-      read flat$34$simp$203 = flat$34$simp$201 [Error];
-      read flat$34$simp$204 = flat$34$simp$202 [Double];
-      init flat$35$simp$205@{Error} = ExceptNotAnError@{Error};
-      init flat$35$simp$206@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$34$simp$203 (ExceptNotAnError@{Error}))
-      {
-        write flat$35$simp$205 = ExceptNotAnError@{Error};
-        write flat$35$simp$206 = add#@{Double} a$conv$63$aval$5$simp$191 flat$34$simp$204;
+        write flat$40$simp$201 = ExceptNotAnError@{Error};
+        write flat$40$simp$202 = div# flat$39$simp$200 nn$conv$70;
       }
       else
       {
-        write flat$35$simp$205 = flat$34$simp$203;
-        write flat$35$simp$206 = 0.0@{Double};
+        write flat$40$simp$201 = flat$39$simp$199;
+        write flat$40$simp$202 = 0.0@{Double};
       }
-      read flat$35$simp$207 = flat$35$simp$205 [Error];
-      read flat$35$simp$208 = flat$35$simp$206 [Double];
-      init flat$36$simp$209@{Error} = ExceptNotAnError@{Error};
-      init flat$36$simp$210@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$33$simp$199 (ExceptNotAnError@{Error}))
+      read flat$40$simp$203 = flat$40$simp$201 [Error];
+      read flat$40$simp$204 = flat$40$simp$202 [Double];
+      init flat$41$simp$205@{Error} = ExceptNotAnError@{Error};
+      init flat$41$simp$206@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$40$simp$203 (ExceptNotAnError@{Error}))
       {
-        init flat$51$simp$211@{Error} = ExceptNotAnError@{Error};
-        init flat$51$simp$212@{Double} = 0.0@{Double};
+        write flat$41$simp$205 = ExceptNotAnError@{Error};
+        write flat$41$simp$206 = add#@{Double} a$conv$63$aval$5$simp$191 flat$40$simp$204;
+      }
+      else
+      {
+        write flat$41$simp$205 = flat$40$simp$203;
+        write flat$41$simp$206 = 0.0@{Double};
+      }
+      read flat$41$simp$207 = flat$41$simp$205 [Error];
+      read flat$41$simp$208 = flat$41$simp$206 [Double];
+      init flat$42$simp$209@{Error} = ExceptNotAnError@{Error};
+      init flat$42$simp$210@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$39$simp$199 (ExceptNotAnError@{Error}))
+      {
+        init flat$57$simp$211@{Error} = ExceptNotAnError@{Error};
+        init flat$57$simp$212@{Double} = 0.0@{Double};
         if (eq#@{Error} conv$62$aval$6$simp$179 (ExceptNotAnError@{Error}))
         {
-          init flat$57$simp$213@{Error} = ExceptNotAnError@{Error};
-          init flat$57$simp$214@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat$35$simp$207 (ExceptNotAnError@{Error}))
+          init flat$63$simp$213@{Error} = ExceptNotAnError@{Error};
+          init flat$63$simp$214@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat$41$simp$207 (ExceptNotAnError@{Error}))
           {
-            write flat$57$simp$213 = ExceptNotAnError@{Error};
-            write flat$57$simp$214 = sub#@{Double} conv$62$aval$6$simp$180 flat$35$simp$208;
+            write flat$63$simp$213 = ExceptNotAnError@{Error};
+            write flat$63$simp$214 = sub#@{Double} conv$62$aval$6$simp$180 flat$41$simp$208;
           }
           else
           {
-            write flat$57$simp$213 = flat$35$simp$207;
-            write flat$57$simp$214 = 0.0@{Double};
+            write flat$63$simp$213 = flat$41$simp$207;
+            write flat$63$simp$214 = 0.0@{Double};
           }
-          read flat$57$simp$215 = flat$57$simp$213 [Error];
-          read flat$57$simp$216 = flat$57$simp$214 [Double];
-          write flat$51$simp$211 = flat$57$simp$215;
-          write flat$51$simp$212 = flat$57$simp$216;
+          read flat$63$simp$215 = flat$63$simp$213 [Error];
+          read flat$63$simp$216 = flat$63$simp$214 [Double];
+          write flat$57$simp$211 = flat$63$simp$215;
+          write flat$57$simp$212 = flat$63$simp$216;
         }
         else
         {
-          write flat$51$simp$211 = conv$62$aval$6$simp$179;
-          write flat$51$simp$212 = 0.0@{Double};
+          write flat$57$simp$211 = conv$62$aval$6$simp$179;
+          write flat$57$simp$212 = 0.0@{Double};
         }
-        read flat$51$simp$217 = flat$51$simp$211 [Error];
-        read flat$51$simp$218 = flat$51$simp$212 [Double];
-        init flat$52$simp$219@{Error} = ExceptNotAnError@{Error};
-        init flat$52$simp$220@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$51$simp$217 (ExceptNotAnError@{Error}))
+        read flat$57$simp$217 = flat$57$simp$211 [Error];
+        read flat$57$simp$218 = flat$57$simp$212 [Double];
+        init flat$58$simp$219@{Error} = ExceptNotAnError@{Error};
+        init flat$58$simp$220@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$57$simp$217 (ExceptNotAnError@{Error}))
         {
-          write flat$52$simp$219 = ExceptNotAnError@{Error};
-          write flat$52$simp$220 = mul#@{Double} flat$33$simp$200 flat$51$simp$218;
+          write flat$58$simp$219 = ExceptNotAnError@{Error};
+          write flat$58$simp$220 = mul#@{Double} flat$39$simp$200 flat$57$simp$218;
         }
         else
         {
-          write flat$52$simp$219 = flat$51$simp$217;
-          write flat$52$simp$220 = 0.0@{Double};
+          write flat$58$simp$219 = flat$57$simp$217;
+          write flat$58$simp$220 = 0.0@{Double};
         }
-        read flat$52$simp$221 = flat$52$simp$219 [Error];
-        read flat$52$simp$222 = flat$52$simp$220 [Double];
-        write flat$36$simp$209 = flat$52$simp$221;
-        write flat$36$simp$210 = flat$52$simp$222;
+        read flat$58$simp$221 = flat$58$simp$219 [Error];
+        read flat$58$simp$222 = flat$58$simp$220 [Double];
+        write flat$42$simp$209 = flat$58$simp$221;
+        write flat$42$simp$210 = flat$58$simp$222;
       }
       else
       {
-        write flat$36$simp$209 = flat$33$simp$199;
-        write flat$36$simp$210 = 0.0@{Double};
+        write flat$42$simp$209 = flat$39$simp$199;
+        write flat$42$simp$210 = 0.0@{Double};
       }
-      read flat$36$simp$223 = flat$36$simp$209 [Error];
-      read flat$36$simp$224 = flat$36$simp$210 [Double];
-      init flat$37$simp$225@{Error} = ExceptNotAnError@{Error};
-      init flat$37$simp$226@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$36$simp$223 (ExceptNotAnError@{Error}))
+      read flat$42$simp$223 = flat$42$simp$209 [Error];
+      read flat$42$simp$224 = flat$42$simp$210 [Double];
+      init flat$43$simp$225@{Error} = ExceptNotAnError@{Error};
+      init flat$43$simp$226@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$42$simp$223 (ExceptNotAnError@{Error}))
       {
-        write flat$37$simp$225 = ExceptNotAnError@{Error};
-        write flat$37$simp$226 = add#@{Double} a$conv$63$aval$5$simp$192 flat$36$simp$224;
-      }
-      else
-      {
-        write flat$37$simp$225 = flat$36$simp$223;
-        write flat$37$simp$226 = 0.0@{Double};
-      }
-      read flat$37$simp$227 = flat$37$simp$225 [Error];
-      read flat$37$simp$228 = flat$37$simp$226 [Double];
-      init flat$38$simp$229@{Error} = ExceptNotAnError@{Error};
-      init flat$38$simp$230@{Double} = 0.0@{Double};
-      init flat$38$simp$231@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$35$simp$207 (ExceptNotAnError@{Error}))
-      {
-        write flat$38$simp$229 = ExceptNotAnError@{Error};
-        write flat$38$simp$230 = add#@{Double} a$conv$63$aval$5$simp$190 (1.0@{Double});
-        write flat$38$simp$231 = flat$35$simp$208;
+        write flat$43$simp$225 = ExceptNotAnError@{Error};
+        write flat$43$simp$226 = add#@{Double} a$conv$63$aval$5$simp$192 flat$42$simp$224;
       }
       else
       {
-        write flat$38$simp$229 = flat$35$simp$207;
-        write flat$38$simp$230 = 0.0@{Double};
-        write flat$38$simp$231 = 0.0@{Double};
+        write flat$43$simp$225 = flat$42$simp$223;
+        write flat$43$simp$226 = 0.0@{Double};
       }
-      read flat$38$simp$232 = flat$38$simp$229 [Error];
-      read flat$38$simp$233 = flat$38$simp$230 [Double];
-      read flat$38$simp$234 = flat$38$simp$231 [Double];
-      init flat$39$simp$235@{Error} = ExceptNotAnError@{Error};
-      init flat$39$simp$236@{Double} = 0.0@{Double};
-      init flat$39$simp$237@{Double} = 0.0@{Double};
-      init flat$39$simp$238@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat$38$simp$232 (ExceptNotAnError@{Error}))
+      read flat$43$simp$227 = flat$43$simp$225 [Error];
+      read flat$43$simp$228 = flat$43$simp$226 [Double];
+      init flat$44$simp$229@{Error} = ExceptNotAnError@{Error};
+      init flat$44$simp$230@{Double} = 0.0@{Double};
+      init flat$44$simp$231@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$41$simp$207 (ExceptNotAnError@{Error}))
       {
-        init flat$42$simp$239@{Error} = ExceptNotAnError@{Error};
-        init flat$42$simp$240@{Double} = 0.0@{Double};
-        init flat$42$simp$241@{Double} = 0.0@{Double};
-        init flat$42$simp$242@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat$37$simp$227 (ExceptNotAnError@{Error}))
+        write flat$44$simp$229 = ExceptNotAnError@{Error};
+        write flat$44$simp$230 = add#@{Double} a$conv$63$aval$5$simp$190 (1.0@{Double});
+        write flat$44$simp$231 = flat$41$simp$208;
+      }
+      else
+      {
+        write flat$44$simp$229 = flat$41$simp$207;
+        write flat$44$simp$230 = 0.0@{Double};
+        write flat$44$simp$231 = 0.0@{Double};
+      }
+      read flat$44$simp$232 = flat$44$simp$229 [Error];
+      read flat$44$simp$233 = flat$44$simp$230 [Double];
+      read flat$44$simp$234 = flat$44$simp$231 [Double];
+      init flat$45$simp$235@{Error} = ExceptNotAnError@{Error};
+      init flat$45$simp$236@{Double} = 0.0@{Double};
+      init flat$45$simp$237@{Double} = 0.0@{Double};
+      init flat$45$simp$238@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat$44$simp$232 (ExceptNotAnError@{Error}))
+      {
+        init flat$48$simp$239@{Error} = ExceptNotAnError@{Error};
+        init flat$48$simp$240@{Double} = 0.0@{Double};
+        init flat$48$simp$241@{Double} = 0.0@{Double};
+        init flat$48$simp$242@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat$43$simp$227 (ExceptNotAnError@{Error}))
         {
-          write flat$42$simp$239 = ExceptNotAnError@{Error};
-          write flat$42$simp$240 = flat$38$simp$233;
-          write flat$42$simp$241 = flat$38$simp$234;
-          write flat$42$simp$242 = flat$37$simp$228;
+          write flat$48$simp$239 = ExceptNotAnError@{Error};
+          write flat$48$simp$240 = flat$44$simp$233;
+          write flat$48$simp$241 = flat$44$simp$234;
+          write flat$48$simp$242 = flat$43$simp$228;
         }
         else
         {
-          write flat$42$simp$239 = flat$37$simp$227;
-          write flat$42$simp$240 = 0.0@{Double};
-          write flat$42$simp$241 = 0.0@{Double};
-          write flat$42$simp$242 = 0.0@{Double};
+          write flat$48$simp$239 = flat$43$simp$227;
+          write flat$48$simp$240 = 0.0@{Double};
+          write flat$48$simp$241 = 0.0@{Double};
+          write flat$48$simp$242 = 0.0@{Double};
         }
-        read flat$42$simp$243 = flat$42$simp$239 [Error];
-        read flat$42$simp$244 = flat$42$simp$240 [Double];
-        read flat$42$simp$245 = flat$42$simp$241 [Double];
-        read flat$42$simp$246 = flat$42$simp$242 [Double];
-        write flat$39$simp$235 = flat$42$simp$243;
-        write flat$39$simp$236 = flat$42$simp$244;
-        write flat$39$simp$237 = flat$42$simp$245;
-        write flat$39$simp$238 = flat$42$simp$246;
+        read flat$48$simp$243 = flat$48$simp$239 [Error];
+        read flat$48$simp$244 = flat$48$simp$240 [Double];
+        read flat$48$simp$245 = flat$48$simp$241 [Double];
+        read flat$48$simp$246 = flat$48$simp$242 [Double];
+        write flat$45$simp$235 = flat$48$simp$243;
+        write flat$45$simp$236 = flat$48$simp$244;
+        write flat$45$simp$237 = flat$48$simp$245;
+        write flat$45$simp$238 = flat$48$simp$246;
       }
       else
       {
-        write flat$39$simp$235 = flat$38$simp$232;
-        write flat$39$simp$236 = 0.0@{Double};
-        write flat$39$simp$237 = 0.0@{Double};
-        write flat$39$simp$238 = 0.0@{Double};
+        write flat$45$simp$235 = flat$44$simp$232;
+        write flat$45$simp$236 = 0.0@{Double};
+        write flat$45$simp$237 = 0.0@{Double};
+        write flat$45$simp$238 = 0.0@{Double};
       }
-      read flat$39$simp$247 = flat$39$simp$235 [Error];
-      read flat$39$simp$248 = flat$39$simp$236 [Double];
-      read flat$39$simp$249 = flat$39$simp$237 [Double];
-      read flat$39$simp$250 = flat$39$simp$238 [Double];
-      write flat$30$simp$193 = flat$39$simp$247;
-      write flat$30$simp$194 = flat$39$simp$248;
-      write flat$30$simp$195 = flat$39$simp$249;
-      write flat$30$simp$196 = flat$39$simp$250;
+      read flat$45$simp$247 = flat$45$simp$235 [Error];
+      read flat$45$simp$248 = flat$45$simp$236 [Double];
+      read flat$45$simp$249 = flat$45$simp$237 [Double];
+      read flat$45$simp$250 = flat$45$simp$238 [Double];
+      write flat$36$simp$193 = flat$45$simp$247;
+      write flat$36$simp$194 = flat$45$simp$248;
+      write flat$36$simp$195 = flat$45$simp$249;
+      write flat$36$simp$196 = flat$45$simp$250;
     }
     else
     {
-      write flat$30$simp$193 = a$conv$63$aval$5$simp$189;
-      write flat$30$simp$194 = 0.0@{Double};
-      write flat$30$simp$195 = 0.0@{Double};
-      write flat$30$simp$196 = 0.0@{Double};
+      write flat$36$simp$193 = a$conv$63$aval$5$simp$189;
+      write flat$36$simp$194 = 0.0@{Double};
+      write flat$36$simp$195 = 0.0@{Double};
+      write flat$36$simp$196 = 0.0@{Double};
     }
-    read flat$30$simp$251 = flat$30$simp$193 [Error];
-    read flat$30$simp$252 = flat$30$simp$194 [Double];
-    read flat$30$simp$253 = flat$30$simp$195 [Double];
-    read flat$30$simp$254 = flat$30$simp$196 [Double];
-    write acc$a$conv$63$simp$74 = flat$30$simp$251;
-    write acc$a$conv$63$simp$75 = flat$30$simp$252;
-    write acc$a$conv$63$simp$76 = flat$30$simp$253;
-    write acc$a$conv$63$simp$77 = flat$30$simp$254;
+    read flat$36$simp$251 = flat$36$simp$193 [Error];
+    read flat$36$simp$252 = flat$36$simp$194 [Double];
+    read flat$36$simp$253 = flat$36$simp$195 [Double];
+    read flat$36$simp$254 = flat$36$simp$196 [Double];
+    write acc$a$conv$63$simp$74 = flat$36$simp$251;
+    write acc$a$conv$63$simp$75 = flat$36$simp$252;
+    write acc$a$conv$63$simp$76 = flat$36$simp$253;
+    write acc$a$conv$63$simp$77 = flat$36$simp$254;
   }
 }
 save_resumable@{Error} acc$a$conv$63$simp$74;
@@ -696,104 +696,80 @@ iint_t size_of_state_iprogram_0 ()
 #line 1 "compute function #0 - repl"
 void iprogram_0(iprogram_0_t *s)
 {
-    ierror_t         flat_7_simp_137;
-    idouble_t        flat_7_simp_138;
-    idouble_t        flat_7_simp_139;
-    idouble_t        flat_6_simp_135;
-    ierror_t         flat_6_simp_134;
-    idouble_t        flat_6_simp_136;
-    ierror_t         flat_3_simp_107;
-    idouble_t        flat_3_simp_109;
-    idouble_t        flat_3_simp_108;
-    ierror_t         flat_15_simp_123;
-    ierror_t         flat_15_simp_121;
-    idouble_t        flat_15_simp_122;
-    idouble_t        flat_15_simp_124;
-    idouble_t        flat_14_simp_120;
-    idouble_t        flat_16_simp_127;
-    ierror_t         flat_16_simp_125;
-    idouble_t        flat_16_simp_126;
-    idouble_t        flat_16_simp_129;
-    ierror_t         flat_16_simp_128;
-    ierror_t         flat_39_simp_247;
-    idouble_t        flat_39_simp_248;
-    idouble_t        flat_39_simp_249;
-    idouble_t        flat_30_simp_196;
-    ierror_t         flat_30_simp_193;
-    idouble_t        flat_30_simp_195;
-    idouble_t        flat_30_simp_194;
-    ierror_t         flat_33_simp_199;
-    idouble_t        flat_33_simp_198;
-    ierror_t         flat_33_simp_197;
-    idouble_t        flat_39_simp_250;
-    idouble_t        flat_30_simp_253;
-    idouble_t        flat_30_simp_254;
-    ierror_t         flat_30_simp_251;
-    idouble_t        flat_30_simp_252;
-    idouble_t        flat_36_simp_210;
-    ierror_t         flat_36_simp_209;
-    ierror_t         flat_35_simp_207;
-    idouble_t        flat_35_simp_206;
-    idouble_t        flat_35_simp_208;
-    ierror_t         flat_35_simp_205;
-    idouble_t        flat_34_simp_202;
-    ierror_t         flat_34_simp_203;
-    ierror_t         flat_34_simp_201;
-    idouble_t        flat_34_simp_204;
-    idouble_t        flat_33_simp_200;
-    ierror_t         flat_14_simp_117;
-    idouble_t        flat_14_simp_118;
-    ierror_t         flat_14_simp_119;
-    ierror_t         flat_10_simp_110;
-    idouble_t        flat_10_simp_112;
-    idouble_t        flat_10_simp_111;
-    idouble_t        flat_13_simp_116;
-    ierror_t         flat_13_simp_115;
-    idouble_t        flat_13_simp_114;
-    ierror_t         flat_13_simp_113;
-    idouble_t        flat_16_simp_130;
-    ierror_t         flat_10_simp_131;
-    idouble_t        flat_10_simp_132;
-    idouble_t        flat_10_simp_133;
-    idouble_t        flat_6_simp_144;
-    idouble_t        flat_6_simp_145;
-    ierror_t         flat_6_simp_143;
-    idouble_t        flat_7_simp_141;
-    ierror_t         flat_7_simp_140;
-    idouble_t        flat_7_simp_142;
-    idouble_t        flat_3_simp_148;
-    idouble_t        flat_3_simp_147;
-    ierror_t         flat_3_simp_146;
-    ierror_t         flat_38_simp_229;
-    idouble_t        flat_37_simp_228;
-    ierror_t         flat_37_simp_227;
-    idouble_t        flat_37_simp_226;
-    ierror_t         flat_37_simp_225;
-    ierror_t         flat_36_simp_223;
-    idouble_t        flat_36_simp_224;
-    idouble_t        flat_39_simp_236;
-    idouble_t        flat_39_simp_237;
-    ierror_t         flat_39_simp_235;
-    idouble_t        flat_39_simp_238;
-    idouble_t        flat_38_simp_234;
-    idouble_t        flat_38_simp_230;
-    idouble_t        flat_38_simp_231;
-    ierror_t         flat_38_simp_232;
-    idouble_t        flat_38_simp_233;
+    idouble_t        flat_9_simp_108;
+    ierror_t         flat_9_simp_107;
+    idouble_t        flat_9_simp_109;
+    ierror_t         flat_36_simp_193;
+    idouble_t        flat_36_simp_195;
+    idouble_t        flat_36_simp_194;
+    idouble_t        flat_36_simp_196;
+    ierror_t         flat_39_simp_199;
+    idouble_t        flat_39_simp_198;
+    ierror_t         flat_39_simp_197;
+    idouble_t        flat_13_simp_142;
+    ierror_t         flat_13_simp_140;
+    idouble_t        flat_13_simp_141;
+    ierror_t         flat_12_simp_143;
+    idouble_t        flat_12_simp_145;
+    idouble_t        flat_12_simp_144;
+    ierror_t         flat_36_simp_251;
+    idouble_t        flat_36_simp_252;
+    idouble_t        flat_36_simp_253;
+    idouble_t        flat_36_simp_254;
+    idouble_t        flat_39_simp_200;
+    ierror_t         flat_16_simp_110;
+    idouble_t        flat_16_simp_112;
+    idouble_t        flat_16_simp_111;
+    idouble_t        flat_19_simp_116;
+    ierror_t         flat_19_simp_115;
+    idouble_t        flat_19_simp_114;
+    ierror_t         flat_19_simp_113;
+    idouble_t        flat_16_simp_132;
+    idouble_t        flat_16_simp_133;
+    ierror_t         flat_16_simp_131;
+    idouble_t        flat_12_simp_135;
+    idouble_t        flat_12_simp_136;
+    ierror_t         flat_12_simp_134;
+    ierror_t         flat_13_simp_137;
+    idouble_t        flat_13_simp_139;
+    idouble_t        flat_13_simp_138;
+    idouble_t        flat_9_simp_148;
+    idouble_t        flat_9_simp_147;
+    ierror_t         flat_9_simp_146;
+    iint_t           flat_34_simp_160;
+    idouble_t        flat_35_simp_178;
+    ierror_t         flat_35_simp_175;
+    ierror_t         flat_35_simp_177;
+    idouble_t        flat_35_simp_176;
+    idouble_t        flat_20_simp_118;
+    ierror_t         flat_20_simp_119;
+    ierror_t         flat_20_simp_117;
     idouble_t        conv_11_aval_2_simp_97;
     ierror_t         conv_11_aval_2_simp_96;
+    idouble_t        flat_22_simp_130;
     idouble_t        acc_conv_7_simp_34;
     ierror_t         acc_conv_7_simp_33;
     idouble_t        flat_2_simp_95;
     ierror_t         flat_2_simp_94;
     idouble_t        flat_2_simp_93;
     ierror_t         flat_2_simp_92;
+    iint_t           flat_34_simp_158;
+    ierror_t         flat_34_simp_159;
+    ierror_t         flat_34_simp_157;
+    istring_t        flat_31_simp_152;
+    ierror_t         flat_31_simp_151;
+    istring_t        flat_31_simp_150;
+    ibool_t          flat_32_simp_154;
+    ibool_t          flat_32_simp_156;
+    ierror_t         flat_32_simp_155;
+    ierror_t         flat_32_simp_153;
     ierror_t         flat_1_simp_82;
     idouble_t        flat_1_simp_83;
     ierror_t         flat_1_simp_84;
     idouble_t        flat_1_simp_85;
     ierror_t         flat_0_simp_80;
     iint_t           flat_0_simp_81;
+    ierror_t         flat_31_simp_149;
     idouble_t        flat_93_simp_271;
     ierror_t         flat_93_simp_270;
     ierror_t         flat_94_simp_272;
@@ -813,34 +789,32 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         acc_conv_11_simp_39;
     idouble_t        conv_7_aval_0_simp_87;
     ierror_t         conv_7_aval_0_simp_86;
-    idouble_t        flat_29_simp_178;
-    ierror_t         flat_29_simp_175;
-    idouble_t        flat_29_simp_176;
-    ierror_t         flat_29_simp_177;
-    iint_t           flat_28_simp_160;
     idouble_t        acc_conv_11_simp_40;
+    idouble_t        flat_22_simp_127;
+    idouble_t        flat_22_simp_126;
+    ierror_t         flat_22_simp_125;
+    idouble_t        flat_22_simp_129;
+    ierror_t         flat_22_simp_128;
+    idouble_t        flat_20_simp_120;
+    idouble_t        flat_21_simp_124;
+    idouble_t        flat_21_simp_122;
+    ierror_t         flat_21_simp_121;
+    ierror_t         flat_21_simp_123;
     ierror_t         flat_90_simp_280;
     idouble_t        flat_90_simp_281;
-    iint_t           flat_28_simp_158;
-    ierror_t         flat_28_simp_159;
-    ierror_t         flat_28_simp_157;
-    ierror_t         flat_26_simp_153;
-    ibool_t          flat_26_simp_154;
-    ierror_t         flat_26_simp_155;
-    ibool_t          flat_26_simp_156;
-    ierror_t         flat_25_simp_151;
-    istring_t        flat_25_simp_152;
-    istring_t        flat_25_simp_150;
     idouble_t        acc_a_conv_63_simp_77;
     idouble_t        acc_a_conv_63_simp_76;
     idouble_t        acc_a_conv_63_simp_75;
     ierror_t         acc_a_conv_63_simp_74;
-    ierror_t         flat_25_simp_149;
     idouble_t        acc_conv_62_simp_65;
     ierror_t         acc_conv_62_simp_64;
     idouble_t        a_conv_63_aval_5_simp_190;
     idouble_t        a_conv_63_aval_5_simp_191;
     idouble_t        a_conv_63_aval_5_simp_192;
+    idouble_t        flat_63_simp_214;
+    idouble_t        flat_63_simp_216;
+    ierror_t         flat_63_simp_215;
+    ierror_t         flat_63_simp_213;
     idouble_t        conv_62_aval_6_simp_180;
     idouble_t        s_reify_6_conv_12_simp_260;
     ierror_t         a_conv_63_aval_5_simp_189;
@@ -859,8 +833,34 @@ void iprogram_0(iprogram_0_t *s)
     ierror_t         acc_s_reify_6_conv_12_simp_47;
     idouble_t        acc_s_reify_6_conv_12_simp_48;
     idouble_t        acc_s_reify_6_conv_12_simp_49;
-    ierror_t         flat_42_simp_239;
+    idouble_t        flat_41_simp_208;
+    ierror_t         flat_41_simp_205;
+    ierror_t         flat_41_simp_207;
+    idouble_t        flat_41_simp_206;
+    ierror_t         flat_42_simp_209;
+    ierror_t         flat_40_simp_201;
+    idouble_t        flat_40_simp_204;
+    idouble_t        flat_40_simp_202;
+    ierror_t         flat_40_simp_203;
+    idouble_t        flat_42_simp_210;
+    idouble_t        flat_44_simp_234;
+    idouble_t        flat_44_simp_231;
+    idouble_t        flat_44_simp_230;
+    idouble_t        flat_44_simp_233;
+    ierror_t         flat_44_simp_232;
+    idouble_t        flat_45_simp_237;
+    idouble_t        flat_45_simp_236;
+    ierror_t         flat_45_simp_235;
+    idouble_t        flat_45_simp_238;
+    ierror_t         flat_48_simp_239;
     ierror_t         conv_62_aval_6_simp_179;
+    ierror_t         flat_42_simp_223;
+    idouble_t        flat_42_simp_224;
+    ierror_t         flat_43_simp_225;
+    idouble_t        flat_43_simp_228;
+    idouble_t        flat_43_simp_226;
+    ierror_t         flat_43_simp_227;
+    ierror_t         flat_44_simp_229;
     iint_t           acc_conv_57_simp_51;
     ierror_t         acc_conv_57_simp_50;
     iint_t           acc_conv_58_simp_57;
@@ -868,26 +868,26 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        a_conv_63_simp_258;
     ierror_t         a_conv_63_simp_255;
     idouble_t        a_conv_63_simp_256;
-    ibool_t          flat_27;
-    idouble_t        flat_51_simp_218;
-    ierror_t         flat_51_simp_211;
-    idouble_t        flat_51_simp_212;
-    ierror_t         flat_51_simp_217;
-    ierror_t         flat_57_simp_215;
-    idouble_t        flat_57_simp_216;
-    idouble_t        flat_57_simp_214;
-    ierror_t         flat_57_simp_213;
-    ierror_t         flat_52_simp_219;
-    idouble_t        flat_42_simp_246;
-    idouble_t        flat_42_simp_244;
-    idouble_t        flat_42_simp_245;
-    idouble_t        flat_42_simp_242;
-    ierror_t         flat_42_simp_243;
-    idouble_t        flat_42_simp_240;
-    idouble_t        flat_42_simp_241;
-    ierror_t         flat_52_simp_221;
-    idouble_t        flat_52_simp_220;
-    idouble_t        flat_52_simp_222;
+    idouble_t        flat_57_simp_218;
+    ierror_t         flat_57_simp_211;
+    idouble_t        flat_57_simp_212;
+    ierror_t         flat_57_simp_217;
+    ierror_t         flat_58_simp_219;
+    idouble_t        flat_45_simp_250;
+    ibool_t          flat_33;
+    idouble_t        flat_48_simp_246;
+    idouble_t        flat_48_simp_244;
+    idouble_t        flat_48_simp_241;
+    idouble_t        flat_48_simp_245;
+    idouble_t        flat_48_simp_242;
+    ierror_t         flat_48_simp_243;
+    idouble_t        flat_48_simp_240;
+    idouble_t        flat_45_simp_249;
+    idouble_t        flat_45_simp_248;
+    ierror_t         flat_45_simp_247;
+    idouble_t        flat_58_simp_222;
+    ierror_t         flat_58_simp_221;
+    idouble_t        flat_58_simp_220;
 
     imempool_t      *mempool                  = s->mempool;
     itime_t          conv_3                   = s->conv_3;
@@ -1041,402 +1041,402 @@ void iprogram_0(iprogram_0_t *s)
         s_reify_6_conv_12_aval_1_simp_104     = acc_s_reify_6_conv_12_simp_47;        /* read */
         s_reify_6_conv_12_aval_1_simp_105     = acc_s_reify_6_conv_12_simp_48;        /* read */
         s_reify_6_conv_12_aval_1_simp_106     = acc_s_reify_6_conv_12_simp_49;        /* read */
-        flat_3_simp_107                       = ierror_not_an_error;                  /* init */
-        flat_3_simp_108                       = 0.0;                                  /* init */
-        flat_3_simp_109                       = 0.0;                                  /* init */
+        flat_9_simp_107                       = ierror_not_an_error;                  /* init */
+        flat_9_simp_108                       = 0.0;                                  /* init */
+        flat_9_simp_109                       = 0.0;                                  /* init */
         
         if (ierror_eq (s_reify_6_conv_12_aval_1_simp_104, ierror_not_an_error)) {
-            flat_10_simp_110                  = ierror_not_an_error;                  /* init */
-            flat_10_simp_111                  = 0.0;                                  /* init */
-            flat_10_simp_112                  = 0.0;                                  /* init */
+            flat_16_simp_110                  = ierror_not_an_error;                  /* init */
+            flat_16_simp_111                  = 0.0;                                  /* init */
+            flat_16_simp_112                  = 0.0;                                  /* init */
             
             if (ierror_eq (s_reify_6_conv_12_aval_1_simp_104, ierror_not_an_error)) {
-                flat_13_simp_113              = ierror_not_an_error;                  /* init */
-                flat_13_simp_114              = 0.0;                                  /* init */
+                flat_19_simp_113              = ierror_not_an_error;                  /* init */
+                flat_19_simp_114              = 0.0;                                  /* init */
                 
                 if (ierror_eq (conv_11_aval_2_simp_96, ierror_not_an_error)) {
-                    flat_13_simp_113          = ierror_not_an_error;                  /* write */
-                    flat_13_simp_114          = idouble_sub (conv_11_aval_2_simp_97, s_reify_6_conv_12_aval_1_simp_105); /* write */
+                    flat_19_simp_113          = ierror_not_an_error;                  /* write */
+                    flat_19_simp_114          = idouble_sub (conv_11_aval_2_simp_97, s_reify_6_conv_12_aval_1_simp_105); /* write */
                 } else {
-                    flat_13_simp_113          = conv_11_aval_2_simp_96;               /* write */
-                    flat_13_simp_114          = 0.0;                                  /* write */
+                    flat_19_simp_113          = conv_11_aval_2_simp_96;               /* write */
+                    flat_19_simp_114          = 0.0;                                  /* write */
                 }
                 
-                flat_13_simp_115              = flat_13_simp_113;                     /* read */
-                flat_13_simp_116              = flat_13_simp_114;                     /* read */
-                flat_14_simp_117              = ierror_not_an_error;                  /* init */
-                flat_14_simp_118              = 0.0;                                  /* init */
+                flat_19_simp_115              = flat_19_simp_113;                     /* read */
+                flat_19_simp_116              = flat_19_simp_114;                     /* read */
+                flat_20_simp_117              = ierror_not_an_error;                  /* init */
+                flat_20_simp_118              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_13_simp_115, ierror_not_an_error)) {
-                    flat_14_simp_117          = ierror_not_an_error;                  /* write */
+                if (ierror_eq (flat_19_simp_115, ierror_not_an_error)) {
+                    flat_20_simp_117          = ierror_not_an_error;                  /* write */
                     idouble_t        simp_354 = idouble_add (s_reify_6_conv_12_aval_1_simp_106, 1.0); /* let */
-                    flat_14_simp_118          = idouble_div (flat_13_simp_116, simp_354); /* write */
+                    flat_20_simp_118          = idouble_div (flat_19_simp_116, simp_354); /* write */
                 } else {
-                    flat_14_simp_117          = flat_13_simp_115;                     /* write */
-                    flat_14_simp_118          = 0.0;                                  /* write */
+                    flat_20_simp_117          = flat_19_simp_115;                     /* write */
+                    flat_20_simp_118          = 0.0;                                  /* write */
                 }
                 
-                flat_14_simp_119              = flat_14_simp_117;                     /* read */
-                flat_14_simp_120              = flat_14_simp_118;                     /* read */
-                flat_15_simp_121              = ierror_not_an_error;                  /* init */
-                flat_15_simp_122              = 0.0;                                  /* init */
+                flat_20_simp_119              = flat_20_simp_117;                     /* read */
+                flat_20_simp_120              = flat_20_simp_118;                     /* read */
+                flat_21_simp_121              = ierror_not_an_error;                  /* init */
+                flat_21_simp_122              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_14_simp_119, ierror_not_an_error)) {
-                    flat_15_simp_121          = ierror_not_an_error;                  /* write */
-                    flat_15_simp_122          = idouble_add (s_reify_6_conv_12_aval_1_simp_105, flat_14_simp_120); /* write */
+                if (ierror_eq (flat_20_simp_119, ierror_not_an_error)) {
+                    flat_21_simp_121          = ierror_not_an_error;                  /* write */
+                    flat_21_simp_122          = idouble_add (s_reify_6_conv_12_aval_1_simp_105, flat_20_simp_120); /* write */
                 } else {
-                    flat_15_simp_121          = flat_14_simp_119;                     /* write */
-                    flat_15_simp_122          = 0.0;                                  /* write */
+                    flat_21_simp_121          = flat_20_simp_119;                     /* write */
+                    flat_21_simp_122          = 0.0;                                  /* write */
                 }
                 
-                flat_15_simp_123              = flat_15_simp_121;                     /* read */
-                flat_15_simp_124              = flat_15_simp_122;                     /* read */
-                flat_16_simp_125              = ierror_not_an_error;                  /* init */
-                flat_16_simp_126              = 0.0;                                  /* init */
-                flat_16_simp_127              = 0.0;                                  /* init */
+                flat_21_simp_123              = flat_21_simp_121;                     /* read */
+                flat_21_simp_124              = flat_21_simp_122;                     /* read */
+                flat_22_simp_125              = ierror_not_an_error;                  /* init */
+                flat_22_simp_126              = 0.0;                                  /* init */
+                flat_22_simp_127              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_15_simp_123, ierror_not_an_error)) {
-                    flat_16_simp_125          = ierror_not_an_error;                  /* write */
-                    flat_16_simp_126          = flat_15_simp_124;                     /* write */
-                    flat_16_simp_127          = idouble_add (s_reify_6_conv_12_aval_1_simp_106, 1.0); /* write */
+                if (ierror_eq (flat_21_simp_123, ierror_not_an_error)) {
+                    flat_22_simp_125          = ierror_not_an_error;                  /* write */
+                    flat_22_simp_126          = flat_21_simp_124;                     /* write */
+                    flat_22_simp_127          = idouble_add (s_reify_6_conv_12_aval_1_simp_106, 1.0); /* write */
                 } else {
-                    flat_16_simp_125          = flat_15_simp_123;                     /* write */
-                    flat_16_simp_126          = 0.0;                                  /* write */
-                    flat_16_simp_127          = 0.0;                                  /* write */
+                    flat_22_simp_125          = flat_21_simp_123;                     /* write */
+                    flat_22_simp_126          = 0.0;                                  /* write */
+                    flat_22_simp_127          = 0.0;                                  /* write */
                 }
                 
-                flat_16_simp_128              = flat_16_simp_125;                     /* read */
-                flat_16_simp_129              = flat_16_simp_126;                     /* read */
-                flat_16_simp_130              = flat_16_simp_127;                     /* read */
-                flat_10_simp_110              = flat_16_simp_128;                     /* write */
-                flat_10_simp_111              = flat_16_simp_129;                     /* write */
-                flat_10_simp_112              = flat_16_simp_130;                     /* write */
+                flat_22_simp_128              = flat_22_simp_125;                     /* read */
+                flat_22_simp_129              = flat_22_simp_126;                     /* read */
+                flat_22_simp_130              = flat_22_simp_127;                     /* read */
+                flat_16_simp_110              = flat_22_simp_128;                     /* write */
+                flat_16_simp_111              = flat_22_simp_129;                     /* write */
+                flat_16_simp_112              = flat_22_simp_130;                     /* write */
             } else {
-                flat_10_simp_110              = s_reify_6_conv_12_aval_1_simp_104;    /* write */
-                flat_10_simp_111              = 0.0;                                  /* write */
-                flat_10_simp_112              = 0.0;                                  /* write */
+                flat_16_simp_110              = s_reify_6_conv_12_aval_1_simp_104;    /* write */
+                flat_16_simp_111              = 0.0;                                  /* write */
+                flat_16_simp_112              = 0.0;                                  /* write */
             }
             
-            flat_10_simp_131                  = flat_10_simp_110;                     /* read */
-            flat_10_simp_132                  = flat_10_simp_111;                     /* read */
-            flat_10_simp_133                  = flat_10_simp_112;                     /* read */
-            flat_3_simp_107                   = flat_10_simp_131;                     /* write */
-            flat_3_simp_108                   = flat_10_simp_132;                     /* write */
-            flat_3_simp_109                   = flat_10_simp_133;                     /* write */
+            flat_16_simp_131                  = flat_16_simp_110;                     /* read */
+            flat_16_simp_132                  = flat_16_simp_111;                     /* read */
+            flat_16_simp_133                  = flat_16_simp_112;                     /* read */
+            flat_9_simp_107                   = flat_16_simp_131;                     /* write */
+            flat_9_simp_108                   = flat_16_simp_132;                     /* write */
+            flat_9_simp_109                   = flat_16_simp_133;                     /* write */
         } else {
-            flat_6_simp_134                   = ierror_not_an_error;                  /* init */
-            flat_6_simp_135                   = 0.0;                                  /* init */
-            flat_6_simp_136                   = 0.0;                                  /* init */
+            flat_12_simp_134                  = ierror_not_an_error;                  /* init */
+            flat_12_simp_135                  = 0.0;                                  /* init */
+            flat_12_simp_136                  = 0.0;                                  /* init */
             
             if (ierror_eq (ierror_fold1_no_value, s_reify_6_conv_12_aval_1_simp_104)) {
-                flat_7_simp_137               = ierror_not_an_error;                  /* init */
-                flat_7_simp_138               = 0.0;                                  /* init */
-                flat_7_simp_139               = 0.0;                                  /* init */
+                flat_13_simp_137              = ierror_not_an_error;                  /* init */
+                flat_13_simp_138              = 0.0;                                  /* init */
+                flat_13_simp_139              = 0.0;                                  /* init */
                 
                 if (ierror_eq (conv_11_aval_2_simp_96, ierror_not_an_error)) {
-                    flat_7_simp_137           = ierror_not_an_error;                  /* write */
-                    flat_7_simp_138           = conv_11_aval_2_simp_97;               /* write */
-                    flat_7_simp_139           = 1.0;                                  /* write */
+                    flat_13_simp_137          = ierror_not_an_error;                  /* write */
+                    flat_13_simp_138          = conv_11_aval_2_simp_97;               /* write */
+                    flat_13_simp_139          = 1.0;                                  /* write */
                 } else {
-                    flat_7_simp_137           = conv_11_aval_2_simp_96;               /* write */
-                    flat_7_simp_138           = 0.0;                                  /* write */
-                    flat_7_simp_139           = 0.0;                                  /* write */
+                    flat_13_simp_137          = conv_11_aval_2_simp_96;               /* write */
+                    flat_13_simp_138          = 0.0;                                  /* write */
+                    flat_13_simp_139          = 0.0;                                  /* write */
                 }
                 
-                flat_7_simp_140               = flat_7_simp_137;                      /* read */
-                flat_7_simp_141               = flat_7_simp_138;                      /* read */
-                flat_7_simp_142               = flat_7_simp_139;                      /* read */
-                flat_6_simp_134               = flat_7_simp_140;                      /* write */
-                flat_6_simp_135               = flat_7_simp_141;                      /* write */
-                flat_6_simp_136               = flat_7_simp_142;                      /* write */
+                flat_13_simp_140              = flat_13_simp_137;                     /* read */
+                flat_13_simp_141              = flat_13_simp_138;                     /* read */
+                flat_13_simp_142              = flat_13_simp_139;                     /* read */
+                flat_12_simp_134              = flat_13_simp_140;                     /* write */
+                flat_12_simp_135              = flat_13_simp_141;                     /* write */
+                flat_12_simp_136              = flat_13_simp_142;                     /* write */
             } else {
-                flat_6_simp_134               = s_reify_6_conv_12_aval_1_simp_104;    /* write */
-                flat_6_simp_135               = 0.0;                                  /* write */
-                flat_6_simp_136               = 0.0;                                  /* write */
+                flat_12_simp_134              = s_reify_6_conv_12_aval_1_simp_104;    /* write */
+                flat_12_simp_135              = 0.0;                                  /* write */
+                flat_12_simp_136              = 0.0;                                  /* write */
             }
             
-            flat_6_simp_143                   = flat_6_simp_134;                      /* read */
-            flat_6_simp_144                   = flat_6_simp_135;                      /* read */
-            flat_6_simp_145                   = flat_6_simp_136;                      /* read */
-            flat_3_simp_107                   = flat_6_simp_143;                      /* write */
-            flat_3_simp_108                   = flat_6_simp_144;                      /* write */
-            flat_3_simp_109                   = flat_6_simp_145;                      /* write */
+            flat_12_simp_143                  = flat_12_simp_134;                     /* read */
+            flat_12_simp_144                  = flat_12_simp_135;                     /* read */
+            flat_12_simp_145                  = flat_12_simp_136;                     /* read */
+            flat_9_simp_107                   = flat_12_simp_143;                     /* write */
+            flat_9_simp_108                   = flat_12_simp_144;                     /* write */
+            flat_9_simp_109                   = flat_12_simp_145;                     /* write */
         }
         
-        flat_3_simp_146                       = flat_3_simp_107;                      /* read */
-        flat_3_simp_147                       = flat_3_simp_108;                      /* read */
-        flat_3_simp_148                       = flat_3_simp_109;                      /* read */
-        acc_s_reify_6_conv_12_simp_47         = flat_3_simp_146;                      /* write */
-        acc_s_reify_6_conv_12_simp_48         = flat_3_simp_147;                      /* write */
-        acc_s_reify_6_conv_12_simp_49         = flat_3_simp_148;                      /* write */
-        flat_25_simp_149                      = ierror_not_an_error;                  /* init */
-        flat_25_simp_150                      = "";                                   /* init */
+        flat_9_simp_146                       = flat_9_simp_107;                      /* read */
+        flat_9_simp_147                       = flat_9_simp_108;                      /* read */
+        flat_9_simp_148                       = flat_9_simp_109;                      /* read */
+        acc_s_reify_6_conv_12_simp_47         = flat_9_simp_146;                      /* write */
+        acc_s_reify_6_conv_12_simp_48         = flat_9_simp_147;                      /* write */
+        acc_s_reify_6_conv_12_simp_49         = flat_9_simp_148;                      /* write */
+        flat_31_simp_149                      = ierror_not_an_error;                  /* init */
+        flat_31_simp_150                      = "";                                   /* init */
         
         if (ierror_eq (conv_0_simp_282, ierror_not_an_error)) {
-            flat_25_simp_149                  = ierror_not_an_error;                  /* write */
-            flat_25_simp_150                  = conv_0_simp_283;                      /* write */
+            flat_31_simp_149                  = ierror_not_an_error;                  /* write */
+            flat_31_simp_150                  = conv_0_simp_283;                      /* write */
         } else {
-            flat_25_simp_149                  = conv_0_simp_282;                      /* write */
-            flat_25_simp_150                  = "";                                   /* write */
+            flat_31_simp_149                  = conv_0_simp_282;                      /* write */
+            flat_31_simp_150                  = "";                                   /* write */
         }
         
-        flat_25_simp_151                      = flat_25_simp_149;                     /* read */
-        flat_25_simp_152                      = flat_25_simp_150;                     /* read */
-        flat_26_simp_153                      = ierror_not_an_error;                  /* init */
-        flat_26_simp_154                      = ifalse;                               /* init */
+        flat_31_simp_151                      = flat_31_simp_149;                     /* read */
+        flat_31_simp_152                      = flat_31_simp_150;                     /* read */
+        flat_32_simp_153                      = ierror_not_an_error;                  /* init */
+        flat_32_simp_154                      = ifalse;                               /* init */
         
-        if (ierror_eq (flat_25_simp_151, ierror_not_an_error)) {
-            flat_26_simp_153                  = ierror_not_an_error;                  /* write */
-            flat_26_simp_154                  = istring_eq (flat_25_simp_152, "torso"); /* write */
+        if (ierror_eq (flat_31_simp_151, ierror_not_an_error)) {
+            flat_32_simp_153                  = ierror_not_an_error;                  /* write */
+            flat_32_simp_154                  = istring_eq (flat_31_simp_152, "torso"); /* write */
         } else {
-            flat_26_simp_153                  = flat_25_simp_151;                     /* write */
-            flat_26_simp_154                  = ifalse;                               /* write */
+            flat_32_simp_153                  = flat_31_simp_151;                     /* write */
+            flat_32_simp_154                  = ifalse;                               /* write */
         }
         
-        flat_26_simp_155                      = flat_26_simp_153;                     /* read */
-        flat_26_simp_156                      = flat_26_simp_154;                     /* read */
-        flat_27                               = ifalse;                               /* init */
+        flat_32_simp_155                      = flat_32_simp_153;                     /* read */
+        flat_32_simp_156                      = flat_32_simp_154;                     /* read */
+        flat_33                               = ifalse;                               /* init */
         
-        if (ierror_eq (flat_26_simp_155, ierror_not_an_error)) {
-            flat_27                           = flat_26_simp_156;                     /* write */
+        if (ierror_eq (flat_32_simp_155, ierror_not_an_error)) {
+            flat_33                           = flat_32_simp_156;                     /* write */
         } else {
-            flat_27                           = itrue;                                /* write */
+            flat_33                           = itrue;                                /* write */
         }
         
-        flat_27                               = flat_27;                              /* read */
+        flat_33                               = flat_33;                              /* read */
         
-        if (flat_27) {
-            flat_28_simp_157                  = ierror_not_an_error;                  /* init */
-            flat_28_simp_158                  = 0;                                    /* init */
+        if (flat_33) {
+            flat_34_simp_157                  = ierror_not_an_error;                  /* init */
+            flat_34_simp_158                  = 0;                                    /* init */
             
             if (ierror_eq (conv_0_simp_282, ierror_not_an_error)) {
-                flat_28_simp_157              = ierror_not_an_error;                  /* write */
-                flat_28_simp_158              = conv_0_simp_284;                      /* write */
+                flat_34_simp_157              = ierror_not_an_error;                  /* write */
+                flat_34_simp_158              = conv_0_simp_284;                      /* write */
             } else {
-                flat_28_simp_157              = conv_0_simp_282;                      /* write */
-                flat_28_simp_158              = 0;                                    /* write */
+                flat_34_simp_157              = conv_0_simp_282;                      /* write */
+                flat_34_simp_158              = 0;                                    /* write */
             }
             
-            flat_28_simp_159                  = flat_28_simp_157;                     /* read */
-            flat_28_simp_160                  = flat_28_simp_158;                     /* read */
-            acc_conv_57_simp_50               = flat_28_simp_159;                     /* write */
-            acc_conv_57_simp_51               = flat_28_simp_160;                     /* write */
+            flat_34_simp_159                  = flat_34_simp_157;                     /* read */
+            flat_34_simp_160                  = flat_34_simp_158;                     /* read */
+            acc_conv_57_simp_50               = flat_34_simp_159;                     /* write */
+            acc_conv_57_simp_51               = flat_34_simp_160;                     /* write */
             conv_57_aval_3_simp_161           = acc_conv_57_simp_50;                  /* read */
             conv_57_aval_3_simp_162           = acc_conv_57_simp_51;                  /* read */
             acc_conv_58_simp_56               = conv_57_aval_3_simp_161;              /* write */
             acc_conv_58_simp_57               = conv_57_aval_3_simp_162;              /* write */
             conv_58_aval_4_simp_167           = acc_conv_58_simp_56;                  /* read */
             conv_58_aval_4_simp_168           = acc_conv_58_simp_57;                  /* read */
-            flat_29_simp_175                  = ierror_not_an_error;                  /* init */
-            flat_29_simp_176                  = 0.0;                                  /* init */
+            flat_35_simp_175                  = ierror_not_an_error;                  /* init */
+            flat_35_simp_176                  = 0.0;                                  /* init */
             
             if (ierror_eq (conv_58_aval_4_simp_167, ierror_not_an_error)) {
-                flat_29_simp_175              = ierror_not_an_error;                  /* write */
-                flat_29_simp_176              = iint_extend (conv_58_aval_4_simp_168); /* write */
+                flat_35_simp_175              = ierror_not_an_error;                  /* write */
+                flat_35_simp_176              = iint_extend (conv_58_aval_4_simp_168); /* write */
             } else {
-                flat_29_simp_175              = conv_58_aval_4_simp_167;              /* write */
-                flat_29_simp_176              = 0.0;                                  /* write */
+                flat_35_simp_175              = conv_58_aval_4_simp_167;              /* write */
+                flat_35_simp_176              = 0.0;                                  /* write */
             }
             
-            flat_29_simp_177                  = flat_29_simp_175;                     /* read */
-            flat_29_simp_178                  = flat_29_simp_176;                     /* read */
-            acc_conv_62_simp_64               = flat_29_simp_177;                     /* write */
-            acc_conv_62_simp_65               = flat_29_simp_178;                     /* write */
+            flat_35_simp_177                  = flat_35_simp_175;                     /* read */
+            flat_35_simp_178                  = flat_35_simp_176;                     /* read */
+            acc_conv_62_simp_64               = flat_35_simp_177;                     /* write */
+            acc_conv_62_simp_65               = flat_35_simp_178;                     /* write */
             conv_62_aval_6_simp_179           = acc_conv_62_simp_64;                  /* read */
             conv_62_aval_6_simp_180           = acc_conv_62_simp_65;                  /* read */
             a_conv_63_aval_5_simp_189         = acc_a_conv_63_simp_74;                /* read */
             a_conv_63_aval_5_simp_190         = acc_a_conv_63_simp_75;                /* read */
             a_conv_63_aval_5_simp_191         = acc_a_conv_63_simp_76;                /* read */
             a_conv_63_aval_5_simp_192         = acc_a_conv_63_simp_77;                /* read */
-            flat_30_simp_193                  = ierror_not_an_error;                  /* init */
-            flat_30_simp_194                  = 0.0;                                  /* init */
-            flat_30_simp_195                  = 0.0;                                  /* init */
-            flat_30_simp_196                  = 0.0;                                  /* init */
+            flat_36_simp_193                  = ierror_not_an_error;                  /* init */
+            flat_36_simp_194                  = 0.0;                                  /* init */
+            flat_36_simp_195                  = 0.0;                                  /* init */
+            flat_36_simp_196                  = 0.0;                                  /* init */
             
             if (ierror_eq (a_conv_63_aval_5_simp_189, ierror_not_an_error)) {
                 idouble_t        nn_conv_70   = idouble_add (a_conv_63_aval_5_simp_190, 1.0); /* let */
-                flat_33_simp_197              = ierror_not_an_error;                  /* init */
-                flat_33_simp_198              = 0.0;                                  /* init */
+                flat_39_simp_197              = ierror_not_an_error;                  /* init */
+                flat_39_simp_198              = 0.0;                                  /* init */
                 
                 if (ierror_eq (conv_62_aval_6_simp_179, ierror_not_an_error)) {
-                    flat_33_simp_197          = ierror_not_an_error;                  /* write */
-                    flat_33_simp_198          = idouble_sub (conv_62_aval_6_simp_180, a_conv_63_aval_5_simp_191); /* write */
+                    flat_39_simp_197          = ierror_not_an_error;                  /* write */
+                    flat_39_simp_198          = idouble_sub (conv_62_aval_6_simp_180, a_conv_63_aval_5_simp_191); /* write */
                 } else {
-                    flat_33_simp_197          = conv_62_aval_6_simp_179;              /* write */
-                    flat_33_simp_198          = 0.0;                                  /* write */
+                    flat_39_simp_197          = conv_62_aval_6_simp_179;              /* write */
+                    flat_39_simp_198          = 0.0;                                  /* write */
                 }
                 
-                flat_33_simp_199              = flat_33_simp_197;                     /* read */
-                flat_33_simp_200              = flat_33_simp_198;                     /* read */
-                flat_34_simp_201              = ierror_not_an_error;                  /* init */
-                flat_34_simp_202              = 0.0;                                  /* init */
+                flat_39_simp_199              = flat_39_simp_197;                     /* read */
+                flat_39_simp_200              = flat_39_simp_198;                     /* read */
+                flat_40_simp_201              = ierror_not_an_error;                  /* init */
+                flat_40_simp_202              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_33_simp_199, ierror_not_an_error)) {
-                    flat_34_simp_201          = ierror_not_an_error;                  /* write */
-                    flat_34_simp_202          = idouble_div (flat_33_simp_200, nn_conv_70); /* write */
+                if (ierror_eq (flat_39_simp_199, ierror_not_an_error)) {
+                    flat_40_simp_201          = ierror_not_an_error;                  /* write */
+                    flat_40_simp_202          = idouble_div (flat_39_simp_200, nn_conv_70); /* write */
                 } else {
-                    flat_34_simp_201          = flat_33_simp_199;                     /* write */
-                    flat_34_simp_202          = 0.0;                                  /* write */
+                    flat_40_simp_201          = flat_39_simp_199;                     /* write */
+                    flat_40_simp_202          = 0.0;                                  /* write */
                 }
                 
-                flat_34_simp_203              = flat_34_simp_201;                     /* read */
-                flat_34_simp_204              = flat_34_simp_202;                     /* read */
-                flat_35_simp_205              = ierror_not_an_error;                  /* init */
-                flat_35_simp_206              = 0.0;                                  /* init */
+                flat_40_simp_203              = flat_40_simp_201;                     /* read */
+                flat_40_simp_204              = flat_40_simp_202;                     /* read */
+                flat_41_simp_205              = ierror_not_an_error;                  /* init */
+                flat_41_simp_206              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_34_simp_203, ierror_not_an_error)) {
-                    flat_35_simp_205          = ierror_not_an_error;                  /* write */
-                    flat_35_simp_206          = idouble_add (a_conv_63_aval_5_simp_191, flat_34_simp_204); /* write */
+                if (ierror_eq (flat_40_simp_203, ierror_not_an_error)) {
+                    flat_41_simp_205          = ierror_not_an_error;                  /* write */
+                    flat_41_simp_206          = idouble_add (a_conv_63_aval_5_simp_191, flat_40_simp_204); /* write */
                 } else {
-                    flat_35_simp_205          = flat_34_simp_203;                     /* write */
-                    flat_35_simp_206          = 0.0;                                  /* write */
+                    flat_41_simp_205          = flat_40_simp_203;                     /* write */
+                    flat_41_simp_206          = 0.0;                                  /* write */
                 }
                 
-                flat_35_simp_207              = flat_35_simp_205;                     /* read */
-                flat_35_simp_208              = flat_35_simp_206;                     /* read */
-                flat_36_simp_209              = ierror_not_an_error;                  /* init */
-                flat_36_simp_210              = 0.0;                                  /* init */
+                flat_41_simp_207              = flat_41_simp_205;                     /* read */
+                flat_41_simp_208              = flat_41_simp_206;                     /* read */
+                flat_42_simp_209              = ierror_not_an_error;                  /* init */
+                flat_42_simp_210              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_33_simp_199, ierror_not_an_error)) {
-                    flat_51_simp_211          = ierror_not_an_error;                  /* init */
-                    flat_51_simp_212          = 0.0;                                  /* init */
+                if (ierror_eq (flat_39_simp_199, ierror_not_an_error)) {
+                    flat_57_simp_211          = ierror_not_an_error;                  /* init */
+                    flat_57_simp_212          = 0.0;                                  /* init */
                     
                     if (ierror_eq (conv_62_aval_6_simp_179, ierror_not_an_error)) {
-                        flat_57_simp_213      = ierror_not_an_error;                  /* init */
-                        flat_57_simp_214      = 0.0;                                  /* init */
+                        flat_63_simp_213      = ierror_not_an_error;                  /* init */
+                        flat_63_simp_214      = 0.0;                                  /* init */
                         
-                        if (ierror_eq (flat_35_simp_207, ierror_not_an_error)) {
-                            flat_57_simp_213  = ierror_not_an_error;                  /* write */
-                            flat_57_simp_214  = idouble_sub (conv_62_aval_6_simp_180, flat_35_simp_208); /* write */
+                        if (ierror_eq (flat_41_simp_207, ierror_not_an_error)) {
+                            flat_63_simp_213  = ierror_not_an_error;                  /* write */
+                            flat_63_simp_214  = idouble_sub (conv_62_aval_6_simp_180, flat_41_simp_208); /* write */
                         } else {
-                            flat_57_simp_213  = flat_35_simp_207;                     /* write */
-                            flat_57_simp_214  = 0.0;                                  /* write */
+                            flat_63_simp_213  = flat_41_simp_207;                     /* write */
+                            flat_63_simp_214  = 0.0;                                  /* write */
                         }
                         
-                        flat_57_simp_215      = flat_57_simp_213;                     /* read */
-                        flat_57_simp_216      = flat_57_simp_214;                     /* read */
-                        flat_51_simp_211      = flat_57_simp_215;                     /* write */
-                        flat_51_simp_212      = flat_57_simp_216;                     /* write */
+                        flat_63_simp_215      = flat_63_simp_213;                     /* read */
+                        flat_63_simp_216      = flat_63_simp_214;                     /* read */
+                        flat_57_simp_211      = flat_63_simp_215;                     /* write */
+                        flat_57_simp_212      = flat_63_simp_216;                     /* write */
                     } else {
-                        flat_51_simp_211      = conv_62_aval_6_simp_179;              /* write */
-                        flat_51_simp_212      = 0.0;                                  /* write */
+                        flat_57_simp_211      = conv_62_aval_6_simp_179;              /* write */
+                        flat_57_simp_212      = 0.0;                                  /* write */
                     }
                     
-                    flat_51_simp_217          = flat_51_simp_211;                     /* read */
-                    flat_51_simp_218          = flat_51_simp_212;                     /* read */
-                    flat_52_simp_219          = ierror_not_an_error;                  /* init */
-                    flat_52_simp_220          = 0.0;                                  /* init */
+                    flat_57_simp_217          = flat_57_simp_211;                     /* read */
+                    flat_57_simp_218          = flat_57_simp_212;                     /* read */
+                    flat_58_simp_219          = ierror_not_an_error;                  /* init */
+                    flat_58_simp_220          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_51_simp_217, ierror_not_an_error)) {
-                        flat_52_simp_219      = ierror_not_an_error;                  /* write */
-                        flat_52_simp_220      = idouble_mul (flat_33_simp_200, flat_51_simp_218); /* write */
+                    if (ierror_eq (flat_57_simp_217, ierror_not_an_error)) {
+                        flat_58_simp_219      = ierror_not_an_error;                  /* write */
+                        flat_58_simp_220      = idouble_mul (flat_39_simp_200, flat_57_simp_218); /* write */
                     } else {
-                        flat_52_simp_219      = flat_51_simp_217;                     /* write */
-                        flat_52_simp_220      = 0.0;                                  /* write */
+                        flat_58_simp_219      = flat_57_simp_217;                     /* write */
+                        flat_58_simp_220      = 0.0;                                  /* write */
                     }
                     
-                    flat_52_simp_221          = flat_52_simp_219;                     /* read */
-                    flat_52_simp_222          = flat_52_simp_220;                     /* read */
-                    flat_36_simp_209          = flat_52_simp_221;                     /* write */
-                    flat_36_simp_210          = flat_52_simp_222;                     /* write */
+                    flat_58_simp_221          = flat_58_simp_219;                     /* read */
+                    flat_58_simp_222          = flat_58_simp_220;                     /* read */
+                    flat_42_simp_209          = flat_58_simp_221;                     /* write */
+                    flat_42_simp_210          = flat_58_simp_222;                     /* write */
                 } else {
-                    flat_36_simp_209          = flat_33_simp_199;                     /* write */
-                    flat_36_simp_210          = 0.0;                                  /* write */
+                    flat_42_simp_209          = flat_39_simp_199;                     /* write */
+                    flat_42_simp_210          = 0.0;                                  /* write */
                 }
                 
-                flat_36_simp_223              = flat_36_simp_209;                     /* read */
-                flat_36_simp_224              = flat_36_simp_210;                     /* read */
-                flat_37_simp_225              = ierror_not_an_error;                  /* init */
-                flat_37_simp_226              = 0.0;                                  /* init */
+                flat_42_simp_223              = flat_42_simp_209;                     /* read */
+                flat_42_simp_224              = flat_42_simp_210;                     /* read */
+                flat_43_simp_225              = ierror_not_an_error;                  /* init */
+                flat_43_simp_226              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_36_simp_223, ierror_not_an_error)) {
-                    flat_37_simp_225          = ierror_not_an_error;                  /* write */
-                    flat_37_simp_226          = idouble_add (a_conv_63_aval_5_simp_192, flat_36_simp_224); /* write */
+                if (ierror_eq (flat_42_simp_223, ierror_not_an_error)) {
+                    flat_43_simp_225          = ierror_not_an_error;                  /* write */
+                    flat_43_simp_226          = idouble_add (a_conv_63_aval_5_simp_192, flat_42_simp_224); /* write */
                 } else {
-                    flat_37_simp_225          = flat_36_simp_223;                     /* write */
-                    flat_37_simp_226          = 0.0;                                  /* write */
+                    flat_43_simp_225          = flat_42_simp_223;                     /* write */
+                    flat_43_simp_226          = 0.0;                                  /* write */
                 }
                 
-                flat_37_simp_227              = flat_37_simp_225;                     /* read */
-                flat_37_simp_228              = flat_37_simp_226;                     /* read */
-                flat_38_simp_229              = ierror_not_an_error;                  /* init */
-                flat_38_simp_230              = 0.0;                                  /* init */
-                flat_38_simp_231              = 0.0;                                  /* init */
+                flat_43_simp_227              = flat_43_simp_225;                     /* read */
+                flat_43_simp_228              = flat_43_simp_226;                     /* read */
+                flat_44_simp_229              = ierror_not_an_error;                  /* init */
+                flat_44_simp_230              = 0.0;                                  /* init */
+                flat_44_simp_231              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_35_simp_207, ierror_not_an_error)) {
-                    flat_38_simp_229          = ierror_not_an_error;                  /* write */
-                    flat_38_simp_230          = idouble_add (a_conv_63_aval_5_simp_190, 1.0); /* write */
-                    flat_38_simp_231          = flat_35_simp_208;                     /* write */
+                if (ierror_eq (flat_41_simp_207, ierror_not_an_error)) {
+                    flat_44_simp_229          = ierror_not_an_error;                  /* write */
+                    flat_44_simp_230          = idouble_add (a_conv_63_aval_5_simp_190, 1.0); /* write */
+                    flat_44_simp_231          = flat_41_simp_208;                     /* write */
                 } else {
-                    flat_38_simp_229          = flat_35_simp_207;                     /* write */
-                    flat_38_simp_230          = 0.0;                                  /* write */
-                    flat_38_simp_231          = 0.0;                                  /* write */
+                    flat_44_simp_229          = flat_41_simp_207;                     /* write */
+                    flat_44_simp_230          = 0.0;                                  /* write */
+                    flat_44_simp_231          = 0.0;                                  /* write */
                 }
                 
-                flat_38_simp_232              = flat_38_simp_229;                     /* read */
-                flat_38_simp_233              = flat_38_simp_230;                     /* read */
-                flat_38_simp_234              = flat_38_simp_231;                     /* read */
-                flat_39_simp_235              = ierror_not_an_error;                  /* init */
-                flat_39_simp_236              = 0.0;                                  /* init */
-                flat_39_simp_237              = 0.0;                                  /* init */
-                flat_39_simp_238              = 0.0;                                  /* init */
+                flat_44_simp_232              = flat_44_simp_229;                     /* read */
+                flat_44_simp_233              = flat_44_simp_230;                     /* read */
+                flat_44_simp_234              = flat_44_simp_231;                     /* read */
+                flat_45_simp_235              = ierror_not_an_error;                  /* init */
+                flat_45_simp_236              = 0.0;                                  /* init */
+                flat_45_simp_237              = 0.0;                                  /* init */
+                flat_45_simp_238              = 0.0;                                  /* init */
                 
-                if (ierror_eq (flat_38_simp_232, ierror_not_an_error)) {
-                    flat_42_simp_239          = ierror_not_an_error;                  /* init */
-                    flat_42_simp_240          = 0.0;                                  /* init */
-                    flat_42_simp_241          = 0.0;                                  /* init */
-                    flat_42_simp_242          = 0.0;                                  /* init */
+                if (ierror_eq (flat_44_simp_232, ierror_not_an_error)) {
+                    flat_48_simp_239          = ierror_not_an_error;                  /* init */
+                    flat_48_simp_240          = 0.0;                                  /* init */
+                    flat_48_simp_241          = 0.0;                                  /* init */
+                    flat_48_simp_242          = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flat_37_simp_227, ierror_not_an_error)) {
-                        flat_42_simp_239      = ierror_not_an_error;                  /* write */
-                        flat_42_simp_240      = flat_38_simp_233;                     /* write */
-                        flat_42_simp_241      = flat_38_simp_234;                     /* write */
-                        flat_42_simp_242      = flat_37_simp_228;                     /* write */
+                    if (ierror_eq (flat_43_simp_227, ierror_not_an_error)) {
+                        flat_48_simp_239      = ierror_not_an_error;                  /* write */
+                        flat_48_simp_240      = flat_44_simp_233;                     /* write */
+                        flat_48_simp_241      = flat_44_simp_234;                     /* write */
+                        flat_48_simp_242      = flat_43_simp_228;                     /* write */
                     } else {
-                        flat_42_simp_239      = flat_37_simp_227;                     /* write */
-                        flat_42_simp_240      = 0.0;                                  /* write */
-                        flat_42_simp_241      = 0.0;                                  /* write */
-                        flat_42_simp_242      = 0.0;                                  /* write */
+                        flat_48_simp_239      = flat_43_simp_227;                     /* write */
+                        flat_48_simp_240      = 0.0;                                  /* write */
+                        flat_48_simp_241      = 0.0;                                  /* write */
+                        flat_48_simp_242      = 0.0;                                  /* write */
                     }
                     
-                    flat_42_simp_243          = flat_42_simp_239;                     /* read */
-                    flat_42_simp_244          = flat_42_simp_240;                     /* read */
-                    flat_42_simp_245          = flat_42_simp_241;                     /* read */
-                    flat_42_simp_246          = flat_42_simp_242;                     /* read */
-                    flat_39_simp_235          = flat_42_simp_243;                     /* write */
-                    flat_39_simp_236          = flat_42_simp_244;                     /* write */
-                    flat_39_simp_237          = flat_42_simp_245;                     /* write */
-                    flat_39_simp_238          = flat_42_simp_246;                     /* write */
+                    flat_48_simp_243          = flat_48_simp_239;                     /* read */
+                    flat_48_simp_244          = flat_48_simp_240;                     /* read */
+                    flat_48_simp_245          = flat_48_simp_241;                     /* read */
+                    flat_48_simp_246          = flat_48_simp_242;                     /* read */
+                    flat_45_simp_235          = flat_48_simp_243;                     /* write */
+                    flat_45_simp_236          = flat_48_simp_244;                     /* write */
+                    flat_45_simp_237          = flat_48_simp_245;                     /* write */
+                    flat_45_simp_238          = flat_48_simp_246;                     /* write */
                 } else {
-                    flat_39_simp_235          = flat_38_simp_232;                     /* write */
-                    flat_39_simp_236          = 0.0;                                  /* write */
-                    flat_39_simp_237          = 0.0;                                  /* write */
-                    flat_39_simp_238          = 0.0;                                  /* write */
+                    flat_45_simp_235          = flat_44_simp_232;                     /* write */
+                    flat_45_simp_236          = 0.0;                                  /* write */
+                    flat_45_simp_237          = 0.0;                                  /* write */
+                    flat_45_simp_238          = 0.0;                                  /* write */
                 }
                 
-                flat_39_simp_247              = flat_39_simp_235;                     /* read */
-                flat_39_simp_248              = flat_39_simp_236;                     /* read */
-                flat_39_simp_249              = flat_39_simp_237;                     /* read */
-                flat_39_simp_250              = flat_39_simp_238;                     /* read */
-                flat_30_simp_193              = flat_39_simp_247;                     /* write */
-                flat_30_simp_194              = flat_39_simp_248;                     /* write */
-                flat_30_simp_195              = flat_39_simp_249;                     /* write */
-                flat_30_simp_196              = flat_39_simp_250;                     /* write */
+                flat_45_simp_247              = flat_45_simp_235;                     /* read */
+                flat_45_simp_248              = flat_45_simp_236;                     /* read */
+                flat_45_simp_249              = flat_45_simp_237;                     /* read */
+                flat_45_simp_250              = flat_45_simp_238;                     /* read */
+                flat_36_simp_193              = flat_45_simp_247;                     /* write */
+                flat_36_simp_194              = flat_45_simp_248;                     /* write */
+                flat_36_simp_195              = flat_45_simp_249;                     /* write */
+                flat_36_simp_196              = flat_45_simp_250;                     /* write */
             } else {
-                flat_30_simp_193              = a_conv_63_aval_5_simp_189;            /* write */
-                flat_30_simp_194              = 0.0;                                  /* write */
-                flat_30_simp_195              = 0.0;                                  /* write */
-                flat_30_simp_196              = 0.0;                                  /* write */
+                flat_36_simp_193              = a_conv_63_aval_5_simp_189;            /* write */
+                flat_36_simp_194              = 0.0;                                  /* write */
+                flat_36_simp_195              = 0.0;                                  /* write */
+                flat_36_simp_196              = 0.0;                                  /* write */
             }
             
-            flat_30_simp_251                  = flat_30_simp_193;                     /* read */
-            flat_30_simp_252                  = flat_30_simp_194;                     /* read */
-            flat_30_simp_253                  = flat_30_simp_195;                     /* read */
-            flat_30_simp_254                  = flat_30_simp_196;                     /* read */
-            acc_a_conv_63_simp_74             = flat_30_simp_251;                     /* write */
-            acc_a_conv_63_simp_75             = flat_30_simp_252;                     /* write */
-            acc_a_conv_63_simp_76             = flat_30_simp_253;                     /* write */
-            acc_a_conv_63_simp_77             = flat_30_simp_254;                     /* write */
+            flat_36_simp_251                  = flat_36_simp_193;                     /* read */
+            flat_36_simp_252                  = flat_36_simp_194;                     /* read */
+            flat_36_simp_253                  = flat_36_simp_195;                     /* read */
+            flat_36_simp_254                  = flat_36_simp_196;                     /* read */
+            acc_a_conv_63_simp_74             = flat_36_simp_251;                     /* write */
+            acc_a_conv_63_simp_75             = flat_36_simp_252;                     /* write */
+            acc_a_conv_63_simp_76             = flat_36_simp_253;                     /* write */
+            acc_a_conv_63_simp_77             = flat_36_simp_254;                     /* write */
         }
         
     }


### PR DESCRIPTION
Substitution takes a Map of substitutions rather than performing a single substitution.

ForwardStmts keeps track of an environment of substitutions to perform, rather than substituting many, many times.

Statement mappend does not perform simplification on the blocks produced, instead leaving them for nestBlocks to simplify these later. This produces a few naming differences.

Dead usage only needs to check if the sizes are the same; since elements are only added to the usage, if the size is the same it means nothing was added.