### PR TITLE
Minor yak shaving: clean up compiler pipeline

### DIFF
--- a/src/Icicle/Benchmark.hs
+++ b/src/Icicle/Benchmark.hs
@@ -97,7 +97,9 @@ createBenchmark mode dictionaryPath inputPath outputPath dropPath packedChordPat
   (dictionary, input') <- firstEitherT BenchDictionaryImportError $ inputCfg input
   let output'           = outputCfg output
 
-  avalanche  <- hoistEither (first BenchCompileError $ P.avalancheOfDictionary P.defaultInline dictionary)
+  avalanche  <- hoistEither
+              $ first BenchCompileError
+              $ P.avalancheOfDictionary P.defaultCompileOptions dictionary
 
   let cfg = HasInput
           ( FormatPsv (PsvInputConfig  mode input')

--- a/src/Icicle/Source/Checker/Base.hs
+++ b/src/Icicle/Source/Checker/Base.hs
@@ -11,6 +11,7 @@ module Icicle.Source.Checker.Base (
   , CheckOptions (..)
   , optionBigData
   , optionSmallData
+  , defaultCheckOptions
 
   , GenEnv, GenConstraintSet
   , Gen(..)
@@ -100,6 +101,8 @@ optionBigData = CheckOptions True True
 optionSmallData :: CheckOptions
 optionSmallData = CheckOptions False True
 
+defaultCheckOptions :: CheckOptions
+defaultCheckOptions = optionSmallData
 
 --------------------------------------------------------------------------------
 

--- a/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/src/Icicle/Storage/Dictionary/Toml.hs
@@ -181,7 +181,7 @@ loadImports parentFuncs parsedImports
 checkDefs
   :: SC.CheckOptions
   -> Dictionary
-  -> [(Namespace, Attribute, P.QueryTop' P.SourceVar)]
+  -> [(Namespace, Attribute, P.QueryTopPosUntyped P.SourceVar)]
   -> EitherT DictionaryImportError IO [DictionaryEntry]
 checkDefs checkOpts d defs
  = hoistEither . first DictionaryErrorCompilation

--- a/test/Icicle/Test/Language.hs
+++ b/test/Icicle/Test/Language.hs
@@ -83,7 +83,7 @@ prop_languages_eval ewt = testIO $ do
 data EvalWellTyped = EvalWellTyped
   { welltyped        :: WellTyped
   , wtEvalFacts      :: [D.AsAt D.Fact]
-  , wtEvalDummyQuery :: P.QueryTop'T P.SourceVar
+  , wtEvalDummyQuery :: P.QueryTopPosTyped P.SourceVar
   } deriving (Show)
 
 instance Arbitrary EvalWellTyped where
@@ -102,7 +102,7 @@ mkFacts wt
       = D.AsAt <$> (D.Fact ent attr <$> factFromCoreValue (D.atFact a))
                <*> pure (D.atTime a)
 
-mkDummyQuery :: WellTyped -> P.QueryTop'T P.SourceVar
+mkDummyQuery :: WellTyped -> P.QueryTopPosTyped P.SourceVar
 mkDummyQuery wt
   = let x = nameOf $ NameBase $ SP.Variable "dummy"
         pos = Parsec.initialPos "dummy"


### PR DESCRIPTION
More yak shaving on `Pipeline`. It should be easier to find what we need and not write redundant compilation functions now?

I think the type aliases in Pipeline helps.