### PR TITLE
Source evaluator: respect whether latest is returning array or not

### DIFF
--- a/icicle-compiler/test/Icicle/Test/Source/Progress.hs
+++ b/icicle-compiler/test/Icicle/Test/Source/Progress.hs
@@ -17,6 +17,7 @@ import           Icicle.Source.Transform.Desugar
 
 import qualified Icicle.Common.Base          as CB
 import qualified Icicle.Common.Type          as CT
+import Icicle.Data.Time (unsafeTimeOfYMD)
 
 import           P
 
@@ -45,6 +46,27 @@ prop_progress_no_values f q
     Left _
      -> discard
  | otherwise = discard
+
+
+prop_progress_no_values_QWF :: QueryWithFeature -> Property
+prop_progress_no_values_QWF qwf
+ | Right qt <- qwfCheck qwf
+ = counterexample (qwfPretty qwf)
+ $ let val = evalQ (query qt) [] (valuesForQwf qwf)
+   in  counterexample (show val) $ isRight val
+ | otherwise = discard
+
+valuesForQwf :: QueryWithFeature -> Map.Map (CB.Name T.Variable) CB.BaseValue
+valuesForQwf qwf
+ = Map.fromList
+ ( vnow <> vtime )
+ where
+  vnow = case qwfNow qwf of
+    Nothing -> []
+    Just nm -> [(nm, timezero)]
+  vtime = [(qwfTimeName qwf, timezero)]
+
+  timezero = CB.VTime $ unsafeTimeOfYMD 2000 1 1 
 
 
 return []


### PR DESCRIPTION
This fixes #493 .

The source evaluator was doing something rather stupid, perhaps because `latest` is rather stupid. Latest with an aggregate returns a single value, but latest with an element returns an array.

The source evaluator was dealing with this by just trying to evaluate as an aggregate, and if that failed trying as an array. So it was returning a single element instead of an array when it could, but the context around it was expecting an array.

I also added another test that uses `QueryWithFeature` to generate some nicer, more well typed expressions. It's still not a very good generator though.

! @tranma 