### PR TITLE
Remove duplicate work in constant folding

### DIFF
--- a/src/Icicle/Source/ToCore/Prim.hs
+++ b/src/Icicle/Source/ToCore/Prim.hs
@@ -316,7 +316,7 @@ convertPrim p ann resT xts = go p
    | otherwise
    = convertError $ ConvertErrorPrimNoArguments ann 3 p
   gomap MapDelete
-   | (_ : _ : (_, tm) : _) <- xts
+   | (_ : (_, tm) : _) <- xts
    = case valTypeOfType tm of
        Just (T.MapT tk tv)
          -> return $ applies $ CE.XPrim () $ C.PrimMap $ C.PrimMapDelete tk tv

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -174,12 +174,12 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
   read conv$4$aval$0$simp$26 = acc$conv$4$simp$21 [Array (Buf 2 FactIdentifier)];
   read conv$4$aval$0$simp$27 = acc$conv$4$simp$22 [Array (Buf 2 Error)];
   read conv$4$aval$0$simp$28 = acc$conv$4$simp$23 [Array (Buf 2 Int)];
-  let simp$323 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
-  let simp$193 = Buf_push#@{Buf 2 FactIdentifier} simp$323 conv$1;
-  let simp$324 = Buf_make#@{Buf 2 Error} (()@{Unit});
-  let simp$196 = Buf_push#@{Buf 2 Error} simp$324 conv$0$simp$97;
-  let simp$325 = Buf_make#@{Buf 2 Int} (()@{Unit});
-  let simp$199 = Buf_push#@{Buf 2 Int} simp$325 conv$0$simp$98;
+  let simp$326 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
+  let simp$196 = Buf_push#@{Buf 2 FactIdentifier} simp$326 conv$1;
+  let simp$327 = Buf_make#@{Buf 2 Error} (()@{Unit});
+  let simp$199 = Buf_push#@{Buf 2 Error} simp$327 conv$0$simp$97;
+  let simp$328 = Buf_make#@{Buf 2 Int} (()@{Unit});
+  let simp$202 = Buf_push#@{Buf 2 Int} simp$328 conv$0$simp$98;
   init flat$1@{Bool} = False@{Bool};
   init flat$2@{Array Time} = conv$4$aval$0$simp$25;
   init flat$3$simp$30@{Array (Buf 2 FactIdentifier)} = conv$4$aval$0$simp$26;
@@ -196,15 +196,15 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
     let simp$115 = unsafe_Array_index#@{Time} flat$2 flat$5;
     if (eq#@{Time} simp$115 conv$0$simp$99)
     {
-      let simp$206 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5;
-      let simp$208 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$35 flat$5;
-      let simp$210 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$36 flat$5;
-      let simp$217 = Buf_push#@{Buf 2 FactIdentifier} simp$206 conv$1;
-      let simp$220 = Buf_push#@{Buf 2 Error} simp$208 conv$0$simp$97;
-      let simp$223 = Buf_push#@{Buf 2 Int} simp$210 conv$0$simp$98;
-      write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5 simp$217;
-      write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$3$simp$35 flat$5 simp$220;
-      write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$3$simp$36 flat$5 simp$223;
+      let simp$209 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5;
+      let simp$211 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$35 flat$5;
+      let simp$213 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$36 flat$5;
+      let simp$220 = Buf_push#@{Buf 2 FactIdentifier} simp$209 conv$1;
+      let simp$223 = Buf_push#@{Buf 2 Error} simp$211 conv$0$simp$97;
+      let simp$226 = Buf_push#@{Buf 2 Int} simp$213 conv$0$simp$98;
+      write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5 simp$220;
+      write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$3$simp$35 flat$5 simp$223;
+      write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$3$simp$36 flat$5 simp$226;
       write flat$1 = True@{Bool};
     }
   }
@@ -222,9 +222,9 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
     read flat$9$simp$39 = flat$3$simp$31 [Array (Buf 2 Error)];
     read flat$9$simp$40 = flat$3$simp$32 [Array (Buf 2 Int)];
     let simp$134 = Array_length#@{Buf 2 FactIdentifier} flat$9$simp$38;
-    write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$9$simp$38 simp$134 simp$193;
-    write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$9$simp$39 simp$134 simp$196;
-    write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$9$simp$40 simp$134 simp$199;
+    write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$9$simp$38 simp$134 simp$196;
+    write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$9$simp$39 simp$134 simp$199;
+    write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$9$simp$40 simp$134 simp$202;
   }
   read flat$2 = flat$2 [Array Time];
   read flat$3$simp$42 = flat$3$simp$30 [Array (Buf 2 FactIdentifier)];
@@ -238,8 +238,8 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
 read acc$conv$4$flat$11$simp$47 = acc$conv$4$simp$21 [Array (Buf 2 FactIdentifier)];
 foreach (flat$13 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47)
 {
-  let simp$257 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47 flat$13;
-  let flat$14 = Buf_read#@{Array FactIdentifier} simp$257;
+  let simp$260 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47 flat$13;
+  let flat$14 = Buf_read#@{Array FactIdentifier} simp$260;
   foreach (flat$15 in 0@{Int} .. Array_length#@{FactIdentifier} flat$14)
   {
     keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$14 flat$15;
@@ -260,34 +260,34 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
   read flat$23$simp$59 = flat$23$simp$56 [Error];
   read flat$23$simp$60 = flat$23$simp$57 [Array Time];
   read flat$23$simp$61 = flat$23$simp$58 [Array Int];
-  let simp$272 = unsafe_Array_index#@{Time} conv$4$simp$51 flat$24;
-  let simp$276 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$53 flat$24;
-  let simp$278 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$54 flat$24;
+  let simp$275 = unsafe_Array_index#@{Time} conv$4$simp$51 flat$24;
+  let simp$279 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$53 flat$24;
+  let simp$281 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$54 flat$24;
   init flat$26$simp$62@{Error} = ExceptNotAnError@{Error};
   init flat$26$simp$63@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat$26$simp$64@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
   if (eq#@{Error} flat$23$simp$59 (ExceptNotAnError@{Error}))
   {
-    let simp$294 = Buf_read#@{Array Error} simp$276;
-    let simp$296 = Buf_read#@{Array Int} simp$278;
+    let simp$297 = Buf_read#@{Array Error} simp$279;
+    let simp$299 = Buf_read#@{Array Int} simp$281;
     init flat$30$simp$67@{Error} = ExceptNotAnError@{Error};
     init flat$30$simp$68@{Int} = 0@{Int};
-    foreach (flat$43 in 0@{Int} .. Array_length#@{Error} simp$294)
+    foreach (flat$43 in 0@{Int} .. Array_length#@{Error} simp$297)
     {
       read flat$30$simp$71 = flat$30$simp$67 [Error];
       read flat$30$simp$72 = flat$30$simp$68 [Int];
-      let simp$301 = unsafe_Array_index#@{Error} simp$294 flat$43;
-      let simp$303 = unsafe_Array_index#@{Int} simp$296 flat$43;
+      let simp$304 = unsafe_Array_index#@{Error} simp$297 flat$43;
+      let simp$306 = unsafe_Array_index#@{Int} simp$299 flat$43;
       init flat$45$simp$73@{Error} = ExceptNotAnError@{Error};
       init flat$45$simp$74@{Int} = 0@{Int};
-      if (eq#@{Error} simp$301 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} simp$304 (ExceptNotAnError@{Error}))
       {
         init flat$48$simp$75@{Error} = ExceptNotAnError@{Error};
         init flat$48$simp$76@{Int} = 0@{Int};
         if (eq#@{Error} flat$30$simp$71 (ExceptNotAnError@{Error}))
         {
           write flat$48$simp$75 = ExceptNotAnError@{Error};
-          write flat$48$simp$76 = add#@{Int} simp$303 flat$30$simp$72;
+          write flat$48$simp$76 = add#@{Int} simp$306 flat$30$simp$72;
         }
         else
         {
@@ -301,7 +301,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
       }
       else
       {
-        write flat$45$simp$73 = simp$301;
+        write flat$45$simp$73 = simp$304;
         write flat$45$simp$74 = 0@{Int};
       }
       read flat$45$simp$79 = flat$45$simp$73 [Error];
@@ -326,7 +326,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
         read flat$35 = flat$35 [Array Time];
         read flat$36 = flat$36 [Array Int];
         let simp$174 = unsafe_Array_index#@{Time} flat$35 flat$38;
-        if (eq#@{Time} simp$174 simp$272)
+        if (eq#@{Time} simp$174 simp$275)
         {
           let flat$39 = unsafe_Array_index#@{Int} flat$36 flat$38;
           write flat$36 = Array_put_mutable#@{Int} flat$36 flat$38 flat$39;
@@ -342,7 +342,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
       {
         read flat$40 = flat$35 [Array Time];
         let simp$175 = Array_length#@{Time} flat$40;
-        write flat$35 = Array_put_mutable#@{Time} flat$40 simp$175 simp$272;
+        write flat$35 = Array_put_mutable#@{Time} flat$40 simp$175 simp$275;
         read flat$41 = flat$36 [Array Int];
         let simp$176 = Array_length#@{Int} flat$41;
         write flat$36 = Array_put_mutable#@{Int} flat$41 simp$176 flat$30$simp$84;

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -174,12 +174,12 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
   read conv$4$aval$0$simp$26 = acc$conv$4$simp$21 [Array (Buf 2 FactIdentifier)];
   read conv$4$aval$0$simp$27 = acc$conv$4$simp$22 [Array (Buf 2 Error)];
   read conv$4$aval$0$simp$28 = acc$conv$4$simp$23 [Array (Buf 2 Int)];
-  let simp$326 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
-  let simp$196 = Buf_push#@{Buf 2 FactIdentifier} simp$326 conv$1;
-  let simp$327 = Buf_make#@{Buf 2 Error} (()@{Unit});
-  let simp$199 = Buf_push#@{Buf 2 Error} simp$327 conv$0$simp$97;
-  let simp$328 = Buf_make#@{Buf 2 Int} (()@{Unit});
-  let simp$202 = Buf_push#@{Buf 2 Int} simp$328 conv$0$simp$98;
+  let simp$323 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
+  let simp$193 = Buf_push#@{Buf 2 FactIdentifier} simp$323 conv$1;
+  let simp$324 = Buf_make#@{Buf 2 Error} (()@{Unit});
+  let simp$196 = Buf_push#@{Buf 2 Error} simp$324 conv$0$simp$97;
+  let simp$325 = Buf_make#@{Buf 2 Int} (()@{Unit});
+  let simp$199 = Buf_push#@{Buf 2 Int} simp$325 conv$0$simp$98;
   init flat$1@{Bool} = False@{Bool};
   init flat$2@{Array Time} = conv$4$aval$0$simp$25;
   init flat$3$simp$30@{Array (Buf 2 FactIdentifier)} = conv$4$aval$0$simp$26;
@@ -196,15 +196,15 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
     let simp$115 = unsafe_Array_index#@{Time} flat$2 flat$5;
     if (eq#@{Time} simp$115 conv$0$simp$99)
     {
-      let simp$209 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5;
-      let simp$211 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$35 flat$5;
-      let simp$213 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$36 flat$5;
-      let simp$220 = Buf_push#@{Buf 2 FactIdentifier} simp$209 conv$1;
-      let simp$223 = Buf_push#@{Buf 2 Error} simp$211 conv$0$simp$97;
-      let simp$226 = Buf_push#@{Buf 2 Int} simp$213 conv$0$simp$98;
-      write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5 simp$220;
-      write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$3$simp$35 flat$5 simp$223;
-      write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$3$simp$36 flat$5 simp$226;
+      let simp$206 = unsafe_Array_index#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5;
+      let simp$208 = unsafe_Array_index#@{Buf 2 Error} flat$3$simp$35 flat$5;
+      let simp$210 = unsafe_Array_index#@{Buf 2 Int} flat$3$simp$36 flat$5;
+      let simp$217 = Buf_push#@{Buf 2 FactIdentifier} simp$206 conv$1;
+      let simp$220 = Buf_push#@{Buf 2 Error} simp$208 conv$0$simp$97;
+      let simp$223 = Buf_push#@{Buf 2 Int} simp$210 conv$0$simp$98;
+      write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$3$simp$34 flat$5 simp$217;
+      write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$3$simp$35 flat$5 simp$220;
+      write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$3$simp$36 flat$5 simp$223;
       write flat$1 = True@{Bool};
     }
   }
@@ -222,9 +222,9 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
     read flat$9$simp$39 = flat$3$simp$31 [Array (Buf 2 Error)];
     read flat$9$simp$40 = flat$3$simp$32 [Array (Buf 2 Int)];
     let simp$134 = Array_length#@{Buf 2 FactIdentifier} flat$9$simp$38;
-    write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$9$simp$38 simp$134 simp$196;
-    write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$9$simp$39 simp$134 simp$199;
-    write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$9$simp$40 simp$134 simp$202;
+    write flat$3$simp$30 = Array_put_mutable#@{Buf 2 FactIdentifier} flat$9$simp$38 simp$134 simp$193;
+    write flat$3$simp$31 = Array_put_mutable#@{Buf 2 Error} flat$9$simp$39 simp$134 simp$196;
+    write flat$3$simp$32 = Array_put_mutable#@{Buf 2 Int} flat$9$simp$40 simp$134 simp$199;
   }
   read flat$2 = flat$2 [Array Time];
   read flat$3$simp$42 = flat$3$simp$30 [Array (Buf 2 FactIdentifier)];
@@ -238,8 +238,8 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simp$97@{Error}, conv$
 read acc$conv$4$flat$11$simp$47 = acc$conv$4$simp$21 [Array (Buf 2 FactIdentifier)];
 foreach (flat$13 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47)
 {
-  let simp$260 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47 flat$13;
-  let flat$14 = Buf_read#@{Array FactIdentifier} simp$260;
+  let simp$257 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$4$flat$11$simp$47 flat$13;
+  let flat$14 = Buf_read#@{Array FactIdentifier} simp$257;
   foreach (flat$15 in 0@{Int} .. Array_length#@{FactIdentifier} flat$14)
   {
     keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$14 flat$15;
@@ -260,34 +260,34 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
   read flat$23$simp$59 = flat$23$simp$56 [Error];
   read flat$23$simp$60 = flat$23$simp$57 [Array Time];
   read flat$23$simp$61 = flat$23$simp$58 [Array Int];
-  let simp$275 = unsafe_Array_index#@{Time} conv$4$simp$51 flat$24;
-  let simp$279 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$53 flat$24;
-  let simp$281 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$54 flat$24;
+  let simp$272 = unsafe_Array_index#@{Time} conv$4$simp$51 flat$24;
+  let simp$276 = unsafe_Array_index#@{Buf 2 Error} conv$4$simp$53 flat$24;
+  let simp$278 = unsafe_Array_index#@{Buf 2 Int} conv$4$simp$54 flat$24;
   init flat$26$simp$62@{Error} = ExceptNotAnError@{Error};
   init flat$26$simp$63@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat$26$simp$64@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
   if (eq#@{Error} flat$23$simp$59 (ExceptNotAnError@{Error}))
   {
-    let simp$297 = Buf_read#@{Array Error} simp$279;
-    let simp$299 = Buf_read#@{Array Int} simp$281;
+    let simp$294 = Buf_read#@{Array Error} simp$276;
+    let simp$296 = Buf_read#@{Array Int} simp$278;
     init flat$30$simp$67@{Error} = ExceptNotAnError@{Error};
     init flat$30$simp$68@{Int} = 0@{Int};
-    foreach (flat$43 in 0@{Int} .. Array_length#@{Error} simp$297)
+    foreach (flat$43 in 0@{Int} .. Array_length#@{Error} simp$294)
     {
       read flat$30$simp$71 = flat$30$simp$67 [Error];
       read flat$30$simp$72 = flat$30$simp$68 [Int];
-      let simp$304 = unsafe_Array_index#@{Error} simp$297 flat$43;
-      let simp$306 = unsafe_Array_index#@{Int} simp$299 flat$43;
+      let simp$301 = unsafe_Array_index#@{Error} simp$294 flat$43;
+      let simp$303 = unsafe_Array_index#@{Int} simp$296 flat$43;
       init flat$45$simp$73@{Error} = ExceptNotAnError@{Error};
       init flat$45$simp$74@{Int} = 0@{Int};
-      if (eq#@{Error} simp$304 (ExceptNotAnError@{Error}))
+      if (eq#@{Error} simp$301 (ExceptNotAnError@{Error}))
       {
         init flat$48$simp$75@{Error} = ExceptNotAnError@{Error};
         init flat$48$simp$76@{Int} = 0@{Int};
         if (eq#@{Error} flat$30$simp$71 (ExceptNotAnError@{Error}))
         {
           write flat$48$simp$75 = ExceptNotAnError@{Error};
-          write flat$48$simp$76 = add#@{Int} simp$306 flat$30$simp$72;
+          write flat$48$simp$76 = add#@{Int} simp$303 flat$30$simp$72;
         }
         else
         {
@@ -301,7 +301,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
       }
       else
       {
-        write flat$45$simp$73 = simp$304;
+        write flat$45$simp$73 = simp$301;
         write flat$45$simp$74 = 0@{Int};
       }
       read flat$45$simp$79 = flat$45$simp$73 [Error];
@@ -326,7 +326,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
         read flat$35 = flat$35 [Array Time];
         read flat$36 = flat$36 [Array Int];
         let simp$174 = unsafe_Array_index#@{Time} flat$35 flat$38;
-        if (eq#@{Time} simp$174 simp$275)
+        if (eq#@{Time} simp$174 simp$272)
         {
           let flat$39 = unsafe_Array_index#@{Int} flat$36 flat$38;
           write flat$36 = Array_put_mutable#@{Int} flat$36 flat$38 flat$39;
@@ -342,7 +342,7 @@ foreach (flat$24 in 0@{Int} .. Array_length#@{Time} conv$4$simp$51)
       {
         read flat$40 = flat$35 [Array Time];
         let simp$175 = Array_length#@{Time} flat$40;
-        write flat$35 = Array_put_mutable#@{Time} flat$40 simp$175 simp$275;
+        write flat$35 = Array_put_mutable#@{Time} flat$40 simp$175 simp$272;
         read flat$41 = flat$36 [Array Int];
         let simp$176 = Array_length#@{Int} flat$41;
         write flat$36 = Array_put_mutable#@{Int} flat$41 simp$176 flat$30$simp$84;


### PR DESCRIPTION
This reduces the compilation time of a big dictionary with nested cases from 17057.11s to 257.91s.
@amosr 