### PR TITLE
Use readlink to get input filepath from the fd

### DIFF
--- a/icicle-compiler/src/Icicle/Sea/IO/Base/Input.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Base/Input.hs
@@ -182,7 +182,7 @@ seaOfReadNamedFact funs errs allowDupTime state
       , indent 8 $ seaInputErrorCountExceedLimit errs
       , "    }"
       , ""
-      , "    return " <> fun <> " (value_ptr, value_size, time, fleet->mempool, chord_count, fleet->" <> pname <> ");"
+      , "    return " <> fun <> " (input_fd, value_ptr, value_size, time, fleet->mempool, chord_count, fleet->" <> pname <> ");"
       , ""
       , "}"
       , ""

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
@@ -249,7 +249,7 @@ seaOfConfigureFleet :: PsvMode -> [SeaProgramState] -> Doc
 seaOfConfigureFleet mode states
  = vsep
  [ "#line 1 \"configure fleet state\""
- , "static ierror_loc_t psv_configure_fleet (const char *entity, size_t entity_size, const ichord_t **chord, ifleet_t *fleet)"
+ , "static ierror_loc_t psv_configure_fleet (const iint_t input_fd, const char *entity, size_t entity_size, const ichord_t **chord, ifleet_t *fleet)"
  , "{"
  , "    iint_t max_chord_count = fleet->max_chord_count;"
  , ""
@@ -262,7 +262,7 @@ seaOfConfigureFleet mode states
  , ""
  , "    if (chord_count > max_chord_count) {"
  , "        return ierror_loc_format"
- , "            ( 0, 0"
+ , "            ( input_fd, 0, 0"
  , "            , \"exceeded maximum number of chords per entity (chord_count = %lld, max_chord_count = %lld)\""
  , "            , chord_count"
  , "            , max_chord_count );"


### PR DESCRIPTION
This is a dirty stop-gap solution to find out the input filename when an error occurs. It only works on Linux (tested on CentOS 6), should eventually be replaced when we get to https://github.com/ambiata/icicle/issues/439. I hope this isn't too savage for now.

! @jystic @olorin 