### PR TITLE
Oil rigs for Sea structs

### DIFF
--- a/icicle.cabal
+++ b/icicle.cabal
@@ -184,6 +184,8 @@ library
                        Icicle.Sea.IO.Psv.Base
                        Icicle.Sea.IO.Psv.Input
                        Icicle.Sea.IO.Psv.Output
+                       Icicle.Sea.IO.Zebra
+                       Icicle.Sea.IO.Zebra.Input
 
                        Icicle.Source.Eval
                        Icicle.Source.Query

--- a/icicle.cabal
+++ b/icicle.cabal
@@ -30,6 +30,9 @@ library
                      , filepath                        >= 1.3        && < 1.5
                      , hashable                        == 1.2.*
                      , lens                            >= 4.7        && < 4.10
+                     , language-c-quote                == 0.11.*
+                     , srcloc                          == 0.5.*
+                     , mainland-pretty                 == 0.4.*
                      , mmorph                          == 1.0.*
                      , old-locale                      == 1.0.*
                      , parallel                        == 3.2.*

--- a/master.toml
+++ b/master.toml
@@ -4,23 +4,35 @@
   sha1 = "b89ee2ce5fc08b8f1ec5d92c6199b5fda9484783"
 
 [build.dist]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
   HADDOCK="true"
   PUBLISH="icicle-repl"
 
 [build.dist-bench]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
   TEST="false"
   BENCH="true"
   PUBLISH_BENCH="icicle"  
 
 [build.branches]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
 
 [build.branches-bench]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
   TEST="false"
   BENCH="true"
 
 [build.appshop]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
   PUBLISH_APPSHOP="icicle-repl"
 
 [build.appshop.master]
+  MAFIA_ALEX = "true"
+  MAFIA_HAPPY = "true"
   runner = "s3://ambiata-dispensary-v2/dist/master/master-ambiata/master-haskell-appshop-0.0.1-20160114232634-a8a6f45"
   sha1 = "7890c390e5088c5b38264341d2451bd2f54de184"

--- a/src/Icicle/Internal/Pretty.hs
+++ b/src/Icicle/Internal/Pretty.hs
@@ -24,12 +24,17 @@ module Icicle.Internal.Pretty (
     , annSepByComma
     , annTypeArgs
     , annotateTypeArgs
+
+    , ppm
+    , ppmDoc
     ) where
 
 -- The one we want to export without <> or <$>
 import              Text.PrettyPrint.Annotated.Leijen as PP hiding ((<>), (<$>), Doc)
 -- The one with <>
 import qualified    Text.PrettyPrint.Annotated.Leijen as PJOIN
+-- Compatibility with mainland-pretty for codegen purposes
+import qualified    Text.PrettyPrint.Mainland as Mainland
 
 import              P
 
@@ -133,3 +138,12 @@ padDoc wid doc
    in  if w <= wid
        then doc P.<> mconcat (replicate (wid - w) (text " "))
        else doc P.<> line P.<> mconcat (replicate wid (text " "))
+
+--------------------------------------------------------------------------------
+
+ppmDoc :: Mainland.Doc -> Doc
+ppmDoc = text . Mainland.pretty 0
+
+-- To avoid importing it and create confusion with our Pretty
+ppm :: Mainland.Pretty a => a -> Doc
+ppm = ppmDoc . Mainland.ppr

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -122,7 +122,7 @@ seaOfStatement stmt
      ForeachFacts (FactBinds ntime nfid ns) _ FactLoopNew stmt'
       -> let structAssign (n, t) = assign (defOfVar' 1 ("const" <+> seaOfValType t)
                                                        ("const" <+> pretty newPrefix <> seaOfName n))
-                                          ("s->" <> pretty newPrefix <> seaOfName n) <> semi
+                                          (stNew n) <> semi
              loopAssign   (n, t) = assign (defOfVar 0 t (seaOfName n))
                                           (pretty newPrefix <> seaOfName n <> "[i]") <> semi
              factTime = case reverse ns of
@@ -155,13 +155,13 @@ seaOfStatement stmt
 
      LoadResumable n _
       -> vsep [ ""
-              , "if (s->" <> pretty hasPrefix <> seaOfName n <> ") {"
-              , indent 4 $ assign (seaOfName n) ("s->" <> pretty resPrefix <> seaOfName n) <> semi <> suffix "load"
+              , "if (" <> stHas n <> ") {"
+              , indent 4 $ assign (seaOfName n) (stRes n) <> semi <> suffix "load"
               , "}" ]
 
      SaveResumable n _
-      -> assign ("s->" <> pretty hasPrefix <> seaOfName n) "itrue"       <> semi <> suffix "save" <> line
-      <> assign ("s->" <> pretty resPrefix <> seaOfName n) (seaOfName n) <> semi <> suffix "save" <> line
+      -> assign (stHas n) "itrue"       <> semi <> suffix "save" <> line
+      <> assign (stRes n) (seaOfName n) <> semi <> suffix "save" <> line
 
      Output n _ xts
       | ixAssign <- \ix xx -> assign ("s->" <> seaOfNameIx n ix) (seaOfExp xx) <> semi <> suffix "output"
@@ -174,6 +174,11 @@ seaOfStatement stmt
 
      KeepFactInHistory _
       -> Pretty.empty
+  where
+   stNew n = "s->" <> stateInputNew (seaOfName n)
+   stRes n = "s->" <> stateInputRes (seaOfName n)
+   stHas n = "s->" <> stateInputHas (seaOfName n)
+
 
 seaOfForeachCompare :: ForeachType -> Doc
 seaOfForeachCompare ForeachStepUp   = "<"

--- a/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -57,7 +57,7 @@ seaOfProgram name attrib program = do
     , ""
     , indent 4 $ assign (defOfVar' 1 "imempool_t" "mempool") "s->mempool;"
     , indent 4 $ assign (defOfVar  0 TimeT (pretty (stateTimeVar state)))
-                        ("s->" <> pretty (stateTimeVar state)) <> ";"
+                        ("s->" <> stateInputTime state) <> ";"
     , ""
     , indent 4 (seaOfStatement (statements program))
     , "}"
@@ -130,7 +130,7 @@ seaOfStatement stmt
                          ((n,_):_) -> pretty newPrefix <> seaOfName n <> "[i]"
          in vsep $
             [ ""
-            , assign (defOfVar' 0 ("const" <+> seaOfValType IntT) "new_count") "s->new_count;"
+            , assign (defOfVar' 0 ("const" <+> seaOfValType IntT) "new_count") (stCount <> ";")
             ] <> fmap structAssign ns <>
             [ ""
             , "for (iint_t i = 0; i < new_count; i++) {"
@@ -175,9 +175,10 @@ seaOfStatement stmt
      KeepFactInHistory _
       -> Pretty.empty
   where
-   stNew n = "s->" <> stateInputNew (seaOfName n)
-   stRes n = "s->" <> stateInputRes (seaOfName n)
-   stHas n = "s->" <> stateInputHas (seaOfName n)
+   stNew   n = "s->" <> stateInputNew (seaOfName n)
+   stRes   n = "s->" <> stateInputRes (seaOfName n)
+   stHas   n = "s->" <> stateInputHas (seaOfName n)
+   stCount   = "s->" <> stateNewCount
 
 
 seaOfForeachCompare :: ForeachType -> Doc

--- a/src/Icicle/Sea/FromAvalanche/State.hs
+++ b/src/Icicle/Sea/FromAvalanche/State.hs
@@ -1,6 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE QuasiQuotes       #-}
+
 module Icicle.Sea.FromAvalanche.State (
     SeaProgramState(..)
   , nameOfProgram
@@ -11,6 +14,12 @@ module Icicle.Sea.FromAvalanche.State (
   , nameOfStateType
   , nameOfStateSize
   , nameOfStateSize'
+  , stateInputTypeName
+  , stateInputName
+  , stateInput
+  , stateInputNew
+  , stateInputRes
+  , stateInputHas
 
   -- * Prefixes for facts/resumables.
   , hasPrefix
@@ -18,10 +27,12 @@ module Icicle.Sea.FromAvalanche.State (
   , newPrefix
   ) where
 
-import qualified Data.List as List
-import qualified Data.Map as Map
+import qualified Data.List          as List
+import qualified Data.Map           as Map
 import           Data.Text (Text)
-import qualified Data.Text as T
+import qualified Data.Text          as T
+import qualified Language.C.Syntax  as C
+import           Language.C.Quote.C
 
 import           Icicle.Avalanche.Prim.Flat
 import           Icicle.Avalanche.Program
@@ -102,18 +113,18 @@ seaOfStateInfo state = "#" <> int (stateName state) <+> "-" <+> seaOfAttributeDe
 seaOfState :: SeaProgramState -> Doc
 seaOfState state
  = vsep
- [ "#line 1 \"state definition" <+> seaOfStateInfo state <> "\""
+ [ "#line 1 \"state and input definition" <+> seaOfStateInfo state <> "\""
+ , ""
+ , ppm (defFactStruct (stateInputTypeName state) (stateInputVars state))
+ , ""
  , "typedef struct {"
  , "    /* runtime */"
  , indent 4 (defOfVar' 1 "imempool_t" "mempool;")
  , ""
  , "    /* inputs */"
- , indent 4 (defOfVar 0 TimeT (pretty (stateTimeVar state) <> ";"))
- , indent 4 (defOfVar 0 IntT  "new_count;")
- , indent 4 . vsep
-            . fmap defOfFactVar
-            . stateInputVars
-            $ state
+ , indent 4 (defOfVar  0 TimeT (pretty (stateTimeVar state) <> ";"))
+ , indent 4 (defOfVar  0 IntT  "new_count;")
+ , indent 4 (defOfVar_ 0 (pretty (stateInputTypeName state)) "input;")
  , ""
  , "    /* outputs */"
  , indent 4 . vsep
@@ -137,14 +148,26 @@ seaOfState state
 
 ------------------------------------------------------------------------
 
+-- | Define a struct where the fields are the melted types.
+--
+defFactStruct :: Text -> [(Text, ValType)] -> C.Definition
+defFactStruct typename fields
+  = let fs = fmap defFactField fields
+        t  = T.unpack typename
+    in  [cedecl|typedef struct { $sdecls:fs } $id:t;|]
+
+defFactField :: (Text, ValType) -> C.FieldGroup
+defFactField (name, ty)
+  = let t = show     (seaOfValType ty)
+        n = T.unpack ("*" <> newPrefix <> name)
+    in  [csdecl|typename $id:t $id:n;|]
+
+------------------------------------------------------------------------
+
 defOfResumable :: (Text, ValType) -> Doc
 defOfResumable (n, t)
  =  defOfVar 0 BoolT (pretty hasPrefix <> pretty n) <> semi <> line
  <> defOfVar 0 t     (pretty resPrefix <> pretty n) <> semi
-
-defOfFactVar :: (Text, ValType) -> Doc
-defOfFactVar (n, t)
- = defOfVar 1 t (pretty newPrefix <> pretty n) <> semi
 
 defsOfOutput :: (OutputName, (ValType, [ValType])) -> [Doc]
 defsOfOutput (n, (_, ts))
@@ -168,3 +191,24 @@ resPrefix = "res_"
 -- | Prefix for new facts.
 newPrefix :: Text
 newPrefix = "new_"
+
+stateInputName :: Text
+stateInputName
+ = "input"
+
+stateInputTypeName :: SeaProgramState -> Text
+stateInputTypeName state
+ = "input_" <> getAttribute (stateAttribute state) <> "_t"
+
+stateInput :: Doc
+stateInput = pretty stateInputName
+
+stateInputNew :: Doc -> Doc
+stateInputNew n = pretty stateInputName <> "." <> pretty newPrefix <> n
+
+stateInputRes :: Doc -> Doc
+stateInputRes n = pretty resPrefix <> n
+
+stateInputHas :: Doc -> Doc
+stateInputHas n = pretty hasPrefix <> n
+

--- a/src/Icicle/Sea/FromAvalanche/Type.hs
+++ b/src/Icicle/Sea/FromAvalanche/Type.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE PatternGuards #-}
-
+{-# LANGUAGE PatternGuards     #-}
 module Icicle.Sea.FromAvalanche.Type (
     seaOfDefinitions
   , prefixOfArithType
@@ -9,13 +8,14 @@ module Icicle.Sea.FromAvalanche.Type (
   , baseOfValType
   , defOfVar
   , defOfVar'
+  , defOfVar_
   , seaOfValType
   , valTypeOfExp
   ) where
 
 import           Data.Set (Set)
-import qualified Data.Set as Set
-import qualified Data.List as List
+import qualified Data.Set           as Set
+import qualified Data.List          as List
 
 import           Icicle.Avalanche.Prim.Flat
 import           Icicle.Avalanche.Program
@@ -96,6 +96,10 @@ prefixOfValType t
 defOfVar :: Int -> ValType -> Doc -> Doc
 defOfVar nptrs typ var
  = defOfVar' nptrs (seaOfValType typ) var
+
+defOfVar_ :: Int -> Doc -> Doc -> Doc
+defOfVar_ nptrs typ var
+ = defOfVar' nptrs typ var
 
 defOfVar' :: Int -> Doc -> Doc -> Doc
 defOfVar' nptrs typ var

--- a/src/Icicle/Sea/IO.hs
+++ b/src/Icicle/Sea/IO.hs
@@ -22,19 +22,22 @@ import           Icicle.Internal.Pretty
 
 import           Icicle.Sea.Error (SeaError(..))
 import           Icicle.Sea.FromAvalanche.State
+
 import           Icicle.Sea.IO.Base
-import qualified Icicle.Sea.IO.Psv as Psv
+import qualified Icicle.Sea.IO.Psv   as Psv
+import qualified Icicle.Sea.IO.Zebra as Zebra
 
 import           P
 
 
 data IOFormat
   = FormatPsv Psv.PsvInputConfig Psv.PsvOutputConfig
-  | FormatEnterprise
+  | FormatZebra
 
 seaOfDriver :: IOFormat -> InputOpts -> [SeaProgramState] -> Either SeaError Doc
 seaOfDriver format opts states
   = case format of
       FormatPsv inputConfig outputConfig
         -> Psv.seaOfPsvDriver opts inputConfig outputConfig states
-      FormatEnterprise -> Right "" -- todo
+      FormatZebra
+        -> Zebra.seaOfZebraDriver -- todo

--- a/src/Icicle/Sea/IO/Psv.hs
+++ b/src/Icicle/Sea/IO/Psv.hs
@@ -120,7 +120,8 @@ seaOfAllocProgram state
 
        calloc n t = "calloc (" <> n <> ", sizeof (" <> t <> "));"
 
-       go (n, t) = program <> pretty (newPrefix <> n)
+       go (n, t) = program
+                <> stateInputNew (pretty n)
                 <> " = "
                 <> calloc "psv_max_row_count" (seaOfValType t)
 

--- a/src/Icicle/Sea/IO/Psv.hs
+++ b/src/Icicle/Sea/IO/Psv.hs
@@ -170,7 +170,7 @@ seaOfCollectProgram :: SeaProgramState -> Doc
 seaOfCollectProgram state
  = let pname = pretty (nameOfProgram state)
        stype = pretty (nameOfStateType state)
-       pvar  = "program->"
+       pvar  = "program->input."
 
        new n = pvar <> pretty (newPrefix <> n)
        res n = pvar <> pretty (resPrefix <> n)

--- a/src/Icicle/Sea/IO/Psv.hs
+++ b/src/Icicle/Sea/IO/Psv.hs
@@ -170,16 +170,17 @@ seaOfCollectProgram :: SeaProgramState -> Doc
 seaOfCollectProgram state
  = let pname = pretty (nameOfProgram state)
        stype = pretty (nameOfStateType state)
-       pvar  = "program->input."
+       pvar  = "program->"
+       pvari = pvar <> "input."
 
-       new n = pvar <> pretty (newPrefix <> n)
-       res n = pvar <> pretty (resPrefix <> n)
+       new n = pvari <> pretty (newPrefix <> n)
+       res n = pvar  <> pretty (resPrefix <> n)
 
        copyInputs nts
         = let docs = concatMap copyInput (stateInputVars state)
           in if List.null docs
              then []
-             else [ "iint_t new_count = " <> pvar <> "new_count;"
+             else [ "iint_t new_count = " <> pvari <> "new_count;"
                   , ""
                   , "for (iint_t ix = 0; ix < new_count; ix++) {"
                   , indent 4 $ vsep $ concatMap copyInput nts
@@ -291,8 +292,8 @@ defOfLastTime state
 
 seaOfAssignTime :: SeaProgramState -> Doc
 seaOfAssignTime state
- = let ptime = "p" <> pretty (stateName state) <> "[ix]." <> pretty (stateTimeVar state)
-   in ptime <+> "=" <+> "chord_time;"
+ = let ptime = "p" <> pretty (stateName state) <> "[ix].input." <> pretty (stateTimeVar state)
+   in  ptime <+> "=" <+> "chord_time;"
 
 seaOfChordTimes :: [Time] -> Doc
 seaOfChordTimes times

--- a/src/Icicle/Sea/IO/Psv/Input.hs
+++ b/src/Icicle/Sea/IO/Psv/Input.hs
@@ -136,10 +136,10 @@ seaOfReadFact state tombstones input readInput checkCount =
     , "        " <> pretty (nameOfStateType state) <+> "*program = &programs[chord_ix];"
     , ""
     , "        /* don't read values after the chord time */"
-    , "        if (time > program->" <> pretty (stateTimeVar state) <> ")"
+    , "        if (time > program->input." <> pretty (stateTimeVar state) <> ")"
     , "            continue;"
     , ""
-    , "        iint_t new_count = program->new_count;"
+    , "        iint_t new_count = program->input.new_count;"
     , ""
     , "        program->input." <> pretty (Base.inputSumError input) <> "[new_count] = " <> pretty (Base.inputSumError input) <> ";"
     , indent 8 . vsep . fmap seaOfAssignInput $ Base.inputVars input
@@ -149,7 +149,7 @@ seaOfReadFact state tombstones input readInput checkCount =
     , ""
     , indent 4 checkCount
     , ""
-    , "        program->new_count = new_count;"
+    , "        program->input.new_count = new_count;"
     , "    }"
     , ""
     , "    return 0; /* no error */"

--- a/src/Icicle/Sea/IO/Psv/Output.hs
+++ b/src/Icicle/Sea/IO/Psv/Output.hs
@@ -140,7 +140,7 @@ seaOfWriteProgramOutput config state = do
     , "/* " <> seaOfAttributeDesc (stateAttribute state) <> " */"
     , stype <+> "*" <> ps <+> "=" <+> "&fleet->" <> pname <> "[chord_ix];"
     , pname <+> "(" <> ps <> ");"
-    , ps <> "->new_count = 0;"
+    , ps <> "->input.new_count = 0;"
     , vsep resumeables
     , ""
     , vsep outputs

--- a/src/Icicle/Sea/IO/Zebra.hs
+++ b/src/Icicle/Sea/IO/Zebra.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Sea.IO.Zebra (
+    seaOfZebraDriver
+  ) where
+
+import           Icicle.Internal.Pretty
+
+import           Icicle.Sea.Error (SeaError(..))
+import           P
+
+
+-- TODO implement me
+seaOfZebraDriver :: Either SeaError Doc
+seaOfZebraDriver = Right ""

--- a/src/Icicle/Sea/IO/Zebra/Input.hs
+++ b/src/Icicle/Sea/IO/Zebra/Input.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Sea.IO.Zebra.Input
+  ( seaInputZebra
+  ) where
+
+import qualified Icicle.Sea.IO.Base.Input as Base
+
+--------------------------------------------------------------------------------
+
+-- * Psv input "interface"
+
+-- TODO implement me
+seaInputZebra :: Base.SeaInput
+seaInputZebra = Base.SeaInput
+  { Base.cstmtReadFact     = seaOfReadFact
+  , Base.cstmtReadTime     = seaOfReadTime
+  , Base.cfunReadTombstone = seaOfReadTombstone
+  , Base.cnameFunReadFact  = nameOfReadFact
+  }
+  where
+    seaOfReadFact _ _ _ _ _ = ""
+    seaOfReadTime = ""
+    seaOfReadTombstone _ _ = ""
+    nameOfReadFact _ = ""

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -637,6 +637,8 @@ output@{(Sum Error Double)} repl (flat$90$simp$280@{Error}, flat$90$simp$281@{Do
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
+    itime_t          conv_3;
+    iint_t           new_count;
     ierror_t         *new_conv_0_simp_282;
     istring_t        *new_conv_0_simp_283;
     iint_t           *new_conv_0_simp_284;
@@ -648,8 +650,6 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_3;
-    iint_t           new_count;
     input_repl_t     input;
 
     /* outputs */
@@ -895,7 +895,7 @@ void iprogram_0(iprogram_0_t *s)
     idouble_t        flat_58_simp_220;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_3                   = s->conv_3;
+    itime_t          conv_3                   = s->input.conv_3;
 
     acc_conv_7_simp_33                        = ierror_not_an_error;                  /* init */
     acc_conv_7_simp_34                        = 0.0;                                  /* init */
@@ -983,7 +983,7 @@ void iprogram_0(iprogram_0_t *s)
         acc_conv_7_simp_34                    = s->res_acc_conv_7_simp_34;            /* load */
     }
     
-    const iint_t     new_count                = s->new_count;
+    const iint_t     new_count                = s->input.new_count;
     const ierror_t  *const new_conv_0_simp_282 = s->input.new_conv_0_simp_282;
     const istring_t *const new_conv_0_simp_283 = s->input.new_conv_0_simp_283;
     const iint_t    *const new_conv_0_simp_284 = s->input.new_conv_0_simp_284;
@@ -1648,6 +1648,8 @@ output@{(Sum Error Time)} repl (s$reify$2$conv$5$simp$22@{Error}, s$reify$2$conv
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
+    itime_t          conv_3;
+    iint_t           new_count;
     ierror_t         *new_conv_0_simp_24;
     iint_t           *new_conv_0_simp_25;
     itime_t          *new_conv_0_simp_26;
@@ -1658,8 +1660,6 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_3;
-    iint_t           new_count;
     input_repl_t     input;
 
     /* outputs */
@@ -1702,7 +1702,7 @@ void iprogram_0(iprogram_0_t *s)
     itime_t          acc_conv_4_simp_2;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_3                   = s->conv_3;
+    itime_t          conv_3                   = s->input.conv_3;
 
     acc_conv_4_simp_2                         = 0x7420b1100000000;                    /* init */
     acc_s_reify_2_conv_5_simp_6               = ierror_fold1_no_value;                /* init */
@@ -1720,7 +1720,7 @@ void iprogram_0(iprogram_0_t *s)
         acc_conv_4_simp_2                     = s->res_acc_conv_4_simp_2;             /* load */
     }
     
-    const iint_t     new_count                = s->new_count;
+    const iint_t     new_count                = s->input.new_count;
     const ierror_t  *const new_conv_0_simp_24 = s->input.new_conv_0_simp_24;
     const iint_t    *const new_conv_0_simp_25 = s->input.new_conv_0_simp_25;
     const itime_t   *const new_conv_0_simp_26 = s->input.new_conv_0_simp_26;

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -634,7 +634,16 @@ read flat$90$simp$281 = flat$90$simp$267 [Double];
 output@{(Sum Error Double)} repl (flat$90$simp$280@{Error}, flat$90$simp$281@{Double});
 
 - C:
-#line 1 "state definition #0 - repl"
+#line 1 "state and input definition #0 - repl"
+
+typedef struct {
+            ierror_t *new_conv_0_simp_282;
+            istring_t *new_conv_0_simp_283;
+            iint_t *new_conv_0_simp_284;
+            itime_t *new_conv_0_simp_285;
+        }
+input_repl_t;
+
 typedef struct {
     /* runtime */
     imempool_t      *mempool;
@@ -642,10 +651,7 @@ typedef struct {
     /* inputs */
     itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_282;
-    istring_t       *new_conv_0_simp_283;
-    iint_t          *new_conv_0_simp_284;
-    itime_t         *new_conv_0_simp_285;
+    input_repl_t     input;
 
     /* outputs */
     ierror_t         repl_ix_0;
@@ -979,10 +985,10 @@ void iprogram_0(iprogram_0_t *s)
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_282 = s->new_conv_0_simp_282;
-    const istring_t *const new_conv_0_simp_283 = s->new_conv_0_simp_283;
-    const iint_t    *const new_conv_0_simp_284 = s->new_conv_0_simp_284;
-    const itime_t   *const new_conv_0_simp_285 = s->new_conv_0_simp_285;
+    const ierror_t  *const new_conv_0_simp_282 = s->input.new_conv_0_simp_282;
+    const istring_t *const new_conv_0_simp_283 = s->input.new_conv_0_simp_283;
+    const iint_t    *const new_conv_0_simp_284 = s->input.new_conv_0_simp_284;
+    const itime_t   *const new_conv_0_simp_285 = s->input.new_conv_0_simp_285;
     
     for (iint_t i = 0; i < new_count; i++) {
         ifactid_t        conv_1               = i;
@@ -1640,7 +1646,15 @@ read s$reify$2$conv$5$simp$23 = acc$s$reify$2$conv$5$simp$7 [Time];
 output@{(Sum Error Time)} repl (s$reify$2$conv$5$simp$22@{Error}, s$reify$2$conv$5$simp$23@{Time});
 
 - C:
-#line 1 "state definition #0 - repl"
+#line 1 "state and input definition #0 - repl"
+
+typedef struct {
+            ierror_t *new_conv_0_simp_24;
+            iint_t *new_conv_0_simp_25;
+            itime_t *new_conv_0_simp_26;
+        }
+input_repl_t;
+
 typedef struct {
     /* runtime */
     imempool_t      *mempool;
@@ -1648,9 +1662,7 @@ typedef struct {
     /* inputs */
     itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_24;
-    iint_t          *new_conv_0_simp_25;
-    itime_t         *new_conv_0_simp_26;
+    input_repl_t     input;
 
     /* outputs */
     ierror_t         repl_ix_0;
@@ -1711,9 +1723,9 @@ void iprogram_0(iprogram_0_t *s)
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_24 = s->new_conv_0_simp_24;
-    const iint_t    *const new_conv_0_simp_25 = s->new_conv_0_simp_25;
-    const itime_t   *const new_conv_0_simp_26 = s->new_conv_0_simp_26;
+    const ierror_t  *const new_conv_0_simp_24 = s->input.new_conv_0_simp_24;
+    const iint_t    *const new_conv_0_simp_25 = s->input.new_conv_0_simp_25;
+    const itime_t   *const new_conv_0_simp_26 = s->input.new_conv_0_simp_26;
     
     for (iint_t i = 0; i < new_count; i++) {
         ifactid_t        conv_1               = i;

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -637,12 +637,11 @@ output@{(Sum Error Double)} repl (flat$90$simp$280@{Error}, flat$90$simp$281@{Do
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
-            ierror_t *new_conv_0_simp_282;
-            istring_t *new_conv_0_simp_283;
-            iint_t *new_conv_0_simp_284;
-            itime_t *new_conv_0_simp_285;
-        }
-input_repl_t;
+    ierror_t         *new_conv_0_simp_282;
+    istring_t        *new_conv_0_simp_283;
+    iint_t           *new_conv_0_simp_284;
+    itime_t          *new_conv_0_simp_285;
+} input_repl_t;
 
 typedef struct {
     /* runtime */
@@ -1649,11 +1648,10 @@ output@{(Sum Error Time)} repl (s$reify$2$conv$5$simp$22@{Error}, s$reify$2$conv
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
-            ierror_t *new_conv_0_simp_24;
-            iint_t *new_conv_0_simp_25;
-            itime_t *new_conv_0_simp_26;
-        }
-input_repl_t;
+    ierror_t         *new_conv_0_simp_24;
+    iint_t           *new_conv_0_simp_25;
+    itime_t          *new_conv_0_simp_26;
+} input_repl_t;
 
 typedef struct {
     /* runtime */

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -21,7 +21,15 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                     \_____________)
 > ok, c is now on
 > > - C:
-#line 1 "state definition #0 - repl"
+#line 1 "state and input definition #0 - repl"
+
+typedef struct {
+            ierror_t *new_conv_0_simp_19;
+            iint_t *new_conv_0_simp_20;
+            itime_t *new_conv_0_simp_21;
+        }
+input_repl_t;
+
 typedef struct {
     /* runtime */
     imempool_t      *mempool;
@@ -29,9 +37,7 @@ typedef struct {
     /* inputs */
     itime_t          conv_3;
     iint_t           new_count;
-    ierror_t        *new_conv_0_simp_19;
-    iint_t          *new_conv_0_simp_20;
-    itime_t         *new_conv_0_simp_21;
+    input_repl_t     input;
 
     /* outputs */
     ibool_t          repl_ix_0;
@@ -91,9 +97,9 @@ void iprogram_0(iprogram_0_t *s)
     }
     
     const iint_t     new_count                = s->new_count;
-    const ierror_t  *const new_conv_0_simp_19 = s->new_conv_0_simp_19;
-    const iint_t    *const new_conv_0_simp_20 = s->new_conv_0_simp_20;
-    const itime_t   *const new_conv_0_simp_21 = s->new_conv_0_simp_21;
+    const ierror_t  *const new_conv_0_simp_19 = s->input.new_conv_0_simp_19;
+    const iint_t    *const new_conv_0_simp_20 = s->input.new_conv_0_simp_20;
+    const itime_t   *const new_conv_0_simp_21 = s->input.new_conv_0_simp_21;
     
     for (iint_t i = 0; i < new_count; i++) {
         ifactid_t        conv_1               = i;

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -24,11 +24,10 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
-            ierror_t *new_conv_0_simp_19;
-            iint_t *new_conv_0_simp_20;
-            itime_t *new_conv_0_simp_21;
-        }
-input_repl_t;
+    ierror_t         *new_conv_0_simp_19;
+    iint_t           *new_conv_0_simp_20;
+    itime_t          *new_conv_0_simp_21;
+} input_repl_t;
 
 typedef struct {
     /* runtime */

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -24,6 +24,8 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 #line 1 "state and input definition #0 - repl"
 
 typedef struct {
+    itime_t          conv_3;
+    iint_t           new_count;
     ierror_t         *new_conv_0_simp_19;
     iint_t           *new_conv_0_simp_20;
     itime_t          *new_conv_0_simp_21;
@@ -34,8 +36,6 @@ typedef struct {
     imempool_t      *mempool;
 
     /* inputs */
-    itime_t          conv_3;
-    iint_t           new_count;
     input_repl_t     input;
 
     /* outputs */
@@ -77,7 +77,7 @@ void iprogram_0(iprogram_0_t *s)
     iint_t           perhaps_conv_4_simp_17;
 
     imempool_t      *mempool                  = s->mempool;
-    itime_t          conv_3                   = s->conv_3;
+    itime_t          conv_3                   = s->input.conv_3;
 
     acc_perhaps_conv_4_simp_4                 = ifalse;                               /* init */
     acc_perhaps_conv_4_simp_5                 = 0;                                    /* init */
@@ -95,7 +95,7 @@ void iprogram_0(iprogram_0_t *s)
         acc_perhaps_conv_4_simp_6             = s->res_acc_perhaps_conv_4_simp_6;     /* load */
     }
     
-    const iint_t     new_count                = s->new_count;
+    const iint_t     new_count                = s->input.new_count;
     const ierror_t  *const new_conv_0_simp_19 = s->input.new_conv_0_simp_19;
     const iint_t    *const new_conv_0_simp_20 = s->input.new_conv_0_simp_20;
     const itime_t   *const new_conv_0_simp_21 = s->input.new_conv_0_simp_21;


### PR DESCRIPTION
Generate a C struct for the input that that confluence can fill in. I imagine when implementing this function `cstmtReadFact :: SeaProgramState -> Tombstones -> CheckedInput -> CStmt -> CStmt -> CFun` for Zebra, it will fill in the `state->input` struct.