### PR TITLE
icicle-bench: Make some of the options mutually exclusive

### DIFF
--- a/icicle-compiler/bench/bench.hs
+++ b/icicle-compiler/bench/bench.hs
@@ -20,6 +20,8 @@ import qualified Icicle.Sea.Eval as I
 
 import           P
 
+import qualified Prelude as Savage
+
 import           System.Directory (createDirectoryIfMissing)
 import           System.Exit (ExitCode(..))
 import           System.FilePath (FilePath, (</>))
@@ -134,9 +136,16 @@ createBenchmark (name, path) = do
       input   = path </> "data.psv"
       output  = path </> "out.psv"
       c       = path </> "bench.c"
-      time    = timeOfText "2015-10-01"
-  b <- I.createPsvBench
-     $ I.Command (I.InputDictionary dict) input output (Just c) I.FlagSnapshot time Nothing (1024*1024) Nothing I.FlagUseDropFile I.FlagInputPsv I.FlagInputPsvSparse I.PsvOutputSparse
+      time    = fromMaybe (Savage.error "createBenchmark: failed parsing date") $ timeOfText "2015-10-01"
+  b <- I.createPsvBench $ I.Command
+    (I.DictionaryToml dict)
+    (I.InputSparsePsv input)
+    (I.OutputSparsePsv output)
+    (Just c)
+    (I.ScopeSnapshot time)
+    (1024*1024)
+    Nothing
+    I.FlagUseDropFile
   return (name, b)
 
 releaseBenchmarks :: [(String, Bench)] -> EitherT I.BenchError IO ()

--- a/icicle-compiler/test/cli/bench/run
+++ b/icicle-compiler/test/cli/bench/run
@@ -9,7 +9,7 @@ t1_expected=test/cli/bench/t1-expected.psv
 t1_out_c=`mktemp -t icicle-bench-t1-c-XXXXXX`
 t1_out_psv=`mktemp -t icicle-bench-t1-out-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t1_dict --input $t1_in --output $t1_out_psv --output-code $t1_out_c --mode snapshot --snapshot-date 2010-01-01
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t1_dict --input-sparse-psv $t1_in --output-sparse-psv $t1_out_psv --output-code $t1_out_c --snapshot 2010-01-01
 
 diff -u $t1_expected $t1_out_psv
 
@@ -22,7 +22,7 @@ echo "OK!"
 
 echo "2a. Dropping facts that exceed the limit: input sparse, output sparse"
 
-t2_common_args="--mode snapshot --snapshot-date 2010-01-01 --input-psv sparse --output-psv sparse"
+t2_common_args="--snapshot 2010-01-01"
 t2_dict=test/cli/bench/t2-dictionary.toml
 t2_in=test/cli/bench/t2-in.psv
 
@@ -34,7 +34,7 @@ t2_c_0=`mktemp -t icicle-bench-t2-c-0-XXXXXX`
 t2_psv_0=`mktemp -t icicle-bench-t2-out-0-XXXXXX`
 t2_drop_0=`mktemp -t icicle-bench-t2-drop-0-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t2_dict --input $t2_in --output $t2_psv_0 --output-code $t2_c_0 --facts-limit 0 --drop $t2_drop_0 $t2_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_0 --output-code $t2_c_0 --facts-limit 0 --drop $t2_drop_0 $t2_common_args
 
 diff -u $t2_expected_psv_0 $t2_psv_0
 diff -u $t2_expected_drop_0 $t2_drop_0
@@ -51,7 +51,7 @@ t2_c_1=`mktemp -t icicle-bench-t2-c-1-XXXXXX`
 t2_psv_1=`mktemp -t icicle-bench-t2-out-1-XXXXXX`
 t2_drop_1=`mktemp -t icicle-bench-t2-drop-1-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t2_dict --input $t2_in --output $t2_psv_1 --output-code $t2_c_1 --facts-limit 1 --drop $t2_drop_1 $t2_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_1 --output-code $t2_c_1 --facts-limit 1 --drop $t2_drop_1 $t2_common_args
 
 diff -u $t2_expected_psv_1 $t2_psv_1
 diff -u $t2_expected_drop_1 $t2_drop_1
@@ -68,7 +68,7 @@ t2_c_2=`mktemp -t icicle-bench-t2-c-2-XXXXXX`
 t2_psv_2=`mktemp -t icicle-bench-t2-out-2-XXXXXX`
 t2_drop_2=`mktemp -t icicle-bench-t2-drop-2-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t2_dict --input $t2_in --output $t2_psv_2 --output-code $t2_c_2 --facts-limit 2 --drop $t2_drop_2 $t2_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_2 --output-code $t2_c_2 --facts-limit 2 --drop $t2_drop_2 $t2_common_args
 
 diff -u $t2_expected_psv_2 $t2_psv_2
 diff -u $t2_expected_drop_2 $t2_drop_2
@@ -79,7 +79,7 @@ rm $t2_drop_2
 
 echo "2b. Dropping facts that exceed the limit: input sparse, output dense"
 
-t2b_common_args="--mode snapshot --snapshot-date 2010-01-01 --input-psv sparse --output-psv dense"
+t2b_common_args="--snapshot 2010-01-01"
 t2b_dict=test/cli/bench/t2b-dictionary.toml
 t2b_in=test/cli/bench/t2b-in.psv
 
@@ -89,7 +89,7 @@ t2b_c=`mktemp -t icicle-bench-t2b-c-XXXXXX`
 t2b_psv=`mktemp -t icicle-bench-t2b-out-XXXXXX`
 t2b_drop=`mktemp -t icicle-bench-t2b-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t2b_dict --input $t2b_in --output $t2b_psv --output-code $t2b_c --facts-limit 1 --drop $t2b_drop $t2b_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t2b_dict --input-sparse-psv $t2b_in --output-dense-psv $t2b_psv --output-code $t2b_c --facts-limit 1 --drop $t2b_drop $t2b_common_args
 
 diff -u $t2b_expected_psv $t2b_psv
 diff -u $t2b_expected_drop $t2b_drop
@@ -104,7 +104,7 @@ echo "OK!"
 
 echo "3a. Dropping facts that exceed the limit: input dense, output sparse"
 
-t3_common_args="--mode snapshot --snapshot-date 2016-01-01 --input-psv dense --output-psv sparse"
+t3_common_args="--snapshot 2016-01-01"
 t3_dict=test/cli/bench/t3-dictionary.toml
 t3_in=test/cli/bench/t3-in.psv
 
@@ -116,7 +116,7 @@ t3_c_2=`mktemp -t icicle-bench-t3-c-XXXXXX`
 t3_psv_2=`mktemp -t icicle-bench-t3-out-XXXXXX`
 t3_drop_2=`mktemp -t icicle-bench-t3-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t3_dict --input $t3_in --output $t3_psv_2 --output-code $t3_c_2 --facts-limit 2 --drop $t3_drop_2 $t3_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t3_dict --input-dense-psv $t3_in --output-sparse-psv $t3_psv_2 --output-code $t3_c_2 --facts-limit 2 --drop $t3_drop_2 $t3_common_args
 
 diff -u $t3_expected_psv_2 $t3_psv_2
 diff -u $t3_expected_drop_2 $t3_drop_2
@@ -127,7 +127,7 @@ rm $t3_drop_2
 
 echo "3b. Dropping facts that exceed the limit: input dense, output dense"
 
-t3b_common_args="--mode snapshot --snapshot-date 2016-01-01 --input-psv dense --output-psv dense"
+t3b_common_args="--snapshot 2016-01-01"
 t3b_dict=test/cli/bench/t3b-dictionary.toml
 t3b_in=test/cli/bench/t3b-in.psv
 
@@ -137,7 +137,7 @@ t3b_c_2=`mktemp -t icicle-bench-t3b-c-XXXXXX`
 t3b_psv_2=`mktemp -t icicle-bench-t3b-out-XXXXXX`
 t3b_drop_2=`mktemp -t icicle-bench-t3b-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t3b_dict --input $t3b_in --output $t3b_psv_2 --output-code $t3b_c_2 --facts-limit 2 --drop $t3b_drop_2 $t3b_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t3b_dict --input-dense-psv $t3b_in --output-dense-psv $t3b_psv_2 --output-code $t3b_c_2 --facts-limit 2 --drop $t3b_drop_2 $t3b_common_args
 
 diff -u $t3b_expected_psv_2 $t3b_psv_2
 diff -u $t3b_expected_drop_2 $t3b_drop_2
@@ -152,7 +152,7 @@ echo "OK!"
 
 echo "4. Output missing value"
 
-t4_common_args="--mode snapshot --snapshot-date 2010-01-01 --input-psv sparse --output-psv dense"
+t4_common_args="--snapshot 2010-01-01"
 t4_dict=test/cli/bench/t4-dictionary.toml
 t4_in=test/cli/bench/t4-in.psv
 
@@ -161,7 +161,7 @@ t4_out_c=`mktemp -t icicle-bench-t4-c-XXXXXX`
 t4_out_psv=`mktemp -t icicle-bench-t4-out-XXXXXX`
 t4_drop=`mktemp -t icicle-bench-t4-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t4_dict --input $t4_in --output $t4_out_psv --output-code $t4_out_c --facts-limit 1000 --drop $t4_drop $t4_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t4_dict --input-sparse-psv $t4_in --output-dense-psv $t4_out_psv --output-code $t4_out_c --facts-limit 1000 --drop $t4_drop $t4_common_args
 
 diff -u $t4_expected $t4_out_psv
 
@@ -176,7 +176,7 @@ echo "OK!"
 
 echo "5. Use C source instead of Icicle dictionary"
 
-t5_common_args="--mode snapshot --snapshot-date 2010-01-01 --input-psv sparse --output-psv dense"
+t5_common_args="--snapshot 2010-01-01"
 t5_dict=test/cli/bench/t5-dictionary.toml
 t5_in=test/cli/bench/t5-in.psv
 
@@ -185,8 +185,8 @@ t5_out_psv_1=`mktemp -t icicle-bench-t5-out-1-XXXXXX`
 t5_out_psv_2=`mktemp -t icicle-bench-t5-out-2-XXXXXX`
 t5_drop=`mktemp -t icicle-bench-t5-drop-XXXXXX`
 
-dist/build/icicle-bench/icicle-bench --dictionary $t5_dict --input $t5_in --output $t5_out_psv_1 --output-code $t5_out_c $t5_common_args
-dist/build/icicle-bench/icicle-bench --input-code $t5_out_c --input $t5_in --output $t5_out_psv_2 $t5_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-toml $t5_dict --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_1 --output-code $t5_out_c $t5_common_args
+dist/build/icicle-bench/icicle-bench --dictionary-code $t5_out_c --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_2 $t5_common_args
 
 diff -u $t5_out_psv_1 $t5_out_psv_2
 


### PR DESCRIPTION
Make it a bit clearer which options need to be set, this is comes out of writing some o2 jobs with @nhibberd 

The new usage is:
```
Usage: icicle-bench (--dictionary-toml DICTIONARY_TOML |
                     --dictionary-code DICTIONARY_C)
                    (--input-sparse-psv INPUT_PSV |
                     --input-dense-psv INPUT_PSV |
                     --input-zebra INPUT_ZEBRA)
                    (--output-sparse-psv OUTPUT_PSV |
                     --output-dense-psv OUTPUT_PSV)
                    [--output-code DICTIONARY_C]
                    (--snapshot SNAPSHOT_DATE |
                     --chord CHORD_DESCRIPTOR)
                    [--facts-limit ARG]
                    [--drop ARG]
                    [--drop-to-output]
```

I'm thinking I might rename `icicle-bench` to `icicle` after this and add all of our normal cli stuff (`--version`, `--dependencies`, etc) given we'll have real jobs running using it

! @tranma @amosr 