### PR TITLE
Fix convert fold patttern

### DIFF
--- a/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
+++ b/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
@@ -670,6 +670,7 @@ peekArray ptr t = do
 peekArrayIx :: (Functor m, MonadIO m) => Ptr x -> ValType -> Int -> EitherT SeaError m BaseValue
 peekArrayIx ptr t ix =
   case t of
+    UnitT   -> pure VUnit
     IntT    -> VInt    . fromInt64    <$> peekWordOff ptr ix
     DoubleT -> VDouble                <$> peekWordOff ptr ix
     TimeT   -> VTime   . timeOfPacked <$> peekWordOff ptr ix

--- a/icicle-source/src/Icicle/Source/ToCore/Fold.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Fold.hs
@@ -117,12 +117,6 @@ convertFold q
             -- Check if it is a scalar variable or postcomputation
             case bound of
              Just v'
-              | TemporalityPure  <- getTemporalityOrPure retty
-              -> do n'ignore <- lift fresh
-                    retty' <- convertValType' retty
-                    let k = CE.xLam n'ignore retty' $ CE.xVar v'
-                    return $ ConvertFoldResult k (CE.xVar v') k retty' retty'
-
               | TemporalityElement <- getTemporalityOrPure retty
               -> do retty' <- convertValType' retty
                     i <- idFun retty'


### PR DESCRIPTION
This was picked up by quickcheck:

```
feature foo ~> group anything ~> case something_pure | Some x -> Right x | .. end

Variable not bound: desugar_q$0$conv$11
```

It should insert a Unit into the map, rather than try to use the unbound `x`

! @amosr 