### PR TITLE
Compilation time improvements

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -24,6 +24,7 @@ library
                      , containers                      == 0.5.*
                      , dates                           == 0.2.*
                      , directory                       == 1.2.*
+                     , deepseq                         == 1.3.*
                      , exceptions                      == 0.8.*
                      , file-embed                      == 0.0.9
                      , filepath                        >= 1.3        && < 1.5

--- a/src/Icicle/Avalanche/Check.hs
+++ b/src/Icicle/Avalanche/Check.hs
@@ -1,5 +1,6 @@
 -- | Evaluate Avalanche programs
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Avalanche.Check (
     checkProgram
   , ProgramError(..)
@@ -20,6 +21,8 @@ import qualified    Data.List   as List
 import qualified    Data.Map    as Map
 import              Data.Hashable (Hashable)
 
+import              GHC.Generics (Generic)
+
 
 data ProgramError a n p
  = ProgramErrorExp  (ExpError a n p)
@@ -29,13 +32,15 @@ data ProgramError a n p
  | ProgramErrorWrongValType         (Name n) ValType ValType
  | ProgramErrorMultipleFactLops
  | ProgramErrorNameNotUnique (Name n)
- deriving (Show, Eq, Ord)
+ deriving (Show, Eq, Ord, Generic)
 
 data Context n
  = Context
  { ctxExp :: Env n Type
  , ctxAcc :: Env n ValType }
  deriving (Show, Eq, Ord)
+
+instance (NFData a, NFData n, NFData p) => NFData (ProgramError a n p)
 
 initialContext :: (Hashable n, Eq n) => Program a n p -> Context n
 initialContext p

--- a/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/src/Icicle/Avalanche/Prim/Flat.hs
@@ -1,7 +1,8 @@
 -- | Flat primitives - after the folds are removed
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Avalanche.Prim.Flat (
       Prim        (..)
     , PrimProject (..)
@@ -26,6 +27,8 @@ import qualified    Icicle.Common.Fragment         as Frag
 import              P
 
 import qualified    Data.Map as Map
+
+import              GHC.Generics (Generic)
 
 
 flatFragment :: Frag.Fragment Prim
@@ -59,14 +62,14 @@ data Prim
 
  -- | Abstract circular buffer prims
  | PrimBuf             PrimBuf
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 data PrimProject
  = PrimProjectArrayLength ValType
  | PrimProjectOptionIsSome ValType
  | PrimProjectSumIsRight   ValType ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 data PrimUnsafe
@@ -75,32 +78,41 @@ data PrimUnsafe
  | PrimUnsafeSumGetLeft  ValType ValType -- ^ Get the Left value, which may be garbage
  | PrimUnsafeSumGetRight ValType ValType -- ^ Get the Right value, which maybe be garbage
  | PrimUnsafeOptionGet   ValType         -- ^ Get the Some value, which maybe be garbage
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 data PrimArray
  = PrimArrayPutMutable   ValType         -- ^ In-place update
  | PrimArrayPutImmutable ValType         -- ^ Copy then update
  | PrimArrayZip          ValType ValType -- ^ Zip two arrays into one
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 data PrimMap
  = PrimMapPack         ValType ValType
  | PrimMapUnpackKeys   ValType ValType
  | PrimMapUnpackValues ValType ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 data PrimMelt
  = PrimMeltPack       ValType
  | PrimMeltUnpack Int ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 -- | These correspond directly to the latest buffer primitives in Core.
 data PrimBuf
  = PrimBufMake Int ValType
  | PrimBufPush Int ValType
  | PrimBufRead Int ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+
+instance NFData Prim
+instance NFData PrimProject
+instance NFData PrimUnsafe
+instance NFData PrimArray
+instance NFData PrimMap
+instance NFData PrimMelt
+instance NFData PrimBuf
 
 
 -- | A primitive always has a well-defined type

--- a/src/Icicle/Avalanche/Program.hs
+++ b/src/Icicle/Avalanche/Program.hs
@@ -1,5 +1,6 @@
 -- | Avalanche programs
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Avalanche.Program (
     Program         (..)
   , renameProgram
@@ -12,6 +13,8 @@ import              Icicle.Common.Type
 
 import              Icicle.Internal.Pretty
 
+import              GHC.Generics (Generic)
+
 import              P
 
 -- | An entire Avalanche program
@@ -21,7 +24,9 @@ data Program a n p =
   , bindtime    :: Name n
   , statements  :: Statement a n p
   }
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance (NFData a, NFData n, NFData p) => NFData (Program a n p)
 
 instance TransformX Program where
  transformX names exps p

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -88,6 +88,8 @@ simpFlattened a_fresh p
    -- and now "x" is no longer mentioned, so can be removed.
    -- Doing this straight away means a smaller program for later passes.
    >>= return .  dead
+   -- Kill off statements that have no observable effect (no write to accumulators, etc.)
+   >>= return . killNoEffect
    -- Perform let-forwarding on statements, so that constant lets become free
    >>= forwardStmts a_fresh
    -- Try to evaluate any exposed primitives

--- a/src/Icicle/Avalanche/Simp.hs
+++ b/src/Icicle/Avalanche/Simp.hs
@@ -1,32 +1,34 @@
 -- | Convert Core programs to Avalanche
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE DoAndIfThenElse   #-}
+{-# LANGUAGE DoAndIfThenElse     #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Icicle.Avalanche.Simp (
     simpAvalanche
   , simpFlattened
   , pullLets
   ) where
 
-import              Icicle.Common.Exp
-import              Icicle.Common.Fresh
-import              Icicle.Common.FixT
+import           Icicle.Common.Exp
+import           Icicle.Common.FixT
+import           Icicle.Common.Fresh
 
-import qualified    Icicle.Core.Exp.Prim as CorePrim
-import qualified    Icicle.Core.Eval.Exp as CorePrim
+import qualified Icicle.Core.Eval.Exp                        as CorePrim
+import qualified Icicle.Core.Exp.Prim                        as CorePrim
 
-import qualified    Icicle.Avalanche.Prim.Eval as Flat
-import qualified    Icicle.Avalanche.Prim.Flat as Flat
-import              Icicle.Avalanche.Statement.Simp
-import              Icicle.Avalanche.Statement.Simp.Eval
-import              Icicle.Avalanche.Statement.Simp.Constructor
-import              Icicle.Avalanche.Statement.Simp.Melt
-import              Icicle.Avalanche.Statement.Simp.Mutate
-import              Icicle.Avalanche.Program
+import qualified Icicle.Avalanche.Prim.Eval                  as Flat
+import qualified Icicle.Avalanche.Prim.Flat                  as Flat
+import           Icicle.Avalanche.Program
+import           Icicle.Avalanche.Statement.Simp
+import           Icicle.Avalanche.Statement.Simp.Constructor
+import           Icicle.Avalanche.Statement.Simp.Eval
+import           Icicle.Avalanche.Statement.Simp.Melt
+import           Icicle.Avalanche.Statement.Simp.Mutate
+import           Icicle.Avalanche.Statement.Statement
 
-import              P
+import           P
 
-import              Control.Monad.Trans.Class
-import              Data.Hashable (Hashable)
+import           Control.Monad.Trans.Class
+import           Data.Hashable                               (Hashable)
 
 
 simpAvalanche
@@ -35,7 +37,7 @@ simpAvalanche
   -> Program a n CorePrim.Prim
   -> Fresh n (Program a n CorePrim.Prim)
 simpAvalanche a_fresh p
- = do p' <- transformX return (simp a_fresh) p
+ = do p' <- transformX return (simpAnn a_fresh) p
       s' <- (once $ forwardStmts a_fresh $ pullLets $ statements p')
          >>= once . thresherWithAlpha     a_fresh
          >>= once . forwardStmts a_fresh
@@ -43,11 +45,11 @@ simpAvalanche a_fresh p
          >>= once . thresherWithAlpha     a_fresh
          >>= transformX return (return . simpEvalX CorePrim.evalPrim CorePrim.typeOfPrim)
          >>= return .  dead
-
-      return $ p { statements = s' }
+      s'' <- transformX return (return . reannotX fst) s'
+      return $ p { statements = s'' }
 
 simpFlattened
-  :: (Show n, Eq a, Hashable n, Eq n, Ord a)
+  :: forall a n . (Show n, Eq a, Hashable n, Eq n, Ord a)
   => a
   -> Program a n Flat.Prim
   -> Fresh n (Program a n Flat.Prim)
@@ -55,6 +57,7 @@ simpFlattened a_fresh p
  = do s' <- transformX return (simp a_fresh) (statements p)
          >>= return . mutate
          >>= melt a_fresh
+         >>= transformX return (simpAnn a_fresh)
          >>= fixpoint crunch
          -- Rename reads from accumulators
          >>= fixpoint (renameReads a_fresh)
@@ -62,9 +65,11 @@ simpFlattened a_fresh p
          >>= return . convertValues a_fresh
          -- Finish off with an a-normalisation
          >>= anormal
-
-      return $ p { statements = s' }
+      s'' <- transformX return (return . reannotX fst) s'
+      return $ p { statements = s'' }
  where
+  crunch :: Statement (Ann a n) n Flat.Prim
+         -> FixT (Fresh n) (Statement (Ann a n) n Flat.Prim)
   crunch ss
    -- Start by a-normalising, so it's ready for constructor
    =   lift (anormal ss)
@@ -92,9 +97,11 @@ simpFlattened a_fresh p
    -- Thresh to remove duplicate expressions
    >>= thresherNoAlpha     a_fresh
 
+  anormal :: Statement (Ann a n) n Flat.Prim
+          -> Fresh n (Statement (Ann a n) n Flat.Prim)
   anormal ss
    -- Expression simp: first perform beta reduction, then a-normalise.
-   =   transformX return (simp a_fresh) ss
+   =   transformX return (simpKeepAnn a_fresh) ss
    -- finish a-normalisation by taking lets from inside expressions to statements.
    >>= return . pullLets
 

--- a/src/Icicle/Avalanche/Statement/Flatten/Base.hs
+++ b/src/Icicle/Avalanche/Statement/Flatten/Base.hs
@@ -1,7 +1,8 @@
 -- | Turn Core primitives into Flat - removing the folds
 -- The input statements must be in A-normal form.
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Avalanche.Statement.Flatten.Base (
     FlattenError(..)
   , FlatM
@@ -17,12 +18,16 @@ import              Icicle.Common.Fresh
 
 import              P
 
+import              GHC.Generics
+
 
 data FlattenError a n
  = FlattenErrorApplicationNonPrimitive (Exp a n Core.Prim)
  | FlattenErrorBareLambda (Exp a n Core.Prim)
  | FlattenErrorPrimBadArgs Core.Prim [Exp a n Core.Prim]
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance (NFData a, NFData n) => NFData (FlattenError a n)
 
 type FlatM a n
  = FreshT n (Either (FlattenError a n)) (Statement a n Flat.Prim)

--- a/src/Icicle/Avalanche/Statement/Simp.hs
+++ b/src/Icicle/Avalanche/Statement/Simp.hs
@@ -1,8 +1,9 @@
 -- | Simplifying and transforming statements
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE PatternGuards     #-}
-{-# LANGUAGE TupleSections     #-}
-{-# LANGUAGE BangPatterns      #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE PatternGuards       #-}
+{-# LANGUAGE TupleSections       #-}
+{-# LANGUAGE BangPatterns        #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Icicle.Avalanche.Statement.Simp (
     pullLets
@@ -10,6 +11,7 @@ module Icicle.Avalanche.Statement.Simp (
   , forwardStmts
   , renameReads
   , substXinS
+  , substXinS'
   , thresherWithAlpha, thresherNoAlpha
   , nestBlocks
   , dead
@@ -42,7 +44,7 @@ import              Data.Hashable (Hashable)
 import              Control.Monad.Trans.Class
 
 
-convertValues :: a -> Statement a n Prim -> Statement a n Prim
+convertValues :: (Eq n) => a -> Statement (Ann a n) n Prim -> Statement (Ann a n) n Prim
 convertValues a_fresh statements
  = runIdentity
  $ transformUDStmt trans () statements
@@ -90,23 +92,23 @@ convertValues a_fresh statements
 
   goB' t v
    | BufT n t' <- t
-   = goB (XValue a_fresh t v) n t' v
+   = goB (xValue t v) n t' v
    | otherwise
-   = XValue a_fresh t v
+   = xValue t v
 
   goA xx t v
    = case v of
        VArray arr
-         -> arrPrim 0 (XValue a_fresh IntT (VInt (length arr))) t arr
+         -> arrPrim 0 (xValue IntT (VInt (length arr))) t arr
        _ -> xx
 
   bufPrim n t b
    = case b of
        []
-         -> XPrim a_fresh (PrimBuf (PrimBufMake n t))
-              `xApp`  XValue a_fresh UnitT VUnit
+         -> xPrim (PrimBuf (PrimBufMake n t))
+              `xApp`  xValue UnitT VUnit
        (x : xs)
-         -> XPrim a_fresh (PrimBuf (PrimBufPush n t))
+         -> xPrim (PrimBuf (PrimBufPush n t))
               `xApp` bufPrim n t xs
               -- Allow for nested buffers
               `xApp` goB' t x
@@ -114,20 +116,24 @@ convertValues a_fresh statements
   arrPrim i n t a
     = case a of
          []
-           -> XPrim a_fresh (PrimUnsafe (PrimUnsafeArrayCreate t))
+           -> xPrim (PrimUnsafe (PrimUnsafeArrayCreate t))
                `xApp` n
          (x : xs)
            -- This can mutate since it's on a newly created array
-           -> XPrim a_fresh (PrimArray  (PrimArrayPutMutable t))
+           -> xPrim (PrimArray  (PrimArrayPutMutable t))
                 `xApp` arrPrim (i + 1) n t xs
-                `xApp` (XValue a_fresh IntT (VInt i))
+                `xApp` (xValue IntT (VInt i))
                 `xApp` goB' t x
 
-  xApp
-   = XApp a_fresh
+  xApp x1 x2
+   = XApp (a_fresh, snd (annotOfExp x1) <> snd (annotOfExp x2)) x1 x2
+  xPrim
+   = XPrim (a_fresh, Set.empty)
+  xValue
+   = XValue (a_fresh, Set.empty)
 
 
-pullLets :: Statement a n p -> Statement a n p
+pullLets :: Statement (Ann a n) n p -> Statement (Ann a n) n p
 pullLets statements
  = runIdentity
  $ transformUDStmt trans () statements
@@ -175,12 +181,18 @@ pullLets statements
 
 
 -- | Let-forwarding on statements
-forwardStmts :: (Hashable n, Eq n) => a -> Statement a n p -> FixT (Fresh n) (Statement a n p)
+forwardStmts
+  :: forall a n p. (Hashable n, Eq n)
+  => a
+  -> Statement (Ann a n) n p
+  -> FixT (Fresh n) (Statement (Ann a n) n p)
 forwardStmts a_fresh statements
  = transformUDStmt trans Map.empty statements
  where
-  sub e x = lift $ subst a_fresh e x
-  subS e x f 
+  sub e x
+   = lift $ substAnn a_fresh e x
+
+  subS e x f
    = do x' <- sub e x
         return (e, f x')
 
@@ -241,17 +253,23 @@ forwardStmts a_fresh statements
 --
 -- and the C compiler should be able to get rid of the first, etc.
 --
-renameReads :: (Hashable n, Eq n) => a -> Statement a n p -> FixT (Fresh n) (Statement a n p)
+renameReads
+ :: (Hashable n, Eq n)
+ => a
+ -> Statement (Ann a n) n p
+ -> FixT (Fresh n) (Statement (Ann a n) n p)
 renameReads a_fresh statements
  = transformUDStmt trans () statements
  where
+  xVar n
+   = XVar (a_fresh, Set.singleton n) n
   trans _ s
    = case s of
       Read nm acc vt ss
        | Just (pre, post) <- splitWrite acc mempty ss
        , nm /= acc
        , not $ Set.member nm $ stmtFreeX post
-       -> do    pre' <- lift $ substXinS a_fresh nm (XVar a_fresh acc) pre
+       -> do    pre' <- lift $ substXinS a_fresh nm (xVar acc) pre
                 progress ((), Read acc acc vt (pre' <> post))
       _ -> return ((), s)
 
@@ -295,10 +313,18 @@ renameReads a_fresh statements
 -- > in subst monkey := banana
 -- > in (subst banana := banana' in monkey)
 --
-substXinS :: (Hashable n, Eq n) => a -> Name n -> Exp a n p -> Statement a n p -> Fresh n (Statement a n p)
+substXinS
+ :: (Hashable n, Eq n)
+ => a
+ -> Name n
+ -> Exp (Ann a n) n p
+ -> Statement (Ann a n) n p
+ -> Fresh n (Statement (Ann a n) n p)
 substXinS a_fresh name payload statements
  = transformUDStmt trans True statements
  where
+  xVar n
+   = XVar (a_fresh, Set.singleton n) n
   -- Do nothing; the variable has been shadowed
   trans False s
    = return (False, s)
@@ -347,14 +373,14 @@ substXinS a_fresh name payload statements
        | any (flip Set.member frees . fst) (factBindsAll binds)
        -> do ntime'  <- fresh
              nfid'   <- fresh
-             let subF n n' = substXinS a_fresh n (XVar a_fresh n')
+             let subF n n' = substXinS a_fresh n (xVar n')
              ss'     <- subF ntime  ntime' ss >>= subF nfid   nfid'
              freshenForeach ntime'  nfid' [] ns x y ss'
 
       _
        -> return (True, s)
 
-  sub = subst a_fresh (Map.singleton name payload)
+  sub = substAnn a_fresh (Map.singleton name payload)
   sub1 x f
    = do x' <- sub x
         return (True, f x')
@@ -370,18 +396,31 @@ substXinS a_fresh name payload statements
 
   freshen n ss f
    = do n' <- fresh
-        ss' <- substXinS a_fresh n (XVar a_fresh n') ss
+        ss' <- substXinS a_fresh n (xVar n') ss
         trans True (f n' ss')
 
   freshenForeach ntime nfid ns [] x y ss
    = return (True, ForeachFacts (FactBinds ntime nfid ns) x y ss)
   freshenForeach ntime nfid ns ((n,t):ns') x y ss
    = do n'  <- fresh
-        ss' <- substXinS a_fresh n (XVar a_fresh n') ss
+        ss' <- substXinS a_fresh n (xVar n') ss
         freshenForeach ntime nfid (ns <> [(n',t)]) ns' x y ss'
 
   frees = freevars payload
 
+-- | Like above, but the set of variables in the annotation isn't important.
+substXinS'
+ :: (Hashable n, Eq n)
+ => a
+ -> Name n
+ -> Exp a n p
+ -> Statement a n p
+ -> Fresh n (Statement a n p)
+substXinS' a_fresh name payload statements
+  =   transformX return (return . reannotX ann) statements
+  >>= substXinS a_fresh name (reannotX ann payload)
+  >>= transformX return (return . reannotX fst)
+  where ann a = (a, Set.empty)
 
 -- | Thresher transform - throw out the chaff.
 --  * Find let bindings that have already been bound:
@@ -391,10 +430,16 @@ substXinS a_fresh name payload statements
 --      statements that do not have any external effect are silly
 --  * Constant folding for ifs
 --
-thresherNoAlpha :: (Hashable n, Eq n, Ord a) => a -> Statement a n Prim -> FixT (Fresh n) (Statement a n Prim)
+thresherNoAlpha
+ :: (Hashable n, Eq n, Ord a)
+ => a
+ -> Statement (Ann a n) n Prim
+ -> FixT (Fresh n) (Statement (Ann a n) n Prim)
 thresherNoAlpha a_fresh statements
  = transformUDStmt trans Map.empty statements
  where
+  xVar n
+   = XVar (a_fresh, Set.singleton n) n
   trans env s
    -- Check if it actually does anything:
    -- updates accumulators, returns a value, etc.
@@ -410,7 +455,7 @@ thresherNoAlpha a_fresh statements
       Let n x ss
       -- Duplicate let: change to refer to existing one
        | Just n' <- Map.lookup (ThreshMapOrd x) env
-       -> progress (env, Let n (XVar a_fresh n') ss)
+       -> progress (env, Let n (xVar n') ss)
        | otherwise
        -> return (Map.insert (ThreshMapOrd x) n env, s)
 
@@ -422,10 +467,16 @@ thresherNoAlpha a_fresh statements
       _
        -> return (env, s)
 
-thresherWithAlpha :: (Hashable n, Eq n, Ord p) => a -> Statement a n p -> FixT (Fresh n) (Statement a n p)
+thresherWithAlpha
+ :: (Hashable n, Eq n, Ord p)
+ => a
+ -> Statement (Ann a n) n p
+ -> FixT (Fresh n) (Statement (Ann a n) n p)
 thresherWithAlpha a_fresh statements
  = transformUDStmt trans emptyExpEnv statements
  where
+  xVar n
+   = XVar (a_fresh, Set.singleton n) n
   trans env s
    -- Check if it actually does anything:
    -- updates accumulators, returns a value, etc.
@@ -442,7 +493,7 @@ thresherWithAlpha a_fresh statements
       -- Duplicate let: change to refer to existing one
       -- I tried to use simple equality for simpFlattened since expressions cannot contain lambdas, but it was slower. WEIRD.
        | ((n',_):_) <- filter (\(_,x') -> x `alphaEquality` x') $ Map.toList env
-       -> progress (env, Let n (XVar a_fresh n') ss)
+       -> progress (env, Let n (xVar n') ss)
 
       If (XValue _ _ (VBool b)) t f
        -> let s' = if b then t else f
@@ -600,14 +651,18 @@ stmtFreeX_ frees statements
 -- > Let x $
 -- > Block [ Let y ...
 -- >       , baloney ]
--- 
+--
 -- this does not affect semantics so long as x isn't free in baloney.
 -- In fact, it doesn't do anything except allowing thresher to
 -- remove more duplicates.
---   
+--
 -- Note that the above example is only one step: nesting would then be
 -- recursively performed etc.
-nestBlocks :: (Hashable n, Eq n) => a -> Statement a n p -> Fresh n (Statement a n p)
+nestBlocks
+ :: (Hashable n, Eq n)
+ => a
+ -> Statement (Ann a n) n p
+ -> Fresh n (Statement (Ann a n) n p)
 nestBlocks _ statements
  = transformUDStmt trans () statements
  where

--- a/src/Icicle/Avalanche/Statement/Simp/Melt.hs
+++ b/src/Icicle/Avalanche/Statement/Simp/Melt.hs
@@ -1,10 +1,10 @@
-{-# LANGUAGE DoAndIfThenElse #-}
-{-# LANGUAGE LambdaCase #-}
-{-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
-{-# LANGUAGE PatternSynonyms #-}
-{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DoAndIfThenElse     #-}
+{-# LANGUAGE LambdaCase          #-}
+{-# LANGUAGE NoImplicitPrelude   #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PatternGuards       #-}
+{-# LANGUAGE PatternSynonyms     #-}
+{-# LANGUAGE RecordWildCards     #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 module Icicle.Avalanche.Statement.Simp.Melt (
     melt
@@ -12,32 +12,32 @@ module Icicle.Avalanche.Statement.Simp.Melt (
   , unmeltValue
   ) where
 
-import              Icicle.Avalanche.Prim.Flat
-import              Icicle.Avalanche.Prim.Eval
-import              Icicle.Avalanche.Statement.Simp
-import              Icicle.Avalanche.Statement.Statement
+import           Icicle.Avalanche.Prim.Eval
+import           Icicle.Avalanche.Prim.Flat
+import           Icicle.Avalanche.Statement.Simp
+import           Icicle.Avalanche.Statement.Statement
 
-import              Icicle.Common.Base
-import              Icicle.Common.Exp
-import              Icicle.Common.Fresh
-import              Icicle.Common.Type
+import           Icicle.Common.Base
+import           Icicle.Common.Exp
+import           Icicle.Common.Fresh
+import           Icicle.Common.Type
 
-import              P
+import           P
 
-import qualified    Data.List as List
-import qualified    Data.Map as Map
-import              Data.Hashable (Hashable)
+import           Data.Hashable                        (Hashable)
+import qualified Data.List                            as List
+import qualified Data.Map                             as Map
 
 
 ------------------------------------------------------------------------
 
 data MeltOps a n p = MeltOps {
-    xPrim  :: p                      -> Exp a n p
-  , xVar   :: Name n                 -> Exp a n p
-  , xValue :: ValType   -> BaseValue -> Exp a n p
-  , xApp   :: Exp a n p -> Exp a n p -> Exp a n p
+    xPrim      :: p                      -> Exp a n p
+  , xVar       :: Name n                 -> Exp a n p
+  , xValue     :: ValType   -> BaseValue -> Exp a n p
+  , xApp       :: Exp a n p -> Exp a n p -> Exp a n p
 
-  , primPack ::          ValType -> [Name n]  -> Exp a n p
+  , primPack   ::          ValType -> [Name n]  -> Exp a n p
   , primUnpack :: Int -> ValType -> Exp a n p -> Exp a n p
   }
 
@@ -91,7 +91,7 @@ meltAccumulators a_fresh statements
            | Just (tp, ns) <- Map.lookup acc env'
            , Just ts       <- tryMeltType tp
            -> do ns' <- freshes (length ns) na
-                 ss' <- substXinS a_fresh na (primPack tp ns') ss
+                 ss' <- substXinS' a_fresh na (primPack tp ns') ss
                  go $ foldr (\(n',n,t) -> Read n' n t) ss' (List.zip3 ns' ns ts)
 
           Write n x
@@ -173,7 +173,7 @@ meltForeachFacts a_fresh statements
   meltFact (n, t) ss
    | Just ts <- tryMeltType t
    = do ns  <- freshes (length ts) n
-        ss' <- substXinS a_fresh n (primPack t ns) ss
+        ss' <- substXinS' a_fresh n (primPack t ns) ss
         let nts = List.zip ns ts
         return (nts, ss')
 

--- a/src/Icicle/Avalanche/Statement/Statement.hs
+++ b/src/Icicle/Avalanche/Statement/Statement.hs
@@ -1,6 +1,7 @@
 -- | Statements and mutable accumulators (variables) for Avalanche
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Avalanche.Statement.Statement (
     Statement       (..)
   , Accumulator     (..)
@@ -18,6 +19,8 @@ import              Icicle.Common.Exp
 import              Icicle.Internal.Pretty
 
 import              P
+
+import              GHC.Generics (Generic)
 
 
 -- | Part of a loop
@@ -64,7 +67,9 @@ data Statement a n p
 
  -- | Save an accumulator to history. Must be after all fact loops.
  | SaveResumable !(Name n) !ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance (NFData a, NFData n, NFData p) => NFData (Statement a n p)
 
 instance Monoid (Statement a n p) where
  mempty = Block []
@@ -77,7 +82,9 @@ data FactBinds n
   , factBindId      :: Name n
   , factBindValue   :: [(Name n, ValType)]
  }
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance NFData n => NFData (FactBinds n)
 
 factBindsAll :: FactBinds n -> [(Name n, ValType)]
 factBindsAll (FactBinds ntime nid nvalue)
@@ -90,7 +97,9 @@ data Accumulator a n p
  , accValType   :: !ValType
  , accInit      :: !(Exp a n p)
  }
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance (NFData a, NFData n, NFData p) => NFData (Accumulator a n p)
 
 
 -- | When executing the feature, we also keep track of what data

--- a/src/Icicle/Common/Annot.hs
+++ b/src/Icicle/Common/Annot.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE DeriveGeneric     #-}
 
 module Icicle.Common.Annot (
       Annot (..)
@@ -6,6 +7,8 @@ module Icicle.Common.Annot (
 
 import              Icicle.Internal.Pretty
 import              Icicle.Common.Type
+
+import              GHC.Generics
 
 import              P
 
@@ -15,8 +18,9 @@ data Annot a
  { annType :: !Type
  , annTail :: !a
  }
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
+instance NFData a => NFData (Annot a)
 
 instance Pretty (Annot a) where
  pretty ann

--- a/src/Icicle/Common/Base.hs
+++ b/src/Icicle/Common/Base.hs
@@ -30,7 +30,7 @@ import              GHC.Generics (Generic)
 data Name n = Name {
     nameHash :: {-# UNPACK #-} !Int
   , nameBase :: !(NameBase n)
-  } deriving (Show)
+  } deriving (Show, Generic)
 
 instance Hashable (Name n) where
   hash           (Name h _) = h
@@ -42,6 +42,8 @@ instance Eq n => Eq  (Name n) where
 instance Eq n => Ord (Name n) where
   compare x y = compare (nameHash x) (nameHash y)
 
+instance NFData (Name n)
+
 -- | User defined names.
 data NameBase n =
  -- | Raw name
@@ -52,6 +54,8 @@ data NameBase n =
  deriving (Eq, Ord, Show, Functor, Generic)
 
 instance Hashable n => Hashable (NameBase n)
+
+instance NFData (NameBase n)
 
 nameOf :: Hashable n => NameBase n -> Name n
 nameOf n = Name (hash n) n

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Icicle.Common.Exp.Exp (
       Exp     (..)
+    , Ann
     , renameExp
     , annotOfExp
     , TransformX (..)
@@ -13,6 +14,8 @@ import              Icicle.Common.Base
 import              Icicle.Common.Type
 
 import              P
+
+import              Data.Set (Set)
 
 
 -- | Incredibly simple expressions;
@@ -63,6 +66,10 @@ class TransformX x where
             => (Name  n   -> m (Name   n'))
             -> (Exp a n p -> m (Exp a' n' p'))
             ->    x a n p -> m (x   a' n' p')
+
+type Ann a n = (a, Set (Name n))
+
+
 
 -- Pretty printing ---------------
 

--- a/src/Icicle/Common/Exp/Exp.hs
+++ b/src/Icicle/Common/Exp/Exp.hs
@@ -1,6 +1,7 @@
 -- | Definition of expressions
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Common.Exp.Exp (
       Exp     (..)
     , Ann
@@ -16,6 +17,7 @@ import              Icicle.Common.Type
 import              P
 
 import              Data.Set (Set)
+import              GHC.Generics (Generic)
 
 
 -- | Incredibly simple expressions;
@@ -40,8 +42,11 @@ data Exp a n p
 
  -- | Let binding
  | XLet !a !(Name n) !(Exp a n p) !(Exp a n p)
- deriving (Eq,Ord,Show)
+ deriving (Eq, Ord, Show, Generic)
 
+-- Turns out making the whole AST strict has a massive impact
+-- on compilation performance.
+instance NFData (Exp a n p)
 
 renameExp :: (Name n -> Name n') -> Exp a n p -> Exp a n' p
 renameExp f (XVar a n)     = XVar a (f n)

--- a/src/Icicle/Common/Exp/Simp.hs
+++ b/src/Icicle/Common/Exp/Simp.hs
@@ -1,10 +1,11 @@
 -- | Simplifier for simple expressions
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Common.Exp.Simp (
-      simp
+      simp, simpKeepAnn, simpAnn
     ) where
 
 import Icicle.Common.Exp.Exp
+import Icicle.Common.Exp.Compounds
 import Icicle.Common.Exp.Simp.Beta
 import Icicle.Common.Exp.Simp.ANormal
 import Icicle.Common.Fresh
@@ -20,3 +21,22 @@ simp a_fresh xx
  = anormal a_fresh
  $ beta isSimpleValue
    xx
+
+simpKeepAnn
+  :: (Hashable n, Eq n)
+  => a
+  -> Exp (Ann a n) n p
+  -> Fresh n (Exp (Ann a n) n p)
+simpKeepAnn a_fresh xx
+  = anormalAllVars a_fresh
+  $ beta isSimpleValue xx
+
+simpAnn
+  :: (Hashable n, Eq n)
+  => a
+  -> Exp a n p
+  -> Fresh n (Exp (Ann a n) n p)
+simpAnn a_fresh xx
+  = anormalAllVars a_fresh
+  $ beta isSimpleValue
+  $ allvarsExp xx

--- a/src/Icicle/Common/Exp/Simp/ANormal.hs
+++ b/src/Icicle/Common/Exp/Simp/ANormal.hs
@@ -41,10 +41,9 @@ anormal :: (Hashable n, Eq n) => a -> Exp a n p -> Fresh n (Exp a n p)
 anormal a_fresh xx
  -- Annotate each expression with all the variables underneath it,
  -- then perform a-normalisation, then throw away the annotations
- -- = reannotX fst <$> (anormalAllVars a_fresh $ allvarsExp xx)
- = do let !x = {-# SCC anormal_ann #-} allvarsExp xx
-      !y <- {-# SCC anormal_actual #-} anormalAllVars a_fresh x
-      let !z = {-# SCC anormal_reannot #-} reannotX fst y
+ = do let !x  = allvarsExp xx
+      !y     <- anormalAllVars a_fresh x
+      let !z  = reannotX fst y
       return z
 
 
@@ -59,16 +58,16 @@ anormal a_fresh xx
 --
 anormalAllVars :: (Hashable n, Eq n) => a -> Exp (Ann a n) n p -> Fresh n (Exp (Ann a n) n p)
 anormalAllVars a_fresh xx
- = do   (bs, x)  <- {-# SCC anormal_pullsubexps #-}pullSubExps a_fresh xx
+ = do   (bs, x)  <- pullSubExps a_fresh xx
         -- Get the union of all the variables
-        let !allNames = {-# SCC anormal_varOfLets #-}varsOfLets bs x
+        let !allNames = varsOfLets bs x
         -- and rename the outside binds if they are used
-        (bs',x') <- {-# SCC anormal_renames #-}renames allNames bs [] x
+        (bs',x') <- renames allNames bs [] x
 
         -- Tag the result with the union of the original bindings (bs)
         -- as well as the new names of the bindings.
-        let !allNames' = {-# SCC anormal_allnames #-} allNames <> Set.fromList (fmap fst bs')
-        let !ret = {-# SCC anormal_mklets#-}makeLets (a_fresh, allNames') bs' x'
+        let !allNames' = allNames <> Set.fromList (fmap fst bs')
+        let !ret       = makeLets (a_fresh, allNames') bs' x'
         return ret
 
  where

--- a/src/Icicle/Common/Exp/Simp/ANormal.hs
+++ b/src/Icicle/Common/Exp/Simp/ANormal.hs
@@ -17,7 +17,8 @@
 -- Conversion to a-normal form is not a benefit in itself, but simplifies
 -- later transformations.
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE BangPatterns      #-}
 module Icicle.Common.Exp.Simp.ANormal (
       anormal
     , anormalAllVars
@@ -33,7 +34,6 @@ import Data.List (unzip)
 import Data.Hashable (Hashable)
 
 import qualified    Data.Set    as Set
-import              Data.Set     ( Set )
 
 -- | A-normalise an expression.
 -- We need a fresh name supply.
@@ -41,7 +41,11 @@ anormal :: (Hashable n, Eq n) => a -> Exp a n p -> Fresh n (Exp a n p)
 anormal a_fresh xx
  -- Annotate each expression with all the variables underneath it,
  -- then perform a-normalisation, then throw away the annotations
- = reannotX fst <$> (anormalAllVars a_fresh $ allvarsExp xx)
+ -- = reannotX fst <$> (anormalAllVars a_fresh $ allvarsExp xx)
+ = do let !x = {-# SCC anormal_ann #-} allvarsExp xx
+      !y <- {-# SCC anormal_actual #-} anormalAllVars a_fresh x
+      let !z = {-# SCC anormal_reannot #-} reannotX fst y
+      return z
 
 
 -- | A-normalise an expression, annotated with all the mentioned variables.
@@ -53,18 +57,19 @@ anormal a_fresh xx
 -- * a superset is allowed, as it will just make renaming more pessimistic
 -- * new fresh variables don't need to be mentioned, as they will not appear elsewhere as binders or mentioned
 --
-anormalAllVars :: (Hashable n, Eq n) => a -> Exp (a, Set (Name n)) n p -> Fresh n (Exp (a, Set (Name n)) n p)
+anormalAllVars :: (Hashable n, Eq n) => a -> Exp (Ann a n) n p -> Fresh n (Exp (Ann a n) n p)
 anormalAllVars a_fresh xx
- = do   (bs, x)  <- pullSubExps a_fresh xx
+ = do   (bs, x)  <- {-# SCC anormal_pullsubexps #-}pullSubExps a_fresh xx
         -- Get the union of all the variables
-        let allNames = varsOfLets bs x
+        let !allNames = {-# SCC anormal_varOfLets #-}varsOfLets bs x
         -- and rename the outside binds if they are used
-        (bs',x') <- renames allNames bs [] x
+        (bs',x') <- {-# SCC anormal_renames #-}renames allNames bs [] x
 
         -- Tag the result with the union of the original bindings (bs)
         -- as well as the new names of the bindings.
-        let allNames' = allNames <> Set.fromList (fmap fst bs')
-        return $ makeLets (a_fresh, allNames') bs' x'
+        let !allNames' = {-# SCC anormal_allnames #-} allNames <> Set.fromList (fmap fst bs')
+        let !ret = {-# SCC anormal_mklets#-}makeLets (a_fresh, allNames') bs' x'
+        return ret
 
  where
   -- All the variables inside the bindings
@@ -116,7 +121,7 @@ anormalAllVars a_fresh xx
 
 
 -- | Recursively pull out sub-expressions to be bound
-pullSubExps :: (Hashable n, Eq n) => a -> Exp (a, Set (Name n)) n p -> Fresh n ([(Name n, Exp (a, Set (Name n)) n p)], Exp (a, Set (Name n)) n p)
+pullSubExps :: (Hashable n, Eq n) => a -> Exp (Ann a n) n p -> Fresh n ([(Name n, Exp (Ann a n) n p)], Exp (Ann a n) n p)
 pullSubExps a_fresh xx
  = case xx of
     -- Values and other simple expressions can be left alone.
@@ -165,7 +170,7 @@ pullSubExps a_fresh xx
 -- | Extract bindings for part of an application expression.
 -- If it's simple, just give it back.
 -- If it's interesting, anormalise it and bind it to a fresh name
-extractBinding :: (Hashable n, Eq n) => a -> Exp (a, Set (Name n)) n p -> Fresh n ([(Name n, Exp (a, Set (Name n)) n p)], Exp (a, Set (Name n)) n p)
+extractBinding :: (Hashable n, Eq n) => a -> Exp (Ann a n) n p -> Fresh n ([(Name n, Exp (Ann a n) n p)], Exp (Ann a n) n p)
 extractBinding a_fresh xx
  | isNormal xx
  = return ([], xx)

--- a/src/Icicle/Common/Fresh.hs
+++ b/src/Icicle/Common/Fresh.hs
@@ -1,6 +1,7 @@
 -- | Generating Fresh names
-{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE NoImplicitPrelude         #-}
 {-# LANGUAGE ExistentialQuantification #-}
+{-# LANGUAGE DeriveGeneric             #-}
 module Icicle.Common.Fresh (
       FreshT   (..)
     , Fresh
@@ -45,6 +46,8 @@ runFreshIdentity f
 
 data NameState n
  = forall s. NameState (s -> (NameBase n, s)) s
+
+instance NFData (NameState n)
 
 mkNameState :: (s -> (NameBase n, s)) -> s -> NameState n
 mkNameState = NameState

--- a/src/Icicle/Core/Exp/Prim.hs
+++ b/src/Icicle/Core/Exp/Prim.hs
@@ -1,6 +1,7 @@
 -- | Primitive functions, constant values and so on
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Core.Exp.Prim (
       Prim          (..)
     , PrimFold      (..)
@@ -17,6 +18,8 @@ import qualified    Icicle.Common.Exp.Prim.Minimal as Min
 
 import              P
 
+import              GHC.Generics (Generic)
+
 
 -- | Top-level primitive for Core expressions
 -- Includes folds etc that won't be present in Avalanche
@@ -32,7 +35,7 @@ data Prim
  -- | Circular buffer for latest
  | PrimLatest   PrimLatest
  | PrimWindow   WindowUnit (Maybe WindowUnit)
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 -- | Folds and destructing things
@@ -42,13 +45,13 @@ data PrimFold
  | PrimFoldOption ValType
  | PrimFoldSum    ValType ValType
  | PrimFoldMap    ValType ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 -- | Array primitives
 data PrimArray
  = PrimArrayMap ValType ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 -- | Map primitives
@@ -56,14 +59,20 @@ data PrimMap
  = PrimMapInsertOrUpdate ValType ValType
  | PrimMapMapValues ValType ValType ValType
  | PrimMapLookup ValType ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
 
 
 -- | Latest buffer primitives
 data PrimLatest
  = PrimLatestPush Int ValType
  | PrimLatestRead Int ValType
- deriving (Eq, Ord, Show)
+ deriving (Eq, Ord, Show, Generic)
+
+instance NFData Prim
+instance NFData PrimFold
+instance NFData PrimArray
+instance NFData PrimMap
+instance NFData PrimLatest
 
 
 -- | A primitive always has a well-defined type

--- a/src/Icicle/Core/Program/Program.hs
+++ b/src/Icicle/Core/Program/Program.hs
@@ -1,6 +1,7 @@
 -- | An entire core program
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Core.Program.Program (
       Program (..)
     , renameProgram
@@ -14,6 +15,8 @@ import              Icicle.Core.Exp
 import              Icicle.Core.Stream.Stream
 
 import              P
+
+import              GHC.Generics (Generic)
 
 
 -- | Core program composed of different stages of bindings
@@ -38,8 +41,9 @@ data Program a n =
  -- | The return values
  , returns      :: [(OutputName, Exp a n)]
  }
- deriving (Show, Eq, Ord)
+ deriving (Show, Eq, Ord, Generic)
 
+instance (NFData a, NFData n) => NFData (Program a n)
 
 renameProgram :: (Name n -> Name n') -> Program a n -> Program a n'
 renameProgram f p

--- a/src/Icicle/Source/Lexer/Token.hs
+++ b/src/Icicle/Source/Lexer/Token.hs
@@ -128,6 +128,7 @@ newtype Variable
  deriving (Eq, Ord, Show, Generic)
 
 instance Hashable Variable
+instance NFData Variable
 
 -- | Each keyword with their name
 keywords :: [(Text, Keyword)]

--- a/test/Icicle/Test/Arbitrary/Data.hs
+++ b/test/Icicle/Test/Arbitrary/Data.hs
@@ -37,6 +37,7 @@ data Var = Var T.Text Int
  deriving (Eq,Ord,Show,Generic)
 
 instance Hashable Var
+instance NFData Var
 
 instance IsString Var where
   fromString s


### PR DESCRIPTION
* Keep an annotation of variables in an expression, to avoid recomputing it during avalanche simplification. This brings the compilation time down quite a bit, from 5-6hrs to maybe half an hour. It's not great but it's a start:

```
./dist/build/ice/ice snapshot empty.psv dictionary-postpaid.toml 2016-01-01    3112.85s user 3233.29s system 312% cpu 33:52.69 total
``` 