### PR TITLE
Output tombstone

### DIFF
--- a/icicle-compiler/src/Icicle/Benchmark.hs
+++ b/icicle-compiler/src/Icicle/Benchmark.hs
@@ -32,7 +32,6 @@ import           Control.Monad.IO.Class (liftIO)
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
-import           Data.Set (Set)
 import qualified Data.Text.Lazy.IO as TL
 import           Data.Time (NominalDiffTime, getCurrentTime, diffUTCTime)
 
@@ -171,7 +170,7 @@ runBenchmark b = do
     , benchBytes    = fromIntegral size
     }
 
-tombstonesOfDictionary :: Dictionary -> Map Attribute (Set Text)
+tombstonesOfDictionary :: Dictionary -> Map Attribute [Text]
 tombstonesOfDictionary dict =
   let go (DictionaryEntry a (ConcreteDefinition _ ts _) _) = [(a, ts)]
       go _                                                 = []

--- a/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
+++ b/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
@@ -5,6 +5,7 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE ViewPatterns #-}
 module Icicle.Sea.Eval.Base (
     MemPool
   , SeaState
@@ -320,9 +321,15 @@ codeOfPrograms
   -> Either SeaError Text
 codeOfPrograms input programs = do
   let defs = seaOfDefinitions (fmap snd programs)
+      outputTombstone a
+        = case input of
+            HasInput _ (InputOpts _ tombstones)
+              | Just (reverse -> t : _) <- Map.lookup a tombstones
+              -> t
+            _ -> defaultOutputTombstone
 
-  progs   <- zipWithM (\ix (a, p) -> seaOfProgram   ix a p) [0..] programs
-  states  <- zipWithM (\ix (a, p) -> stateOfProgram ix a p) [0..] programs
+  progs   <- zipWithM (\ix (a, p) -> seaOfProgram   ix a (outputTombstone a) p) [0..] programs
+  states  <- zipWithM (\ix (a, p) -> stateOfProgram ix a (outputTombstone a) p) [0..] programs
 
   case input of
     NoInput -> do
@@ -339,6 +346,9 @@ codeOfPrograms input programs = do
 
 textOfDoc :: Doc -> Text
 textOfDoc doc = T.pack (displayS (renderPretty 0.8 80 (pretty doc)) "")
+
+defaultOutputTombstone :: Text
+defaultOutputTombstone = "NA"
 
 ------------------------------------------------------------------------
 

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -40,9 +40,9 @@ import qualified Data.Map as Map
 ------------------------------------------------------------------------
 
 seaOfProgram :: (Show a, Show n, Pretty n, Eq n)
-             => Int -> Attribute -> Program (Annot a) n Prim -> Either SeaError Doc
-seaOfProgram name attrib program = do
-  state <- stateOfProgram name attrib program
+             => Int -> Attribute -> Text -> Program (Annot a) n Prim -> Either SeaError Doc
+seaOfProgram name attrib tombstone program = do
+  state <- stateOfProgram name attrib tombstone program
   pure $ vsep
     [ seaOfState state
     , ""

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
@@ -59,6 +59,7 @@ import           P
 data SeaProgramState = SeaProgramState {
     stateName       :: Int
   , stateAttribute  :: Attribute
+  , stateTombstone  :: Text
   , stateTimeVar    :: Text
   , stateInputType  :: ValType
   , stateInputVars  :: [(Text, ValType)]
@@ -72,9 +73,10 @@ stateOfProgram
   :: (Pretty n, Eq n)
   => Int
   -> Attribute
+  -> Text
   -> Program (Annot a) n Prim
   -> Either SeaError SeaProgramState
-stateOfProgram name attrib program
+stateOfProgram name attrib tombstone program
  = case factVarsOfProgram FactLoopNew program of
     Nothing
      -> Left SeaNoFactLoop
@@ -83,6 +85,7 @@ stateOfProgram name attrib program
      -> Right SeaProgramState {
           stateName       = name
         , stateAttribute  = attrib
+        , stateTombstone  = tombstone
         , stateTimeVar    = textOfName (bindtime program)
         , stateInputType  = factType
         , stateInputVars  = fmap (first textOfName) factVars

--- a/icicle-compiler/src/Icicle/Sea/IO/Base/Input.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Base/Input.hs
@@ -14,7 +14,6 @@ module Icicle.Sea.IO.Base.Input
   , CBlock
   , CName
   , CFun
-  , Tombstones
   , SeaInput (..)
   , SeaInputError (..)
   , seaOfReadNamedFact
@@ -40,7 +39,6 @@ module Icicle.Sea.IO.Base.Input
 
 import qualified Data.ByteString                  as B
 import           Data.Map                         (Map)
-import           Data.Set                         (Set)
 import qualified Data.Text.Encoding               as T
 import           Data.Word                        (Word8)
 
@@ -67,7 +65,7 @@ type Name = Text
 
 data InputOpts = InputOpts
   { inputAllowDupTime :: InputAllowDupTime
-  , inputTombstones   :: Map Attribute (Set Text)
+  , inputTombstones   :: Map Attribute [Text]
   } deriving (Show, Eq)
 
 -- | Whether fact times must be unique for an entity.
@@ -77,9 +75,6 @@ data InputAllowDupTime
   deriving (Eq, Ord, Show)
 
 --------------------------------------------------------------------------------
-
-type Tombstone  = Text
-type Tombstones = Set Tombstone
 
 data CheckedInput = CheckedInput {
     inputSumError :: Name
@@ -122,11 +117,11 @@ data SeaInputError = SeaInputError
 
 -- Common input statements, for both PSV and Zebra
 data SeaInput = SeaInput
-  { cstmtReadFact     :: SeaProgramState -> Tombstones -> CheckedInput -> CStmt -> CStmt -> CFun
+  { cstmtReadFact     :: SeaProgramState -> [Text] -> CheckedInput -> CStmt -> CStmt -> CFun
   -- ^ Generate C code to read input into the `program->input` struct.
   , cstmtReadTime     :: CStmt
   -- ^ Generate C code to read the current fact time.
-  , cfunReadTombstone :: CheckedInput -> [Tombstone] -> CStmt
+  , cfunReadTombstone :: CheckedInput -> [Text] -> CStmt
   -- ^ Generate C code to read the tombstone of this input.
   , cnameFunReadFact  :: SeaProgramState -> CName
   -- ^ Name of the read_fact function. e.g. psv_read_fact_0.

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv/Input.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv/Input.hs
@@ -14,8 +14,6 @@ module Icicle.Sea.IO.Psv.Input
 
 import qualified Data.List as List
 import qualified Data.Map as Map
-import           Data.Set (Set)
-import qualified Data.Set as Set
 
 import           Icicle.Common.Type (ValType(..), StructType(..), StructField(..))
 
@@ -46,7 +44,6 @@ data PsvInputFormat
   deriving (Eq, Ord, Show)
 
 --------------------------------------------------------------------------------
-
 
 -- * Psv input "interface"
 
@@ -104,7 +101,7 @@ seaOfReadTombstone input = \case
 
 seaOfReadFact
   :: SeaProgramState
-  -> Base.Tombstones
+  -> [Text]
   -> Base.CheckedInput
   -> Base.CStmt -- C block that reads the input value
   -> Base.CStmt -- C block that performs some check after reading
@@ -126,7 +123,7 @@ seaOfReadFact state tombstones input readInput checkCount =
     , "    ierror_t " <> pretty (Base.inputSumError input) <> ";"
     , indent 4 . vsep . fmap seaOfDefineInput $ Base.inputVars input
     , ""
-    , "    " <> align (seaOfReadTombstone input (Set.toList tombstones)) <> "{"
+    , "    " <> align (seaOfReadTombstone input tombstones) <> "{"
     , "        " <> pretty (Base.inputSumError input) <> " = ierror_not_an_error;"
     , ""
     , indent 8 readInput
@@ -258,7 +255,7 @@ seaOfReadNamedFactDense opts state
       ]
 
 
-seaOfReadFactDense :: PsvInputDenseDict -> SeaProgramState -> Set Text -> Either SeaError Doc
+seaOfReadFactDense :: PsvInputDenseDict -> SeaProgramState -> [Text] -> Either SeaError Doc
 seaOfReadFactDense dict state tombstones = do
   let feeds  = denseDict dict
   let attr   = getAttribute $ stateAttribute state
@@ -410,7 +407,7 @@ seaOfReadNamedFactSparse opts state
 
 seaOfReadFactSparse
   :: SeaProgramState
-  -> Set Text
+  -> [Text]
   -> Either SeaError Doc
 seaOfReadFactSparse state tombstones = do
   input     <- Base.checkInputType state
@@ -582,7 +579,6 @@ seaOfReadJsonField assign ftype vars = do
     , "    break;"
     ]
 
-lookupTombstones :: Base.InputOpts -> SeaProgramState -> Set Text
+lookupTombstones :: Base.InputOpts -> SeaProgramState -> [Text]
 lookupTombstones opts state =
-  fromMaybe Set.empty (Map.lookup (stateAttribute state) (Base.inputTombstones opts))
-
+  fromMaybe [] (Map.lookup (stateAttribute state) (Base.inputTombstones opts))

--- a/icicle-compiler/test/Icicle/Test/Encoding.hs
+++ b/icicle-compiler/test/Icicle/Test/Encoding.hs
@@ -12,7 +12,6 @@ import           P
 import           System.IO
 
 import           Test.QuickCheck
-import qualified Data.Set as Set
 
 
 -- Sanity checking the randomly generated values
@@ -34,7 +33,7 @@ prop_json_roundtrip e =
 
 prop_text_roundtrip e =
  forAll  (valueOfEncoding e)
- $ \v -> (parseValue e (Set.singleton "☠"). renderValue "☠") v === Right v
+ $ \v -> (parseValue e ["☠"] . renderValue "☠") v === Right v
 
 return []
 tests :: IO Bool

--- a/icicle-compiler/test/Icicle/Test/IO/IO.hs
+++ b/icicle-compiler/test/Icicle/Test/IO/IO.hs
@@ -10,7 +10,6 @@ module Icicle.Test.IO.IO where
 import           Control.Monad.Trans.Class
 
 import           Data.List (nubBy)
-import qualified Data.Set                           as Set
 
 import           Disorder.Core.IO
 import           Disorder.Corpus
@@ -70,7 +69,7 @@ instance Arbitrary DictionaryEntry where
  arbitrary
   =   DictionaryEntry
   <$> arbitrary
-  <*> (ConcreteDefinition <$> arbitrary <*> (Set.singleton <$> elements viruses) <*> (pure unkeyed))
+  <*> (ConcreteDefinition <$> arbitrary <*> (pure <$> elements viruses) <*> (pure unkeyed))
   <*> (Namespace <$> elements simpsons)
 
 instance Show a => Testable (Either a Property) where

--- a/icicle-compiler/test/Icicle/Test/Sea/Psv.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Psv.hs
@@ -13,7 +13,6 @@ import           Control.Monad.IO.Class (liftIO)
 import qualified Data.ByteString.Lazy as L
 import qualified Data.List as List
 import qualified Data.Map as Map
-import qualified Data.Set as Set
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LT
@@ -195,7 +194,7 @@ runTest wt (TestOpts showInput showOutput inputFormat allowDupTime) = do
                 (S.PsvSnapshot (wtTime wt))
                 (S.PsvOutputSparse)
       iformat  = S.FormatPsv iconfig oconfig
-      iopts    = S.InputOpts allowDupTime (Map.singleton (wtAttribute wt) (Set.singleton tombstone))
+      iopts    = S.InputOpts allowDupTime (Map.singleton (wtAttribute wt) [tombstone])
 
   let compile  = S.seaCompile' options (S.HasInput iformat iopts) programs
       release  = S.seaRelease

--- a/icicle-compiler/test/cli/bench/run
+++ b/icicle-compiler/test/cli/bench/run
@@ -107,3 +107,23 @@ rm $t3_drop_2
 
 echo "OK!"
 
+################################################################################
+
+echo "3. Output most recently defined tombstone"
+
+t4_dict=test/cli/bench/t4-dictionary.toml
+t4_in=test/cli/bench/t4-in.psv
+
+t4_expected=test/cli/bench/t4-expected.psv
+t4_out_c=`mktemp -t icicle-bench-t4-c-XXXXXX`
+t4_out_psv=`mktemp -t icicle-bench-t4-out-XXXXXX`
+
+dist/build/icicle-bench/icicle-bench $t4_dict $t4_in $t4_out_psv $t4_out_c 2010-01-01
+
+diff $t4_expected $t4_out_psv
+
+rm $t4_out_c
+rm $t4_out_psv
+
+echo "OK!"
+

--- a/icicle-compiler/test/cli/bench/t4-dictionary.toml
+++ b/icicle-compiler/test/cli/bench/t4-dictionary.toml
@@ -1,0 +1,16 @@
+title = "Dense input example dictionary"
+
+version = 1
+
+chapter = []
+
+namespace = """default"""
+
+tombstone = "foo"
+
+[fact.injury]
+  tombstone  = "none"
+  encoding="(location:string,severity:double,action:string*)"
+
+[feature.test]
+   expression = "feature injury ~> newest action"

--- a/icicle-compiler/test/cli/bench/t4-expected.psv
+++ b/icicle-compiler/test/cli/bench/t4-expected.psv
@@ -1,0 +1,1 @@
+homer|test|none

--- a/icicle-compiler/test/cli/bench/t4-in.psv
+++ b/icicle-compiler/test/cli/bench/t4-in.psv
@@ -1,0 +1,3 @@
+homer|injury|{"location":"arm","severity":4}"|1994-01-01
+homer|injury|{"location":"torso","severity":3,"action":"ignore"}"|1999-01-01
+homer|injury|{"location":"torso","severity":1}"|2010-01-01

--- a/icicle-repl/src/Icicle/Repl.hs
+++ b/icicle-repl/src/Icicle/Repl.hs
@@ -351,7 +351,7 @@ handleLine state line = let st = sourceState state in
            prettyOut hasSeaPreamble "- C preamble:" Sea.seaPreamble
 
            when (hasSea state) $ do
-             let seaProgram = Sea.seaOfProgram 0 (Attribute "repl") f'
+             let seaProgram = Sea.seaOfProgram 0 (Attribute "repl") "NA" f'
              case seaProgram of
                Left  e -> prettyOut (const True) "- C error:" e
                Right r -> prettyOut (const True) "- C:" r

--- a/icicle-source/src/Icicle/Dictionary/Data.hs
+++ b/icicle-source/src/Icicle/Dictionary/Data.hs
@@ -40,7 +40,6 @@ import           Icicle.Internal.Pretty
 
 import           Data.Map (Map)
 import qualified Data.Map                           as Map
-import qualified Data.Set                           as Set
 import           Data.String
 
 import           P
@@ -66,7 +65,7 @@ data Definition =
   | VirtualDefinition  Virtual
   deriving (Eq, Show)
 
-type Tombstones = Set.Set Text
+type Tombstones = [Text]
 
 -- | A parsed and typechecked source program.
 newtype Virtual = Virtual {

--- a/icicle-source/src/Icicle/Dictionary/Demographics.hs
+++ b/icicle-source/src/Icicle/Dictionary/Demographics.hs
@@ -7,8 +7,6 @@ module Icicle.Dictionary.Demographics (
 import           Icicle.Data
 import           Icicle.Dictionary.Data
 
-import qualified Data.Set                           as Set
-
 
 -- | Example demographics dictionary
 -- Hard-coded for now
@@ -16,23 +14,23 @@ demographics :: Dictionary
 demographics =
  Dictionary
  [ DictionaryEntry (Attribute "gender")
-                   (ConcreteDefinition StringEncoding Set.empty unkeyed)
+                   (ConcreteDefinition StringEncoding [] unkeyed)
                    nsp
  , DictionaryEntry (Attribute "age")
-                   (ConcreteDefinition IntEncoding    Set.empty unkeyed)
+                   (ConcreteDefinition IntEncoding    [] unkeyed)
                    nsp
  , DictionaryEntry (Attribute "state_of_residence")
-                   (ConcreteDefinition StringEncoding Set.empty unkeyed)
+                   (ConcreteDefinition StringEncoding [] unkeyed)
                    nsp
  , DictionaryEntry (Attribute "salary")
-                   (ConcreteDefinition IntEncoding    Set.empty unkeyed)
+                   (ConcreteDefinition IntEncoding    [] unkeyed)
                    nsp
  , DictionaryEntry (Attribute "injury")
                    (ConcreteDefinition
                       (StructEncoding
                         [StructField Mandatory (Attribute "location") StringEncoding
                         ,StructField Mandatory (Attribute "severity") IntEncoding])
-                      Set.empty unkeyed)
+                      [] unkeyed)
                    nsp
  ]
  []

--- a/icicle-source/src/Icicle/Encoding.hs
+++ b/icicle-source/src/Icicle/Encoding.hs
@@ -26,7 +26,7 @@ import qualified Data.Scientific        as S
 import qualified Data.ByteString.Lazy   as BS
 import qualified Data.HashMap.Strict    as HM
 import qualified Data.Map               as Map
-import qualified Data.Set               as Set
+import qualified Data.List              as List
 import qualified Data.Vector            as V
 
 import qualified Icicle.Common.Type     as IT
@@ -162,9 +162,9 @@ renderValue tombstone val
 
 -- | Attempt to decode value with given encoding.
 -- Some values may fit multiple encodings.
-parseValue :: Encoding -> Set.Set Text -> Text -> Either DecodeError Value
+parseValue :: Encoding -> [Text] -> Text -> Either DecodeError Value
 parseValue e tombstone t
- | Set.member t tombstone
+ | List.elem t tombstone
  = return Tombstone
  | otherwise
  = case e of

--- a/icicle-source/src/Icicle/Storage/Dictionary/TextV1.hs
+++ b/icicle-source/src/Icicle/Storage/Dictionary/TextV1.hs
@@ -9,14 +9,12 @@ module Icicle.Storage.Dictionary.TextV1 (
 import           Icicle.Data
 import           Icicle.Dictionary.Data
 import           Icicle.Serial (ParseError (..))
+import           Icicle.Storage.Encoding
+
 import           P hiding (concat, intercalate)
 
 import           Data.Attoparsec.Text
-
 import           Data.Text hiding (takeWhile)
-import qualified Data.Set as Set
-
-import           Icicle.Storage.Encoding
 
 field :: Parser Text
 field = append <$> takeWhile (not . isDelimOrEscape) <*> (concat <$> many (cons <$> escaped <*> field)) <?> "field"
@@ -35,7 +33,7 @@ parseIcicleDictionaryV1
  = DictionaryEntry
  <$> (Attribute <$> field)
  <*   p
- <*> (ConcreteDefinition <$> parseEncoding <*> pure (Set.singleton "NA") <*> pure unkeyed)
+ <*> (ConcreteDefinition <$> parseEncoding <*> pure ["NA"] <*> pure unkeyed)
  -- No namespace in this legacy dictionary
  <*> pure (Namespace "default")
     where

--- a/icicle-source/src/Icicle/Storage/Dictionary/Toml.hs
+++ b/icicle-source/src/Icicle/Storage/Dictionary/Toml.hs
@@ -40,6 +40,7 @@ import           System.FilePath
 import           System.IO
 
 import qualified Data.Set                                      as Set
+import qualified Data.List                                     as List
 import qualified Data.Text                                     as T
 import qualified Data.Text.Encoding                            as T
 import qualified Data.Text.IO                                  as T
@@ -148,7 +149,7 @@ loadDictionary' checkOpts impPrelude parentFuncs parentConf parentConcrete dictP
   pure $ Dictionary totaldefinitions functions
   where
     remakeConcrete (DictionaryEntry' a (ConcreteDefinition' e t k) nsp) cds
-      = (k, DictionaryEntry a (ConcreteDefinition e (Set.fromList (toList t)) unkeyed) nsp)
+      = (k, DictionaryEntry a (ConcreteDefinition e (toList t) unkeyed) nsp)
       : cds
     remakeConcrete _ cds
       = cds


### PR DESCRIPTION
PSV output was not writing out tombstones (it just doesn't write out anything, e.g. "homer|test|"). Here is a quick fix that uses the tombstone value defined for that fact/namespace (if exists, otherwise the default tombstone "NA" is used)

```
namespace = """default"""
tombstone = "foo"
[fact.injury]
  tombstone  = "none"
  encoding = "(location:string,severity:double,action:string*)"
[feature.test]
   expression = "feature injury ~> newest action"
```

```
homer|injury|{"location":"torso","severity":3,"action":"ignore"}"|1999-01-01
homer|injury|{"location":"torso","severity":1}"|2010-01-01
```

```
homer|test|none
```

! @jystic 