### PR TITLE
Fix chord output dense

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -24,7 +24,7 @@ library
                      , containers                      == 0.5.*
                      , dates                           == 0.2.*
                      , directory                       == 1.2.*
-                     , deepseq                         == 1.3.*
+                     , deepseq                         >= 1.3        && < 1.5
                      , exceptions                      == 0.8.*
                      , file-embed                      == 0.0.9
                      , filepath                        >= 1.3        && < 1.5

--- a/src/Icicle/Sea/Psv/Output.hs
+++ b/src/Icicle/Sea/Psv/Output.hs
@@ -81,13 +81,13 @@ seaOfWriteFleetOutput config whitelist states = do
     , ""
     , "    char *buffer_ptr = *buffer_ptr_ptr;"
     , ""
-    , indent 4 beforeChord
     , "    for (iint_t chord_ix = 0; chord_ix < chord_count; chord_ix++) {"
+    , indent 8 beforeChord
     , indent 8 (seaOfChordTime $ outputPsvMode config)
     , indent 8 (vsep write_sea)
     , indent 8 inChord
+    , indent 8 afterChord
     , "    }"
-    , indent 4 afterChord
     , ""
     , "    *buffer_ptr_ptr = buffer_ptr;"
     , ""


### PR DESCRIPTION
It's currently like this for `chord --output-psv dense`:

```
ID00|foo|bar|2016-01-02|foo|bar|2016-01-03
```

fixes so that it becomes:

```
ID00|foo|bar|2016-01-02
ID00|foo|bar|2016-01-03
```

@jystic 