### PR TITLE
Output missing dense values

### DIFF
--- a/icicle-compiler/test/cli/bench/run
+++ b/icicle-compiler/test/cli/bench/run
@@ -109,21 +109,24 @@ echo "OK!"
 
 ################################################################################
 
-echo "3. Output most recently defined tombstone"
+echo "4. Output missing value"
 
+t4_common_args="--discard=true --input=sparse --output=dense"
 t4_dict=test/cli/bench/t4-dictionary.toml
 t4_in=test/cli/bench/t4-in.psv
 
 t4_expected=test/cli/bench/t4-expected.psv
 t4_out_c=`mktemp -t icicle-bench-t4-c-XXXXXX`
 t4_out_psv=`mktemp -t icicle-bench-t4-out-XXXXXX`
+t4_drop=`mktemp -t icicle-bench-t4-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench $t4_dict $t4_in $t4_out_psv $t4_out_c 2010-01-01
+dist/build/icicle-bench/icicle-bench $t4_dict $t4_in $t4_out_psv $t4_out_c 2010-01-01 1000 $t4_drop $t4_common_args
 
 diff $t4_expected $t4_out_psv
 
 rm $t4_out_c
 rm $t4_out_psv
+rm $t4_drop
 
 echo "OK!"
 

--- a/icicle-compiler/test/cli/bench/t4-dictionary.toml
+++ b/icicle-compiler/test/cli/bench/t4-dictionary.toml
@@ -11,11 +11,11 @@ tombstone = "foo"
 [fact.injury]
   encoding="(location:string,severity:double,action:string*)"
 
-[feature.test]
-   expression = "feature injury ~> latest 2 ~> action"
+[feature.latest_four]
+   expression = "feature injury ~> latest 4 ~> action"
+
+[feature.newest]
+   expression = "feature injury ~> newest action"
 
 [feature.test_map]
    expression = "feature injury ~> group location ~> latest 2 ~> action"
-
-[feature.test_map_struct]
-   expression = "feature injury ~> group location ~> latest 2 ~> fields"

--- a/icicle-compiler/test/cli/bench/t4-expected.psv
+++ b/icicle-compiler/test/cli/bench/t4-expected.psv
@@ -1,3 +1,1 @@
-homer|test|["ignore",NA]
-homer|test_map|[["arm",[NA]],["torso",["ignore",NA]]]
-homer|test_map_struct|[["arm",[{"severity":4616189618054758000.0,"location":"arm"}]],["torso",[{"severity":4613937818241073000.0,"location":"torso","action":"ignore"},{"severity":4607182418800017400.0,"location":"torso"}]]]
+homer|["ignore"]|NA|[["arm",[]]["torso",["ignore"]]]

--- a/icicle-compiler/test/cli/bench/t4-in.psv
+++ b/icicle-compiler/test/cli/bench/t4-in.psv
@@ -1,3 +1,4 @@
 homer|injury|{"location":"arm","severity":4}"|1994-01-01
+homer|injury|{"location":"arm","severity":5}"|1995-01-01
 homer|injury|{"location":"torso","severity":3,"action":"ignore"}"|1999-01-01
-homer|injury|{"location":"torso","severity":1}"|2010-01-01
+homer|injury|{"location":"torso","severity":5}"|2000-01-01


### PR DESCRIPTION
This reverts the previous change. Tombstones are treated as bottoms again, and will be dropped in sparse PSV output. In dense PSV output, if a column is missing, a missing value will be written, e.g.

```
[fact.injury]
  encoding="(location:string,severity:double,action:string*)"

[feature.latest_four]
   expression = "feature injury ~> latest 4 ~> action"

[feature.newest]
   expression = "feature injury ~> newest action"
```

```
homer|injury|{"location":"arm","severity":4}"|1994-01-01
homer|injury|{"location":"arm","severity":5}"|1995-01-01
homer|injury|{"location":"torso","severity":3,"action":"ignore"}"|1999-01-01
homer|injury|{"location":"torso","severity":5}"|2000-01-01
```

dense output:

```
homer|["ignore"]|NA
```

sparse output:

```
homer|latest_four|["ignore"]
homer|newest|
```

! @jystic @raronson 