### PR TITLE
Fix reify bug

### DIFF
--- a/src/Icicle/Source/Transform/ReifyPossibility.hs
+++ b/src/Icicle/Source/Transform/ReifyPossibility.hs
@@ -79,8 +79,10 @@ reifyPossibilityX wrap x
              args' <- mapM (reifyPossibilityX wrap) args
              makeApps a fun' args' False
 
+      -- Primitives do not need their annotation to be wrapped:
+      -- if they are Possiblies, their outer use will be wrapped in a Right.
       Prim a p
-       -> return $ Prim (wrapAnnot a) p
+       -> return $ Prim a p
 
       -- If the scrutinee is possibly, we need to unwrap it before performing the case:
       -- > case scrut | alt -> ...

--- a/test/cli/repl/t07-possiblies/expected
+++ b/test/cli/repl/t07-possiblies/expected
@@ -30,4 +30,8 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 > - Core evaluation:
 [homer, 500,marge, 20]
 
+> > -- Constructing a Right of a Possibility was causing an issue before
+> - Core evaluation:
+[homer, 500,marge, 20]
+
 > 

--- a/test/cli/repl/t07-possiblies/script
+++ b/test/cli/repl/t07-possiblies/script
@@ -16,3 +16,6 @@ feature salary ~> (newest (double value) / 5, oldest (double value / 5), sum val
 
 -- This was causing an issue with nested possibility cases before
 feature salary ~> latest 1 ~> case (0,sum value) | (z,s) -> s end
+
+-- Constructing a Right of a Possibility was causing an issue before
+feature salary ~> fold x = 0 : value ~> Right x


### PR DESCRIPTION
> Tran Ma·9:19 AM convert_is_well_typed failed for this:
```
feature gonzofeaturename
~> fold1 gonzo = 59.14305720951913 : (let kermit = 2
                                      ~> gonzo)
~> Right gonzo
```


@tranma 