### PR TITLE
Add option to inline by name or by value

### DIFF
--- a/data/libs/prelude.icicle
+++ b/data/libs/prelude.icicle
@@ -36,7 +36,7 @@ snd x = case x | (a,b) -> b end.
 
 group_keys k = keys (group k ~> 0).
 
-# This only works if inlining is set to by-value (:set inline by-value in the REPL)
+# This only works if inlining is set to with-subst (:set inline with-subst in the REPL)
 group_vals k v = vals (group k ~> v).
 
 return v = newest v.

--- a/data/libs/prelude.icicle
+++ b/data/libs/prelude.icicle
@@ -36,6 +36,9 @@ snd x = case x | (a,b) -> b end.
 
 group_keys k = keys (group k ~> 0).
 
+# This only works if inlining is set to by-value (:set inline by-value in the REPL)
+group_vals k v = vals (group k ~> v).
+
 return v = newest v.
 
 ##################

--- a/main/icicle-repl.hs
+++ b/main/icicle-repl.hs
@@ -155,7 +155,7 @@ data Command
 
 defaultState :: ReplState
 defaultState
-  = (ReplState [] demographics (unsafeTimeOfYMD 1970 1 1) P.InlineByName False False False False False False False False False False False False False False False False False False False False)
+  = (ReplState [] demographics (unsafeTimeOfYMD 1970 1 1) P.InlineUsingLets False False False False False False False False False False False False False False False False False False False False)
     { hasCoreEval = True
     , doCoreSimp  = True }
 
@@ -247,10 +247,10 @@ readSetCommands ss
        , Just x' <- timeOfYMD y' m' d'
        -> (:) (CurrentTime x') <$> readSetCommands rest
 
-    ("inline" : "by-name" : rest)
-       -> (:) (InlineOpt P.InlineByName) <$> readSetCommands rest
-    ("inline" : "by-value" : rest)
-       -> (:) (InlineOpt P.InlineByValue) <$> readSetCommands rest
+    ("inline" : "with-lets" : rest)
+       -> (:) (InlineOpt P.InlineUsingLets) <$> readSetCommands rest
+    ("inline" : "with-subst" : rest)
+       -> (:) (InlineOpt P.InlineUsingSubst) <$> readSetCommands rest
 
     [] -> Just []
     _  -> Nothing
@@ -549,9 +549,9 @@ handleSetCommand state set
 
     InlineOpt inl -> do
         let inline = case inl of
-                       P.InlineByName  -> "name"
-                       P.InlineByValue -> "value"
-        HL.outputStrLn $ "ok, inline is now by " <> inline
+                       P.InlineUsingLets  -> "lets"
+                       P.InlineUsingSubst -> "subst"
+        HL.outputStrLn $ "ok, inline is now using " <> inline
         return $ state { inlineOpt = inl }
 
     PerformCoreSimp b -> do

--- a/main/icicle-repl.hs
+++ b/main/icicle-repl.hs
@@ -92,6 +92,7 @@ data ReplState
    { facts              :: [AsAt Fact]
    , dictionary         :: Dictionary
    , currentTime        :: Time
+   , inlineOpt          :: P.InlineOption
    , hasType            :: Bool
    , hasBigData         :: Bool
    , hasAnnotated       :: Bool
@@ -136,6 +137,7 @@ data Set
    | CurrentTime             Time
    | PerformCoreSimp         Bool
    | PerformFlattenSimpCheck Bool
+   | InlineOpt               P.InlineOption
 
 -- | REPL commands
 data Command
@@ -153,7 +155,7 @@ data Command
 
 defaultState :: ReplState
 defaultState
-  = (ReplState [] demographics (unsafeTimeOfYMD 1970 1 1) False False False False False False False False False False False False False False False False False False False False)
+  = (ReplState [] demographics (unsafeTimeOfYMD 1970 1 1) P.InlineByName False False False False False False False False False False False False False False False False False False False False)
     { hasCoreEval = True
     , doCoreSimp  = True }
 
@@ -245,6 +247,11 @@ readSetCommands ss
        , Just x' <- timeOfYMD y' m' d'
        -> (:) (CurrentTime x') <$> readSetCommands rest
 
+    ("inline" : "by-name" : rest)
+       -> (:) (InlineOpt P.InlineByName) <$> readSetCommands rest
+    ("inline" : "by-value" : rest)
+       -> (:) (InlineOpt P.InlineByValue) <$> readSetCommands rest
+
     [] -> Just []
     _  -> Nothing
 
@@ -319,7 +326,7 @@ handleLine state line = case readCommand line of
 
       prettyOut hasAnnotated "- Annotated:" (SPretty.PrettyAnnot annot)
 
-      let inlined= SR.sourceInline (dictionary state) annot
+      let inlined = SR.sourceInline (inlineOpt state) (dictionary state) annot
 
       blanded     <- hoist $ SR.sourceDesugar inlined
 
@@ -327,7 +334,7 @@ handleLine state line = case readCommand line of
       prettyOut hasDesugar "- Desugar:" blanded
 
       (annobland, _) <- hoist $ SR.sourceCheck checkOpts (dictionary state) blanded
-      prettyOut hasInlined "- Annotated desugar:" (SPretty.PrettyAnnot annobland)
+      prettyOut hasDesugar "- Annotated desugar:" (SPretty.PrettyAnnot annobland)
 
 
       let reified       = SR.sourceReify annobland
@@ -539,6 +546,13 @@ handleSetCommand state set
     CurrentTime d -> do
         HL.outputStrLn $ "ok, time set to " <> T.unpack (renderTime d)
         return $ state { currentTime = d }
+
+    InlineOpt inl -> do
+        let inline = case inl of
+                       P.InlineByName  -> "name"
+                       P.InlineByValue -> "value"
+        HL.outputStrLn $ "ok, inline is now by " <> inline
+        return $ state { inlineOpt = inl }
 
     PerformCoreSimp b -> do
         HL.outputStrLn $ "ok, core-simp is now " <> showFlag b

--- a/src/Icicle/Benchmark.hs
+++ b/src/Icicle/Benchmark.hs
@@ -14,8 +14,20 @@ module Icicle.Benchmark (
   , withChords
   ) where
 
+import           Icicle.Data
+import           Icicle.Dictionary
+
+import qualified Icicle.Pipeline as P
+
+import           Icicle.Sea.Chords.File (writeChordFile)
+import           Icicle.Sea.Chords.Parse (ChordParseError(..), parseChordFile)
+import           Icicle.Sea.Eval
+
+import qualified Icicle.Source.Checker as SC
+
+import           Icicle.Storage.Dictionary.Toml
+
 import           Control.Monad.IO.Class (liftIO)
-import           Control.Parallel.Strategies (withStrategy, parTraversable, rparWith, rseq)
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -23,31 +35,12 @@ import           Data.Set (Set)
 import qualified Data.Text.Lazy.IO as TL
 import           Data.Time (NominalDiffTime, getCurrentTime, diffUTCTime)
 
-import qualified Icicle.Avalanche.Prim.Flat as A
-import qualified Icicle.Avalanche.Program as A
-import           Icicle.Common.Annot (Annot)
-import           Icicle.Core.Program.Fusion (FusionError)
-import qualified Icicle.Core.Program.Fusion as C
-import qualified Icicle.Core.Program.Program as C
-import           Icicle.Data
-import           Icicle.Dictionary
-import           Icicle.Pipeline
-import           Icicle.Sea.Chords.File (writeChordFile)
-import           Icicle.Sea.Chords.Parse (ChordParseError(..), parseChordFile)
-import           Icicle.Sea.Eval
-import qualified Icicle.Source.Parser as S
-import qualified Icicle.Source.Query as S
-import qualified Icicle.Source.Checker as SC
-import           Icicle.Storage.Dictionary.Toml
-
-import           P
-
 import           System.FilePath (FilePath)
 import           System.IO (IO, IOMode(..), withFile, hFileSize)
 import           System.IO.Temp (createTempDirectory)
 import           System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
 
-import           Text.ParserCombinators.Parsec (SourcePos)
+import           P
 
 import           X.Control.Monad.Trans.Either
 
@@ -55,11 +48,9 @@ import           X.Control.Monad.Trans.Either
 
 data BenchError =
     BenchDictionaryImportError DictionaryImportError
-  | BenchSourceError     (CompileError SourcePos S.Variable ())
-  | BenchFusionError     (FusionError S.Variable)
-  | BenchAvalancheError  (CompileError () S.Variable A.Prim)
-  | BenchSeaError        SeaError
-  | BenchChordParseError ChordParseError
+  | BenchCompileError          (P.CompileError P.SourceVar)
+  | BenchSeaError              SeaError
+  | BenchChordParseError       ChordParseError
   deriving (Show)
 
 ------------------------------------------------------------------------
@@ -106,7 +97,7 @@ createBenchmark mode dictionaryPath inputPath outputPath dropPath packedChordPat
   (dictionary, input') <- firstEitherT BenchDictionaryImportError $ inputCfg input
   let output'           = outputCfg output
 
-  avalanche  <- hoistEither (avalancheOfDictionary dictionary)
+  avalanche  <- hoistEither (first BenchCompileError $ P.avalancheOfDictionary dictionary)
 
   let cfg = HasInput
           ( FormatPsv (PsvInputConfig  mode input')
@@ -182,55 +173,6 @@ tombstonesOfDictionary dict =
   let go (DictionaryEntry a (ConcreteDefinition _ ts) _) = [(a, ts)]
       go _                                               = []
   in Map.fromList (concatMap go (dictionaryEntries dict))
-
-------------------------------------------------------------------------
-
-avalancheOfDictionary :: Dictionary -> Either BenchError (Map Attribute (A.Program (Annot ()) S.Variable A.Prim))
-avalancheOfDictionary dict = do
-  let virtuals = fmap (second unVirtual) (getVirtualFeatures dict)
-
-  core      <- parTraverse (coreOfSource dict) virtuals
-  fused     <- parTraverse fuseCore (Map.unionsWith (<>) core)
-  avalanche <- parTraverse avalancheOfCore fused
-
-  return avalanche
-
-avalancheOfCore :: C.Program () S.Variable -> Either BenchError (A.Program (Annot ()) S.Variable A.Prim)
-avalancheOfCore core = do
-  flat    <- first BenchAvalancheError (coreFlatten core)
-  checked <- first BenchAvalancheError (checkAvalanche flat)
-  return checked
-
-fuseCore :: [(S.Variable, C.Program () S.Variable)] -> Either BenchError (C.Program () S.Variable)
-fuseCore programs =
-  first BenchFusionError $ do
-    fused <- C.fuseMultiple () programs
-    pure (coreSimp fused)
-
-coreOfSource
-  :: Dictionary
-  -> (Attribute, QueryTop'T SourceVar)
-  -> Either BenchError (Map Attribute [(S.Variable, C.Program () S.Variable)])
-coreOfSource dict (Attribute attr, virtual) =
-  first BenchSourceError $ do
-    let inlined = sourceInline dict virtual
-
-    desugared    <- sourceDesugarQT inlined
-    (checked, _) <- sourceCheckQT SC.optionSmallData dict desugared
-
-    let reified = sourceReifyQT checked
-
-    core <- sourceConvert dict reified
-    let simplified = coreSimp core
-
-    let baseattr  = (Attribute . unVar . unName) (S.feature virtual)
-
-    pure (Map.singleton baseattr [(S.Variable attr, simplified)])
-
-parTraverse  :: Traversable t => (a -> Either e b) -> t a -> Either e (t b)
-parTraverse f = sequenceA . parallel . fmap f
- where
-  parallel = withStrategy (parTraversable (rparWith rseq))
 
 ------------------------------------------------------------------------
 

--- a/src/Icicle/Benchmark.hs
+++ b/src/Icicle/Benchmark.hs
@@ -97,7 +97,7 @@ createBenchmark mode dictionaryPath inputPath outputPath dropPath packedChordPat
   (dictionary, input') <- firstEitherT BenchDictionaryImportError $ inputCfg input
   let output'           = outputCfg output
 
-  avalanche  <- hoistEither (first BenchCompileError $ P.avalancheOfDictionary dictionary)
+  avalanche  <- hoistEither (first BenchCompileError $ P.avalancheOfDictionary P.defaultInline dictionary)
 
   let cfg = HasInput
           ( FormatPsv (PsvInputConfig  mode input')

--- a/src/Icicle/Core/Program/Fusion.hs
+++ b/src/Icicle/Core/Program/Fusion.hs
@@ -1,6 +1,7 @@
 -- | Fusing programs together
 {-# LANGUAGE NoImplicitPrelude #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE PatternGuards     #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Icicle.Core.Program.Fusion (
     FusionError (..)
   , fusePrograms
@@ -11,6 +12,7 @@ import Icicle.Common.Base
 import Icicle.Common.Type
 import Icicle.Core.Program.Program
 import Icicle.Core.Program.Subst
+import Icicle.Internal.Pretty
 
 import P
 
@@ -22,6 +24,13 @@ data FusionError n
  | FusionErrorNothingToFuse
  deriving (Show)
 
+instance Pretty n => Pretty (FusionError n) where
+  pretty (FusionErrorNotSameType a b)
+    = vsep [ "Fusion error: types do not match: "
+           , "  a = " <> pretty a
+           , "  b = " <> pretty b ]
+  pretty FusionErrorNothingToFuse
+    = "Fusion error: nothing to fuse, hooray!"
 
 -- | Fuse programs together, prefixing each with its name to ensure that the
 -- generated program has no name clashes.
@@ -31,7 +40,7 @@ fusePrograms a_fresh ln lp rn rp
  = fuseProgramsDistinctNames a_fresh (prefix ln lp) (prefix rn rp)
  where
   prefix n = renameProgram (modName n)
-  
+
 
 -- | Fuse programs together, assuming they already have no name clashes.
 fuseProgramsDistinctNames :: (Hashable n, Eq n) => a -> Program a n -> Program a n -> Either (FusionError n) (Program a n)

--- a/src/Icicle/Debug.hs
+++ b/src/Icicle/Debug.hs
@@ -8,38 +8,39 @@ module Icicle.Debug (
   , avalancheOrDie'
   ) where
 
-import           Data.Map (Map)
-import qualified Data.Map as Map
+import           Data.Map                      (Map)
+import qualified Data.Map                       as Map
 
-import qualified Icicle.Avalanche.Prim.Flat as A
-import qualified Icicle.Avalanche.Program as A
+import qualified Icicle.Avalanche.Prim.Flat     as A
+import qualified Icicle.Avalanche.Program       as A
 
-import           Icicle.Common.Annot (Annot)
+import           Icicle.Common.Annot           (Annot)
 import           Icicle.Common.Base
 
-import           Icicle.Core.Program.Fusion (FusionError)
-import qualified Icicle.Core.Program.Fusion as C
-import qualified Icicle.Core.Program.Program as C
+import           Icicle.Core.Program.Fusion    (FusionError)
+import qualified Icicle.Core.Program.Fusion     as C
+import qualified Icicle.Core.Program.Program    as C
 
 import           Icicle.Data
 
 import           Icicle.Dictionary
 
-import           Icicle.Internal.Pretty (pretty)
+import           Icicle.Internal.Pretty        (pretty)
 
-import qualified Icicle.Pipeline as P
+import qualified Icicle.Pipeline                as P
 
-import qualified Icicle.Source.Parser as S
-import qualified Icicle.Source.Query as S
-import qualified Icicle.Source.Type as S
-import qualified Icicle.Source.Checker as SC
+import qualified Icicle.Source.Parser           as S
+import qualified Icicle.Source.Query            as S
+import qualified Icicle.Source.Type             as S
+import qualified Icicle.Source.Checker          as SC
+import qualified Icicle.Source.Transform.Inline as STI
 
 import           Icicle.Storage.Dictionary.Toml
 
 import           P
 
-import           System.IO (IO, FilePath)
-import           System.IO.Unsafe (unsafePerformIO)
+import           System.IO                     (IO, FilePath)
+import           System.IO.Unsafe              (unsafePerformIO)
 
 import           Text.ParserCombinators.Parsec (SourcePos)
 
@@ -53,26 +54,34 @@ data DebugError =
 
 ------------------------------------------------------------------------
 
-avalancheOrDie :: SC.CheckOptions -> FilePath -> Text -> A.Program (Annot ()) S.Variable A.Prim
-avalancheOrDie checkOpts dictionaryPath source =
-  case Map.minView (avalancheOrDie' checkOpts dictionaryPath [("debug", source)]) of
+avalancheOrDie :: SC.CheckOptions
+               -> STI.InlineOption
+               -> FilePath
+               -> Text
+               -> P.AvalProgram P.SourceVar
+avalancheOrDie checkOpts inlineOpt dictionaryPath source =
+  case Map.minView (avalancheOrDie' checkOpts inlineOpt dictionaryPath [("debug", source)]) of
     Just (x, _) -> x
     Nothing     -> error "avalancheOrDie: program not found"
 
-avalancheOrDie' :: SC.CheckOptions -> FilePath -> [(Text, Text)] -> Map Attribute (A.Program (Annot ()) S.Variable A.Prim)
-avalancheOrDie' checkOpts dictionaryPath sources = unsafePerformIO $ do
-  result <- runEitherT (avalancheFrom checkOpts dictionaryPath sources)
+avalancheOrDie' :: SC.CheckOptions
+                -> STI.InlineOption
+                -> FilePath
+                -> [(Text, Text)]
+                -> P.AvalPrograms P.SourceVar
+avalancheOrDie' checkOpts inlineOpt dictionaryPath sources = unsafePerformIO $ do
+  result <- runEitherT (avalancheFrom checkOpts inlineOpt dictionaryPath sources)
   case result of
     Left (DebugDictionaryImportError x) -> error ("avalancheOrDie: " <> show (pretty x))
     Left (DebugCompileError          x) -> error ("avalancheOrDie: " <> show (pretty x))
     Right xs                            -> pure xs
 
-avalancheFrom
-  :: SC.CheckOptions
-  -> FilePath
-  -> [(Text, Text)]
-  -> EitherT DebugError IO (Map Attribute (A.Program (Annot ()) S.Variable A.Prim))
-avalancheFrom checkOpts dictionaryPath sources = do
+avalancheFrom :: SC.CheckOptions
+              -> STI.InlineOption
+              -> FilePath
+              -> [(Text, Text)]
+              -> EitherT DebugError IO (P.AvalPrograms P.SourceVar)
+avalancheFrom checkOpts inlineOpt dictionaryPath sources = do
   dictionary <- firstEitherT DebugDictionaryImportError (loadDictionary checkOpts ImplicitPrelude dictionaryPath)
   queries    <- hoistEither (traverse (uncurry (queryOfSource checkOpts dictionary)) sources)
 
@@ -84,7 +93,7 @@ avalancheFrom checkOpts dictionaryPath sources = do
   where
     avalancheOfDictionary dict
       = first DebugCompileError
-      $ P.avalancheOfDictionaryOpt checkOpts dict
+      $ P.avalancheOfDictionaryOpt checkOpts inlineOpt dict
 
     queryOfSource checkOpts dict name src
       = first DebugCompileError

--- a/src/Icicle/Pipeline.hs
+++ b/src/Icicle/Pipeline.hs
@@ -6,10 +6,28 @@
 {-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Pipeline
   ( CompileError(..)
+
   , SourceVar
+  , AnnotType
+  , AnnotUnit
+
   , QueryTop'
   , QueryTop'T
-  , CoreProgram'
+
+  , Funs
+  , FunEnvT
+
+  , AvalProgram
+
+  , CoreProgramNoAnnot
+  , AvalProgramNoAnnot
+
+  , CoreProgramNamed
+  , CorePrograms
+  , AvalPrograms
+
+  , Queries
+
   , freshNamer
   , annotOfError
 
@@ -33,12 +51,22 @@ module Icicle.Pipeline
   , simpAvalanche
   , simpFlattened
 
+  , avalancheOfDictionary
+  , avalancheOfDictionaryOpt
+  , avalancheOfCore
+  , fuseCore
+  , coreOfSource
+  , queryOfSource
+  , queryOfSourceOpt
+  , entryOfQuery
+
   , coreEval
   , avalancheEval
   , seaEval
 
   , unName
   , unVar
+  , parTraverse
   ) where
 
 import qualified Icicle.Avalanche.Annot                   as AA
@@ -49,18 +77,20 @@ import qualified Icicle.Avalanche.Program                 as AP
 import qualified Icicle.Avalanche.Simp                    as AS
 import qualified Icicle.Avalanche.Statement.Flatten       as AS
 
-import qualified Icicle.Common.Annot                      as CA
+import qualified Icicle.Common.Annot                      as Common
 import           Icicle.Common.Base                       (Name)
-import qualified Icicle.Common.Base                       as CommonBase
+import qualified Icicle.Common.Base                       as Common
 import qualified Icicle.Common.Fresh                      as Fresh
-import qualified Icicle.Common.Type                       as CT
+import qualified Icicle.Common.Type                       as Common
 
 import qualified Icicle.Core.Exp.Prim                     as Core
 import qualified Icicle.Core.Program.Condense             as Core
+import qualified Icicle.Core.Program.Fusion               as Core
 import qualified Icicle.Core.Program.Program              as Core
 import qualified Icicle.Core.Program.Simp                 as Core
 
-import qualified Icicle.Dictionary                        as D
+import           Icicle.Dictionary                        (Dictionary)
+import qualified Icicle.Dictionary                        as Dict
 
 import           Icicle.Internal.Pretty
 import           Icicle.Internal.Rename
@@ -77,17 +107,20 @@ import qualified Icicle.Source.Type                       as ST
 
 import           Icicle.Data
 
+import           Icicle.Sea.Eval                          (SeaError)
 import qualified Icicle.Sea.Eval                          as Sea
 
 import qualified Icicle.Simulator                         as S
 
 
 import           Data.Functor.Identity
+import           Data.Map                                 (Map)
 import qualified Data.Map                                 as M
 import           Data.Monoid
 import           Data.String
 import           Data.Hashable                            (Hashable)
 
+import           Control.Parallel.Strategies              (withStrategy, parTraversable, rparWith, rseq)
 
 import           Text.ParserCombinators.Parsec            (SourcePos)
 import qualified Text.ParserCombinators.Parsec            as Parsec
@@ -105,29 +138,42 @@ unVar :: SP.Variable -> Text
 unVar (SP.Variable x) = x
 
 unName :: Name a -> a
-unName = go . CommonBase.nameBase
+unName = go . Common.nameBase
   where
-   go (CommonBase.NameBase  x) = x
-   go (CommonBase.NameMod _ x) = go x
+   go (Common.NameBase  x) = x
+   go (Common.NameMod _ x) = go x
+
+freshNamer :: IsString v => v -> Fresh.NameState v
+freshNamer prefix
+ = Fresh.counterPrefixNameState (fromString . show) prefix
+
+parTraverse  :: Traversable t => (a -> Either e b) -> t a -> Either e (t b)
+parTraverse f = sequenceA . parallel . fmap f
+ where
+  parallel = withStrategy (parTraversable (rparWith rseq))
 
 --------------------------------------------------------------------------------
 
-data CompileError a b c
+data CompileError var
  = CompileErrorParse       !Parsec.ParseError
- | CompileErrorDesugar     !(STD.DesugarError a b)
- | CompileErrorCheck       !(SC.CheckError a b)
- | CompileErrorConvert     !(STC.ConvertError a b)
- | CompileErrorFlatten     !(AS.FlattenError a b)
- | CompileErrorFlattenSimp !(AS.SimpError a b c)
- | CompileErrorProgram     !(AC.ProgramError a b c)
+ -- Source
+ | CompileErrorDesugar     !(STD.DesugarError SourcePos var)
+ | CompileErrorCheck       !(SC.CheckError    SourcePos var)
+ -- Core
+ | CompileErrorConvert     !(STC.ConvertError SourcePos var)
+ | CompileErrorFusion      !(Core.FusionError SourceVar)
+ -- Avalanche/Flatten
+ | CompileErrorFlatten     !(AS.FlattenError  () var)
+ | CompileErrorFlattenSimp !(AS.SimpError     () var APF.Prim)
+ | CompileErrorAvalanche   !(AC.ProgramError  () var APF.Prim)
  deriving (Show, Generic)
 
 -- deepseq stops here, we don't really care about sequencing the error
 -- just need this to make sure the return type (with an AST) is sequenced.
-instance NFData (CompileError a b c) where rnf _ = ()
+instance NFData (CompileError a) where rnf _ = ()
 
 
-annotOfError :: CompileError SourcePos b c -> Maybe SourcePos
+annotOfError :: CompileError a -> Maybe SourcePos
 annotOfError e
  = case e of
     CompileErrorParse sp
@@ -139,14 +185,16 @@ annotOfError e
      -> SC.annotOfError  e'
     CompileErrorConvert     e'
      -> STC.annotOfError e'
+    CompileErrorFusion _
+     -> Nothing
     CompileErrorFlatten _
      -> Nothing
     CompileErrorFlattenSimp _
      -> Nothing
-    CompileErrorProgram _
+    CompileErrorAvalanche _
      -> Nothing
 
-instance (Hashable b, Eq b, IsString b, Pretty a, Pretty b, Show a, Show b, Show c) => Pretty (CompileError a b c) where
+instance (Hashable a, Eq a, IsString a, Pretty a, Show a) => Pretty (CompileError a) where
  pretty e
   = case e of
      CompileErrorParse p
@@ -161,13 +209,16 @@ instance (Hashable b, Eq b, IsString b, Pretty a, Pretty b, Show a, Show b, Show
      CompileErrorConvert ce
       -> "Convert error:" <> line
       <> indent 2 (pretty ce)
+     CompileErrorFusion ce
+      -> "Fusion error:" <> line
+      <> indent 2 (pretty ce)
      CompileErrorFlatten d
       -> "Flatten error:" <> line
       <> indent 2 (text $ show d)
      CompileErrorFlattenSimp d
       -> "Flatten simplify error:" <> line
       <> indent 2 (text $ show d)
-     CompileErrorProgram d
+     CompileErrorAvalanche d
       -> "Program error:" <> line
       <> indent 2 (text $ show d)
 
@@ -175,21 +226,32 @@ instance (Hashable b, Eq b, IsString b, Pretty a, Pretty b, Show a, Show b, Show
 
 -- * Compile
 
-type SourceVar  = SP.Variable
-type AnnotT a   = ST.Annot a SourceVar
-
-type CoreProgram' v = Core.Program () v
-type AvalProgram' v = AP.Program () v
-type AvalProgram a v= AP.Program a v
+type SourceVar   = SP.Variable
+type AnnotType a = ST.Annot a SourceVar
+type AnnotUnit   = Common.Annot ()
 
 type QueryTop'  v = SQ.QueryTop SourcePos v
-type QueryTop'T v = SQ.QueryTop (AnnotT SourcePos) v
+type QueryTop'T v = SQ.QueryTop (AnnotType SourcePos) v
 
 
 type Funs a b = [((a, Name b), SQ.Function a b)]
 type FunEnvT a b = [ ( Name b
                    , ( ST.FunctionType b
-                     , SQ.Function (AnnotT a) b )) ]
+                     , SQ.Function (AnnotType a) b )) ]
+
+
+type AvalProgram v = AP.Program AnnotUnit v APF.Prim
+
+type CoreProgramNoAnnot v   = Core.Program () v
+type AvalProgramNoAnnot v p = AP.Program   () v p
+
+type CoreProgramNamed v = (v, CoreProgramNoAnnot v)
+type CorePrograms v     = Map Attribute [CoreProgramNamed v]
+type AvalPrograms v     = Map Attribute (AP.Program AnnotUnit v APF.Prim)
+
+type Queries = (Attribute, QueryTop'T SourceVar)
+
+type Error = CompileError SourceVar
 
 ----------------------------------------
 -- * source
@@ -198,28 +260,29 @@ sourceParseQT
  :: Text
  -> Namespace
  -> Text
- -> Either (CompileError SourcePos SourceVar ()) (QueryTop' SourceVar)
+ -> Either Error (QueryTop' SourceVar)
 sourceParseQT base namespace t
  = first CompileErrorParse
- $ SP.parseQueryTop (CommonBase.OutputName base namespace) t
+ $ SP.parseQueryTop (Common.OutputName base namespace) t
 
 sourceParseF
   :: Parsec.SourceName -> Text
-  -> Either (CompileError SourcePos SourceVar ()) (Funs SourcePos SourceVar)
+  -> Either Error (Funs SourcePos SourceVar)
 sourceParseF env t
  = first CompileErrorParse
  $ SP.parseFunctions env t
 
 sourceDesugarQT
  :: QueryTop' SourceVar
- -> Either (CompileError SourcePos SourceVar ()) (QueryTop' SourceVar)
+ -> Either Error (QueryTop' SourceVar)
 sourceDesugarQT q
  = runIdentity . runEitherT . bimapEitherT CompileErrorDesugar snd
  $ Fresh.runFreshT
      (STD.desugarQT q)
      (freshNamer "desugar_q")
 
-sourceDesugarF :: Funs a SourceVar -> Either (CompileError a SourceVar ()) (Funs a SourceVar)
+sourceDesugarF :: Funs SourcePos SourceVar
+               -> Either (CompileError SourceVar) (Funs SourcePos SourceVar)
 sourceDesugarF fun
  = runIdentity . runEitherT . bimapEitherT CompileErrorDesugar snd
  $ Fresh.runFreshT
@@ -234,21 +297,21 @@ sourceReifyQT q
      (STR.reifyPossibilityQT q)
      (freshNamer "reify")
 
-sourceCheckQT
- :: SC.CheckOptions -> D.Dictionary -> QueryTop' SourceVar
- -> Either (CompileError SourcePos SourceVar ()) (QueryTop'T SourceVar, ST.Type SourceVar)
+sourceCheckQT :: SC.CheckOptions
+              -> Dictionary
+              -> QueryTop' SourceVar
+              -> Either Error (QueryTop'T SourceVar, ST.Type SourceVar)
 sourceCheckQT opts d q
- = let d' = D.featureMapOfDictionary d
+ = let d' = Dict.featureMapOfDictionary d
    in  first CompileErrorCheck
      $ snd
      $ flip Fresh.runFresh (freshNamer "check")
      $ runEitherT
      $ SC.checkQT opts d' q
 
-sourceCheckF
- :: FunEnvT a SourceVar
- -> Funs a SourceVar
- -> Either (CompileError a SourceVar ()) (FunEnvT a SourceVar)
+sourceCheckF :: FunEnvT SourcePos SourceVar
+             -> Funs    SourcePos SourceVar
+             -> Either  Error (FunEnvT SourcePos SourceVar)
 sourceCheckF env parsedImport
  = first CompileErrorCheck
  $ snd
@@ -256,57 +319,59 @@ sourceCheckF env parsedImport
  $ runEitherT
  $ SC.checkFs env parsedImport
 
-sourceInline
- :: D.Dictionary -> QueryTop'T SourceVar -> QueryTop' SourceVar
+sourceInline :: Dictionary
+             -> QueryTop'T SourceVar
+             -> QueryTop' SourceVar
 sourceInline d q
  = SQ.reannotQT ST.annAnnot
  $ inline q
  where
   funs      = M.map snd
             $ M.fromList
-            $ D.dictionaryFunctions d
+            $ Dict.dictionaryFunctions d
   inline q' = snd
             $ Fresh.runFresh
                 (STI.inlineQT funs q')
                 (freshNamer "inline")
 
-
 ----------------------------------------
 -- * core
 
-sourceConvert
-  :: D.Dictionary
-  -> QueryTop'T SourceVar
-  -> Either (CompileError SourcePos SourceVar ()) (CoreProgram' SourceVar)
+sourceConvert :: Dictionary
+              -> QueryTop'T SourceVar
+              -> Either Error (CoreProgramNoAnnot SourceVar)
 sourceConvert d q
  = second snd
  $ first CompileErrorConvert conv
  where
-  d'        = D.featureMapOfDictionary d
+  d'        = Dict.featureMapOfDictionary d
   conv      = Fresh.runFreshT
                 (STC.convertQueryTop d' q)
                 (freshNamer "conv")
 
 coreSimp
  :: (Hashable v, Eq v, IsString v, NFData v)
- => CoreProgram' v
- -> CoreProgram' v
+ => CoreProgramNoAnnot v
+ -> CoreProgramNoAnnot v
 coreSimp p
  = Core.condenseProgram ()
  $!! snd
  $!! Fresh.runFresh (Core.simpProgram () p) (freshNamer "simp")
 
+----------------------------------------
+-- * avalanche
+
 coreFlatten
   :: (Hashable v, Eq v, IsString v, Pretty v, Show v, NFData v)
-  => CoreProgram' v
-  -> Either (CompileError () v APF.Prim) (AvalProgram' v APF.Prim)
+  => CoreProgramNoAnnot v
+  -> Either (CompileError v) (AvalProgramNoAnnot v APF.Prim)
 coreFlatten = coreFlatten_ AS.defaultSimpOpts
 
 coreFlatten_
   :: (Hashable v, Eq v, IsString v, Pretty v, Show v, NFData v)
   => AS.SimpOpts
-  -> CoreProgram' v
-  -> Either (CompileError () v APF.Prim) (AvalProgram' v APF.Prim)
+  -> CoreProgramNoAnnot v
+  -> Either (CompileError v) (AvalProgramNoAnnot v APF.Prim)
 coreFlatten_ opts prog
  =   join
  $!! fmap (simpFlattened opts)
@@ -315,8 +380,8 @@ coreFlatten_ opts prog
 
 flattenAvalanche
   :: (IsString v, Pretty v, Hashable v, Eq v, NFData v, Show v)
-  => AvalProgram () v Core.Prim
-  -> Either (CompileError () v APF.Prim) (AvalProgram (CA.Annot ()) v APF.Prim)
+  => AvalProgramNoAnnot v Core.Prim
+  -> Either (CompileError v) (AP.Program AnnotUnit v APF.Prim)
 flattenAvalanche av
  = join
  . second snd
@@ -328,16 +393,16 @@ flattenAvalanche av
 
 checkAvalanche
   :: (Hashable v, Eq v)
-  => AvalProgram' v APF.Prim
-  -> Either (CompileError () v APF.Prim) (AvalProgram (CA.Annot ()) v APF.Prim)
+  => AvalProgramNoAnnot v APF.Prim
+  -> Either (CompileError v) (AvalProgram v)
 checkAvalanche prog
- = first CompileErrorProgram
+ = first CompileErrorAvalanche
  $ AC.checkProgram APF.flatFragment prog
 
 coreAvalanche
   :: (Eq v, Hashable v, Show v, IsString v)
-  => CoreProgram' v
-  -> AvalProgram () v Core.Prim
+  => CoreProgramNoAnnot v
+  -> AvalProgramNoAnnot v Core.Prim
 coreAvalanche prog
  = simpAvalanche
  $ snd
@@ -345,8 +410,8 @@ coreAvalanche prog
 
 simpAvalanche
   :: (Eq v, Hashable v, Show v, IsString v)
-  => AvalProgram () v Core.Prim
-  -> AvalProgram () v Core.Prim
+  => AvalProgramNoAnnot v Core.Prim
+  -> AvalProgramNoAnnot v Core.Prim
 simpAvalanche av
  = snd
  $ Fresh.runFresh go (freshNamer "anf")
@@ -356,19 +421,78 @@ simpAvalanche av
 simpFlattened
   :: (Eq v, Hashable v, Show v, IsString v, Pretty v)
   => AS.SimpOpts
-  -> AvalProgram (CA.Annot ()) v APF.Prim
-  -> Either (CompileError () v APF.Prim) (AvalProgram' v APF.Prim)
+  -> AvalProgram v
+  -> Either (CompileError v) (AvalProgramNoAnnot v APF.Prim)
 simpFlattened opts av
  = first CompileErrorFlattenSimp . second AA.eraseAnnotP . snd
  $ Fresh.runFresh (go av) (freshNamer "simpflat")
  where
   -- Thread through a dummy annotation
-  go = AS.simpFlattened (CA.Annot (CT.FunT [] CT.ErrorT) ()) opts
+  go = AS.simpFlattened (Common.Annot (Common.FunT [] Common.ErrorT) ()) opts
+
+----------------------------------------
+-- * dictionary
+
+avalancheOfDictionary :: Dictionary -> Either Error (AvalPrograms SourceVar)
+avalancheOfDictionary = avalancheOfDictionaryOpt SC.optionSmallData
+
+avalancheOfDictionaryOpt :: SC.CheckOptions -> Dictionary -> Either Error (AvalPrograms SourceVar)
+avalancheOfDictionaryOpt opt dict = do
+  let virtuals = fmap (second Dict.unVirtual) (Dict.getVirtualFeatures dict)
+
+  core      <- parTraverse (coreOfSourceOpt opt dict) virtuals
+  fused     <- parTraverse fuseCore                   (M.unionsWith (<>) core)
+  avalanche <- parTraverse avalancheOfCore            fused
+
+  return avalanche
 
 
-freshNamer :: IsString v => v -> Fresh.NameState v
-freshNamer prefix
- = Fresh.counterPrefixNameState (fromString . show) prefix
+avalancheOfCore :: CoreProgramNoAnnot SourceVar -> Either Error (AvalProgram SourceVar)
+avalancheOfCore core = do
+  flat    <- coreFlatten core
+  checked <- checkAvalanche flat
+  return checked
+
+
+fuseCore :: [CoreProgramNamed SourceVar] -> Either Error (CoreProgramNoAnnot SourceVar)
+fuseCore programs = first CompileErrorFusion $ do
+  fused <- Core.fuseMultiple () programs
+  pure (coreSimp fused)
+
+
+coreOfSource :: Dictionary -> Queries -> Either Error (CorePrograms SourceVar)
+coreOfSource d qs
+  = coreOfSourceOpt SC.optionSmallData d qs
+
+coreOfSourceOpt :: SC.CheckOptions -> Dictionary -> Queries -> Either Error (CorePrograms SourceVar)
+coreOfSourceOpt opt dict (Attribute attr, virtual) = do
+  let inlined   = sourceInline dict virtual
+
+  desugared    <- sourceDesugarQT inlined
+  (checked, _) <- sourceCheckQT opt dict desugared
+
+  let reified = sourceReifyQT checked
+
+  core <- sourceConvert dict reified
+  let simplified = coreSimp core
+
+  let baseattr  = (Attribute . unVar . unName) (SQ.feature virtual)
+
+  pure (M.singleton baseattr [(SP.Variable attr, simplified)])
+
+queryOfSource :: Dictionary -> Text -> Text -> Text -> Either Error Queries
+queryOfSource = queryOfSourceOpt SC.optionSmallData
+
+queryOfSourceOpt :: SC.CheckOptions -> Dictionary -> Text -> Text -> Text -> Either Error Queries
+queryOfSourceOpt checkOpts dict name src namespace = do
+  parsed       <- sourceParseQT name (Namespace namespace) src
+  desugared    <- sourceDesugarQT parsed
+  (checked, _) <- sourceCheckQT checkOpts dict desugared
+  pure (Attribute name, checked)
+
+entryOfQuery :: Attribute -> (QueryTop'T SourceVar) -> Text -> Dict.DictionaryEntry
+entryOfQuery attr query nsp
+  = Dict.DictionaryEntry attr (Dict.VirtualDefinition (Dict.Virtual query)) (Namespace nsp)
 
 
 --------------------------------------------------------------------------------
@@ -388,7 +512,7 @@ coreEval
   :: Time
   -> [AsAt Fact]
   -> QueryTop'T SourceVar
-  -> CoreProgram' SourceVar
+  -> CoreProgramNoAnnot SourceVar
   -> Either SimError [Result]
 coreEval t fs (renameQT unVar -> query) prog
  = do let partitions = S.streams fs
@@ -401,7 +525,7 @@ coreEval t fs (renameQT unVar -> query) prog
 
   where
     evalP feat (S.Partition ent attr values)
-      | CommonBase.NameBase feat' <- CommonBase.nameBase feat
+      | Common.NameBase feat' <- Common.nameBase feat
       , attr == Attribute feat'
       = do  (vs',_) <- evalV values
             return $ fmap (\v -> Result (ent, snd v)) vs'
@@ -429,7 +553,7 @@ avalancheEval t fs (renameQT unVar -> query) prog
 
   where
     evalP feat (S.Partition ent attr values)
-      | CommonBase.NameBase feat' <- CommonBase.nameBase feat
+      | Common.NameBase feat' <- Common.nameBase feat
       , attr == Attribute feat'
       = do  (vs',_) <- evalV values
             return $ fmap (\v -> Result (ent, snd v)) vs'
@@ -443,22 +567,22 @@ avalancheEval t fs (renameQT unVar -> query) prog
 seaEval :: Time
         -> [AsAt Fact]
         -> QueryTop'T SourceVar
-        -> AP.Program (CA.Annot ()) SP.Variable APF.Prim
-        -> EitherT Sea.SeaError IO [Result]
+        -> AP.Program (Common.Annot ()) SP.Variable APF.Prim
+        -> EitherT SeaError IO [Result]
 seaEval t newFacts (renameQT unVar -> query) program =
   fmap Result . mconcat <$> sequence results
   where
     partitions :: [S.Partition]
     partitions  = S.streams newFacts
 
-    results :: [EitherT Sea.SeaError IO [(Entity, Value)]]
+    results :: [EitherT SeaError IO [(Entity, Value)]]
     results = fmap (evalP (SQ.feature query)) partitions
 
-    evalP :: CommonBase.Name Text
+    evalP :: Common.Name Text
           -> S.Partition
-          -> EitherT Sea.SeaError IO [(Entity, Value)]
+          -> EitherT SeaError IO [(Entity, Value)]
     evalP featureName (S.Partition entityName attributeName values)
-      | CommonBase.NameBase name <- CommonBase.nameBase featureName
+      | Common.NameBase name <- Common.nameBase featureName
       , Attribute name == attributeName
       = do outputs <- Sea.seaEvalAvalanche program t values
            return $ fmap (\out -> (entityName, snd out)) outputs

--- a/src/Icicle/Pipeline.hs
+++ b/src/Icicle/Pipeline.hs
@@ -6,7 +6,6 @@
 {-# LANGUAGE DeriveGeneric     #-}
 module Icicle.Pipeline
   ( CompileError(..)
-  , STI.InlineOption (..)
 
   , SourceVar
   , AnnotType
@@ -28,6 +27,9 @@ module Icicle.Pipeline
   , AvalPrograms
 
   , Queries
+
+  , STI.InlineOption (..)
+  , STI.defaultInline
 
   , freshNamer
   , annotOfError
@@ -435,8 +437,9 @@ simpFlattened opts av
 ----------------------------------------
 -- * dictionary
 
-avalancheOfDictionary :: Dictionary -> Either Error (AvalPrograms SourceVar)
-avalancheOfDictionary = avalancheOfDictionaryOpt SC.optionSmallData STI.InlineByName
+avalancheOfDictionary :: STI.InlineOption -> Dictionary -> Either Error (AvalPrograms SourceVar)
+avalancheOfDictionary opt
+  = avalancheOfDictionaryOpt SC.optionSmallData opt
 
 avalancheOfDictionaryOpt :: SC.CheckOptions
                          -> STI.InlineOption
@@ -465,9 +468,9 @@ fuseCore programs = first CompileErrorFusion $ do
   pure (coreSimp fused)
 
 
-coreOfSource :: Dictionary -> Queries -> Either Error (CorePrograms SourceVar)
-coreOfSource d qs
-  = coreOfSourceOpt SC.optionSmallData STI.InlineByName d qs
+coreOfSource :: STI.InlineOption -> Dictionary -> Queries -> Either Error (CorePrograms SourceVar)
+coreOfSource opt d qs
+  = coreOfSourceOpt SC.optionSmallData opt d qs
 
 coreOfSourceOpt :: SC.CheckOptions
                 -> STI.InlineOption

--- a/src/Icicle/Repl.hs
+++ b/src/Icicle/Repl.hs
@@ -3,7 +3,7 @@
 
 module Icicle.Repl (
     ReplError (..)
-  , Var, P.QueryTop', P.QueryTop'T, P.CoreProgram'
+  , module P
   , annotOfError
   , sourceParse
   , sourceDesugar
@@ -64,9 +64,9 @@ import           X.Control.Monad.Trans.Either
 type Var = P.SourceVar
 
 data ReplError
- = ReplErrorCompileCore      (P.CompileError  Parsec.SourcePos Var ())
- | ReplErrorCompileAvalanche (P.CompileError  ()               Var APF.Prim)
- | ReplErrorRuntime          (S.SimulateError ()               Var)
+ = ReplErrorCompileCore      (P.CompileError     Var)
+ | ReplErrorCompileAvalanche (P.CompileError     Var)
+ | ReplErrorRuntime          (S.SimulateError () Var)
  | ReplErrorDictionaryLoad   DictionaryToml.DictionaryImportError
  | ReplErrorDecode           S.ParseError
  deriving (Show)
@@ -124,17 +124,14 @@ sourceCheck :: SC.CheckOptions -> D.Dictionary -> P.QueryTop' Var -> Either Repl
 sourceCheck opts d
  = first ReplErrorCompileCore . P.sourceCheckQT opts d
 
-sourceConvert :: D.Dictionary -> P.QueryTop'T Var -> Either ReplError (P.CoreProgram' Var)
+sourceConvert :: D.Dictionary -> P.QueryTop'T Var -> Either ReplError (P.CoreProgramNoAnnot Var)
 sourceConvert d
  = first ReplErrorCompileCore . P.sourceConvert d
 
-coreFlatten
-  :: P.CoreProgram' Var -> Either ReplError (AP.Program () Var APF.Prim)
-coreFlatten
- = first ReplErrorCompileAvalanche . P.coreFlatten
+coreFlatten :: P.CoreProgramNoAnnot Var -> Either ReplError (P.AvalProgramNoAnnot Var APF.Prim)
+coreFlatten = first ReplErrorCompileAvalanche . P.coreFlatten
 
-coreFlatten_
-  :: AS.SimpOpts -> P.CoreProgram' Var -> Either ReplError (AP.Program () Var APF.Prim)
+coreFlatten_ :: AS.SimpOpts -> P.CoreProgramNoAnnot Var -> Either ReplError (P.AvalProgramNoAnnot Var APF.Prim)
 coreFlatten_ opts
  = first ReplErrorCompileAvalanche . P.coreFlatten_ opts
 

--- a/src/Icicle/Source/Transform/Inline.hs
+++ b/src/Icicle/Source/Transform/Inline.hs
@@ -5,6 +5,7 @@ module Icicle.Source.Transform.Inline (
   , inlineQT
   , inlineQ
   , InlineOption (..)
+  , defaultInline
   ) where
 
 import Icicle.Source.Query
@@ -22,8 +23,11 @@ import              Data.Hashable (Hashable)
 
 
 data InlineOption
-  = InlineByName
-  | InlineByValue
+  = InlineUsingLets
+  | InlineUsingSubst
+
+defaultInline :: InlineOption
+defaultInline = InlineUsingLets
 
 inlineTransform
         :: (Hashable n, Eq n)
@@ -45,7 +49,7 @@ inlineTransform opt funs
    , argNames        <- fmap snd vars
    , length args == length vars
    = case opt of
-      InlineByName -> do
+      InlineUsingLets -> do
        ns      <- mapM (freshPrefixBase . nameBase) argNames
 
        let lets = fmap (mkLet a) (ns `zip` args)
@@ -56,7 +60,7 @@ inlineTransform opt funs
 
        return ((), Nested a (prefixContexts lets body'))
 
-      InlineByValue -> do
+      InlineUsingSubst -> do
        let sub  = Map.fromList
                 $ argNames `zip` args
        body'   <- substQ sub $ body fun

--- a/src/Icicle/Source/Transform/Inline.hs
+++ b/src/Icicle/Source/Transform/Inline.hs
@@ -4,6 +4,7 @@ module Icicle.Source.Transform.Inline (
     inlineTransform
   , inlineQT
   , inlineQ
+  , InlineOption (..)
   ) where
 
 import Icicle.Source.Query
@@ -20,11 +21,16 @@ import qualified    Data.Map as Map
 import              Data.Hashable (Hashable)
 
 
+data InlineOption
+  = InlineByName
+  | InlineByValue
+
 inlineTransform
         :: (Hashable n, Eq n)
-        => Map.Map (Name n) (Function a n)
+        => InlineOption
+        -> Map.Map (Name n) (Function a n)
         -> Transform (Fresh n) () a n
-inlineTransform funs
+inlineTransform opt funs
  = Transform
  { transformExp     = tranx
  , transformPat     = tranp
@@ -35,18 +41,27 @@ inlineTransform funs
   tranx _ x
    | (Var a n, args) <- takeApps x
    , Just fun        <- Map.lookup n funs
-   , length args == length (arguments fun)
-   = do let argNames
-                    = fmap snd $ arguments fun
-        ns         <- mapM (freshPrefixBase . nameBase) argNames
+   , vars            <- arguments fun
+   , argNames        <- fmap snd vars
+   , length args == length vars
+   = case opt of
+      InlineByName -> do
+       ns      <- mapM (freshPrefixBase . nameBase) argNames
 
-        let sub     = Map.fromList
-                    $ argNames `zip` fmap (Var a) ns
+       let lets = fmap (mkLet a) (ns `zip` args)
+       let sub  = Map.fromList
+                $ argNames `zip` fmap (Var a) ns
 
-        body'      <- substQ sub $ body fun
+       body'   <- substQ sub $ body fun
 
-        let lets = fmap (mkLet a) (ns `zip` args)
-        return ((), Nested a (prefixContexts lets body'))
+       return ((), Nested a (prefixContexts lets body'))
+
+      InlineByValue -> do
+       let sub  = Map.fromList
+                $ argNames `zip` args
+       body'   <- substQ sub $ body fun
+
+       return ((), Nested a body')
 
    | otherwise
    = return ((), x)
@@ -64,16 +79,19 @@ inlineTransform funs
 
 
 inlineQT :: (Hashable n, Eq n)
-        => Map.Map (Name n) (Function a n)
+        => InlineOption
+        -> Map.Map (Name n) (Function a n)
         -> QueryTop a n
         -> Fresh n (QueryTop a n)
-inlineQT funs qt
- = simplifyNestedQT <$> transformQT (inlineTransform funs) qt
+inlineQT opt funs qt
+ = simplifyNestedQT <$> transformQT (inlineTransform opt funs) qt
 
 
 inlineQ :: (Hashable n, Eq n)
-        => Map.Map (Name n) (Function a n)
+        => InlineOption
+        -> Map.Map (Name n) (Function a n)
         -> Query a n
         -> Fresh n (Query a n)
-inlineQ funs
- = transformQ (inlineTransform funs)
+inlineQ opt funs
+ = transformQ (inlineTransform opt funs)
+

--- a/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/src/Icicle/Storage/Dictionary/Toml.hs
@@ -47,7 +47,7 @@ import           X.Control.Monad.Trans.Either
 data DictionaryImportError
   = DictionaryErrorIO          E.SomeException
   | DictionaryErrorParsecTOML  Parsec.ParseError
-  | DictionaryErrorCompilation (P.CompileError Parsec.SourcePos SP.Variable ())
+  | DictionaryErrorCompilation (P.CompileError P.SourceVar)
   | DictionaryErrorParse       [DictionaryValidationError]
   | DictionaryErrorDense       DictionaryDenseError
   deriving (Show)

--- a/test/cli/repl/t01-sanity/expected
+++ b/test/cli/repl/t01-sanity/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Try a simple sum. Expect 1500 and 30.
 > - Core evaluation:

--- a/test/cli/repl/t02-groups/expected
+++ b/test/cli/repl/t02-groups/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Simplest group-by there is
 > - Core evaluation:

--- a/test/cli/repl/t03-distinct/expected
+++ b/test/cli/repl/t03-distinct/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Distinct by value. Expect 5 and 3
 > - Core evaluation:

--- a/test/cli/repl/t04-lets/expected
+++ b/test/cli/repl/t04-lets/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Elem/Scalar lets
 > - Core evaluation:

--- a/test/cli/repl/t05-nested-queries/expected
+++ b/test/cli/repl/t05-nested-queries/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- The ratio of > 300 to all?
 > - Core evaluation:

--- a/test/cli/repl/t06-custom-folds/expected
+++ b/test/cli/repl/t06-custom-folds/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Rolling average
 > - Core evaluation:

--- a/test/cli/repl/t07-possiblies/expected
+++ b/test/cli/repl/t07-possiblies/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Divisions return Possibles.
 > -- Try with group:

--- a/test/cli/repl/t08-randomly/expected
+++ b/test/cli/repl/t08-randomly/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- These two were failing before, but should pass now.
 > -- Not that they are particularly interesting.

--- a/test/cli/repl/t09-group-folds/expected
+++ b/test/cli/repl/t09-group-folds/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Count unique times, this is equivalent to `distinct time ~> count`
 > - Core evaluation:

--- a/test/cli/repl/t10-avalanche/expected
+++ b/test/cli/repl/t10-avalanche/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core-simp is now on

--- a/test/cli/repl/t10.2-core/expected
+++ b/test/cli/repl/t10.2-core/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core is now on

--- a/test/cli/repl/t10.3-flatten/expected
+++ b/test/cli/repl/t10.3-flatten/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, core-simp is now on

--- a/test/cli/repl/t11-nested-dictionaries/expected
+++ b/test/cli/repl/t11-nested-dictionaries/expected
@@ -1,6 +1,6 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Load dictionary
-> ok, loaded dictionary with 8 features and 37 functions
+> ok, loaded dictionary with 8 features and 38 functions
 > 

--- a/test/cli/repl/t12-broken-dictionaries/expected
+++ b/test/cli/repl/t12-broken-dictionaries/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Load dictionary
 > Dictionary load error:

--- a/test/cli/repl/t13-cases-either/expected
+++ b/test/cli/repl/t13-cases-either/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, type is now on
 > - Type:

--- a/test/cli/repl/t14-dates/expected
+++ b/test/cli/repl/t14-dates/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, time set to 2010-01-01
 > > - Core evaluation:

--- a/test/cli/repl/t15-tombstones/expected
+++ b/test/cli/repl/t15-tombstones/expected
@@ -1,7 +1,7 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
-> ok, loaded dictionary with 1 features and 37 functions
+> ok, loaded dictionary with 1 features and 38 functions
 > ok, loaded test/cli/repl/t15-tombstones/data.psv, 5 rows
 > > - Core evaluation:
 [gonzo, [("a",False)

--- a/test/cli/repl/t16-prelude/expected
+++ b/test/cli/repl/t16-prelude/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, core evaluation is now on
 > ok, c evaluation now on

--- a/test/cli/repl/t17-latest/expected
+++ b/test/cli/repl/t17-latest/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, type is now on
 > > -- Latests of groups

--- a/test/cli/repl/t18-nested-structs/expected
+++ b/test/cli/repl/t18-nested-structs/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, core evaluation is now on
 > ok, c evaluation now on
@@ -19,7 +19,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                    |  \_((_(_)|/(_)
                                    \             (
                                     \_____________)
-> > ok, loaded dictionary with 1 features and 37 functions
+> > ok, loaded dictionary with 1 features and 38 functions
 > ok, loaded test/cli/repl/t18-nested-structs/data.psv, 4 rows
 > > - C evaluation:
 [homer, [(1,1.5),(2,6.5)]

--- a/test/cli/repl/t19-windows/expected
+++ b/test/cli/repl/t19-windows/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Set to last month of year
 > ok, time set to 1970-12-01

--- a/test/cli/repl/t20-lexer/expected
+++ b/test/cli/repl/t20-lexer/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Numbers
 > - Core evaluation:

--- a/test/cli/repl/t30-sea/expected
+++ b/test/cli/repl/t30-sea/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Show everything
 > ok, flatten (simplified) is now on

--- a/test/cli/repl/t30.1-eval/expected
+++ b/test/cli/repl/t30.1-eval/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on

--- a/test/cli/repl/t30.2-array-strings/expected
+++ b/test/cli/repl/t30.2-array-strings/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on
@@ -19,7 +19,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                    |  \_((_(_)|/(_)
                                    \             (
                                     \_____________)
-> > ok, loaded dictionary with 2 features and 37 functions
+> > ok, loaded dictionary with 2 features and 38 functions
 > ok, loaded test/cli/repl/t30.2-array-strings/data.psv, 5 rows
 > > - C evaluation:
 [ID00000000, 2

--- a/test/cli/repl/t30.3-sum-not-error/expected
+++ b/test/cli/repl/t30.3-sum-not-error/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Enable C evaluation
 > ok, c evaluation now on

--- a/test/cli/repl/t31-builtin/expected
+++ b/test/cli/repl/t31-builtin/expected
@@ -1,7 +1,7 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
-> ok, loaded dictionary with 8 features and 37 functions
+> ok, loaded dictionary with 8 features and 38 functions
 > ok, loaded data/example/demographics.psv, 24 rows
 > ok, core evaluation is now on
 > ok, c evaluation now on
@@ -91,7 +91,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 [homer, (tombstone
         ,[9496,8035,6209,2191])]
 
-> > ok, loaded dictionary with 1 features and 37 functions
+> > ok, loaded dictionary with 1 features and 38 functions
 > ok, loaded test/cli/repl/t31-builtin/data.psv, 4 rows
 > > -- NY should be 1.5 years, CA should be 3 years, OR should be 0.5 years
 > - C evaluation:

--- a/test/cli/repl/t40-bigdata/expected
+++ b/test/cli/repl/t40-bigdata/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- Test "big data" mode where all queries must be windowed or latest
 > ok, big-data is now on
@@ -30,7 +30,7 @@ Check error:
 > >           λλλλ
 REPL Error:
 Check error:
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 45:9:data/libs/prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 48:9:data/libs/prelude.icicle
   Fold: fold s = 0 : v$inline$0
         + s
         ~> s
@@ -42,7 +42,7 @@ Check error:
 > >           λλλλ
 REPL Error:
 Check error:
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 45:9:data/libs/prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 48:9:data/libs/prelude.icicle
   Fold: fold s = 0 : v$inline$0
         + s
         ~> s
@@ -55,7 +55,7 @@ Check error:
 >           λλλλ
 REPL Error:
 Check error:
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 45:9:data/libs/prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 48:9:data/libs/prelude.icicle
   Fold: fold s = 0 : v$inline$0
         + s
         ~> s
@@ -82,7 +82,7 @@ Check error:
 >           λλλλ
 REPL Error:
 Check error:
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 45:9:data/libs/prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 48:9:data/libs/prelude.icicle
   Fold: fold s = 0 : v$inline$0
         + s
         ~> s
@@ -94,7 +94,7 @@ Check error:
 > >           λλλλ
 REPL Error:
 Check error:
-  For resumable queries, folds, groups and distincts must be inside windowed or latest at 45:9:data/libs/prelude.icicle
+  For resumable queries, folds, groups and distincts must be inside windowed or latest at 48:9:data/libs/prelude.icicle
   Fold: fold s = 0 : v$inline$0
         + s
         ~> s

--- a/test/cli/repl/t50-psv-many-rows/expected
+++ b/test/cli/repl/t50-psv-many-rows/expected
@@ -1,5 +1,5 @@
 welcome to iREPL
-ok, loaded 37 functions from data/libs/prelude.icicle
+ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > -- There was an error where every 128th row was being dropped
 > -- This was a bug in the PSV parsing code, as the count wasn't being updated


### PR DESCRIPTION
@amosr this is it, right? I tried it out by defining a function that would work if we are inlining by value, but not if we are inlining by name:

```
group_vals k v = vals (group k ~> v).
```

by name:

```
> :set inline by-name
ok, inline is now by name
> feature salary ~> vals (group time ~> newest value)
- Inlined:
feature salary
~> vals (group time
         ~>
         let v$inline$0 = value
         ~>
         latest 1
         ~>
         fold1 s = v$inline$0 : v$inline$0
         ~> s)

- Core evaluation:
[homer, [65000,66000,70000,81000,90100],marge, [0]]

> feature salary ~> group_vals time (newest value)
- Inlined:
feature salary
~> let k$inline$0 = time
~>
let v$inline$1 = (let v$inline$2 = value
                  ~>
                  latest 1
                  ~>
                  fold1 s = v$inline$2 : v$inline$2
                  ~> s)
~> vals (group k$inline$0 ~> v$inline$1)

- Core evaluation:
[homer, [90100,90100,90100,90100,90100],marge, [0]]
```

by value:
```
> :set inline by-value
ok, inline is now by value
> feature salary ~> vals (group time ~> newest value)
- Inlined:
feature salary
~> vals (group time ~> latest 1 ~> fold1 s = value : value ~> s)

- Core evaluation:
[homer, [65000,66000,70000,81000,90100],marge, [0]]

> feature salary ~> group_vals time (newest value)
- Inlined:
feature salary
~> vals (group time ~> latest 1 ~> fold1 s = value : value ~> s)

- Core evaluation:
[homer, [65000,66000,70000,81000,90100],marge, [0]]
```