### PR TITLE
Fix melt bugs

### DIFF
--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -74,11 +74,11 @@ constructor a_fresh statements
   primLt  = primRelation Min.PrimRelationLt
   primLe  = primRelation Min.PrimRelationLe
 
-  primFold1 append xs
+  primFold1 def append xs
    = case xs of
-      []     -> xValue UnitT VUnit -- this case shouldn't happen, make it a type error
+      []     -> def
       (y:[]) -> y
-      (y:ys) -> y `append` primFold1 append ys
+      (y:ys) -> y `append` primFold1 def append ys
 
   primLogical op x y
    = xPrim (PrimMinimal (Min.PrimLogical op)) `xApp` x `xApp` y
@@ -327,9 +327,9 @@ constructor a_fresh statements
    , Just tis   <- withIndex tryMeltType t
    , prim       <- relationPrim op
    , ps         <- meltWith prim t
-   , conn       <- connectivePrim op
+   , (conn,def) <- connectivePrim op
    = Just
-   $ primFold1 conn
+   $ primFold1 def conn
    $ fmap (\(p, tvi) -> withPrim p t nx ny tvi) (List.zip ps tis)
 
    | otherwise
@@ -350,12 +350,12 @@ constructor a_fresh statements
     Min.PrimRelationNe -> primNe
 
   connectivePrim p = case p of
-    Min.PrimRelationGt -> primAnd
-    Min.PrimRelationGe -> primAnd
-    Min.PrimRelationLt -> primAnd
-    Min.PrimRelationLe -> primAnd
-    Min.PrimRelationEq -> primAnd
-    Min.PrimRelationNe -> primOr
+    Min.PrimRelationGt -> (primAnd, xFalse)
+    Min.PrimRelationGe -> (primAnd, xTrue)
+    Min.PrimRelationLt -> (primAnd, xFalse)
+    Min.PrimRelationLe -> (primAnd, xTrue)
+    Min.PrimRelationEq -> (primAnd, xTrue)
+    Min.PrimRelationNe -> (primOr, xFalse)
 
 
   -- | For a relation prim applied to t, melt prim to match members of melted t

--- a/icicle-compiler/test/Icicle/Test/Avalanche/Melt.hs
+++ b/icicle-compiler/test/Icicle/Test/Avalanche/Melt.hs
@@ -64,12 +64,15 @@ prop_melt_total t
       Right flatProgram
        -> let checked = P.checkAvalanche $ AA.eraseAnnotP flatProgram
           in case checked of
-              Left _
-               -> counterexample (show $ pretty flatProgram) False
+              Left e
+               -> counterexample (show e)
+                $ counterexample (show (pretty coreProgram))
+                $ counterexample (show $ pretty flatProgram) False
               Right p
                -> let u = unmelted (AP.statements p)
-                  in   counterexample (show $ pretty $ P.coreAvalanche coreProgram)
-                     $ counterexample (show $ pretty flatProgram)
+                  in   counterexample ("core:\n" <> show (pretty coreProgram) <> "\n")
+                     $ counterexample ("unflattened:\n" <> show (pretty $ P.coreAvalanche coreProgram) <> "\n")
+                     $ counterexample ("flat:\n" <> show (pretty flatProgram) <> "\n")
                      $ counterexample ("unmelted:\n" <> show u)
                      $ isNothing u
  where
@@ -92,7 +95,9 @@ prop_melt_total t
       InitAccumulator (Accumulator _ _ x) s
        | notAllowed (getType x)  -> Just stm
        | otherwise               -> unmelted s
-      Read _ _ _ s               -> unmelted s
+      Read _ _ vt s
+       | notAllowed vt           -> Just stm
+       | otherwise               -> unmelted s
       Write _ x
        | notAllowed (getType x)  -> Just stm
       _                          -> Nothing

--- a/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
@@ -446,8 +446,9 @@ pp :: WellTyped -> Zebra.Entity Schema -> [Zebra.Value] -> String
 pp wt entity rs =
   "Fact type = " <> show (wtFactType wt) <> "\n" <>
   "Facts = " <> ppShow (wtFacts wt) <> "\n" <>
-  "As zebra entity = \n" <> ppShow entity <>
-  "Zebra rows = \n" <> ppShow rs
+  "As zebra entity = \n" <> ppShow entity <> "\n" <>
+  "Zebra rows = \n" <> ppShow rs <>
+  "Avalanche program = \n" <> show (PP.pretty (wtAvalancheFlat wt))
 
 return []
 tests :: IO Bool

--- a/icicle-repl/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-repl/test/cli/repl/t10.3-flatten/expected
@@ -338,8 +338,6 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, 
   read map_insert_loc_vals$flat$6$simpflat$52 = map_insert_acc_vals$flat$2$simpflat$48 [Array (Buf 2 FactIdentifier)];
   read map_insert_loc_vals$flat$6$simpflat$53 = map_insert_acc_vals$flat$2$simpflat$49 [Array (Buf 2 Error)];
   read map_insert_loc_vals$flat$6$simpflat$54 = map_insert_acc_vals$flat$2$simpflat$50 [Array (Buf 2 Int)];
-  read map_insert_loc_bs_found$flat$8 = map_insert_acc_bs_found$flat$4 [Bool];
-  read map_insert_loc_bs_index$flat$7 = map_insert_acc_bs_index$flat$3 [Int];
   let map_insert_size$flat$10 = Array_length#@{Time} map_insert_loc_keys$flat$5;
   init bs_acc_found$flat$18@{Bool} = False@{Bool};
   init bs_acc_mid$flat$15@{Int} = -1@{Int};
@@ -582,8 +580,6 @@ foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$4$simpflat$
       init map_insert_acc_bs_index$flat$61@{Int} = -1@{Int};
       read map_insert_loc_keys$flat$63 = map_insert_acc_keys$flat$59 [Array Time];
       read map_insert_loc_vals$flat$64 = map_insert_acc_vals$flat$60 [Array Int];
-      read map_insert_loc_bs_found$flat$66 = map_insert_acc_bs_found$flat$62 [Bool];
-      read map_insert_loc_bs_index$flat$65 = map_insert_acc_bs_index$flat$61 [Int];
       let map_insert_size$flat$68 = Array_length#@{Time} map_insert_loc_keys$flat$63;
       init bs_acc_found$flat$76@{Bool} = False@{Bool};
       init bs_acc_mid$flat$73@{Int} = -1@{Int};
@@ -760,8 +756,6 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, 
   read map_insert_loc_vals$flat$6$simpflat$52 = map_insert_acc_vals$flat$2$simpflat$48 [Array (Buf 2 FactIdentifier)];
   read map_insert_loc_vals$flat$6$simpflat$53 = map_insert_acc_vals$flat$2$simpflat$49 [Array (Buf 2 Error)];
   read map_insert_loc_vals$flat$6$simpflat$54 = map_insert_acc_vals$flat$2$simpflat$50 [Array (Buf 2 Int)];
-  read map_insert_loc_bs_found$flat$8 = map_insert_acc_bs_found$flat$4 [Bool];
-  read map_insert_loc_bs_index$flat$7 = map_insert_acc_bs_index$flat$3 [Int];
   let map_insert_size$flat$10 = Array_length#@{Time} map_insert_loc_keys$flat$5;
   init bs_acc_found$flat$18@{Bool} = False@{Bool};
   init bs_acc_mid$flat$15@{Int} = -1@{Int};
@@ -1004,8 +998,6 @@ foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$4$simpflat$
       init map_insert_acc_bs_index$flat$61@{Int} = -1@{Int};
       read map_insert_loc_keys$flat$63 = map_insert_acc_keys$flat$59 [Array Time];
       read map_insert_loc_vals$flat$64 = map_insert_acc_vals$flat$60 [Array Int];
-      read map_insert_loc_bs_found$flat$66 = map_insert_acc_bs_found$flat$62 [Bool];
-      read map_insert_loc_bs_index$flat$65 = map_insert_acc_bs_index$flat$61 [Int];
       let map_insert_size$flat$68 = Array_length#@{Time} map_insert_loc_keys$flat$63;
       init bs_acc_found$flat$76@{Bool} = False@{Bool};
       init bs_acc_mid$flat$73@{Int} = -1@{Int};


### PR DESCRIPTION
this fixes two melt/constructor/deadcode bugs:

- don't replace `prim_eq unit unit` with `unit` (needs a default case for `fold1`)
- when we have a binding that doesn't get used and is not removed by dead code, melt will not melt it and so constructor won't get rid of it, and we are left with an unmelted value in the end (see #500)

ideally we should have a pass right after `FromCore` that freshify every name

! @amosr @jystic 
/jury approved @amosr @jystic