### PR TITLE
Zebra alloc limit

### DIFF
--- a/icicle-compiler/bench/bench.hs
+++ b/icicle-compiler/bench/bench.hs
@@ -146,8 +146,8 @@ createBenchmark (name, path) = do
     (1024*1024)
     Nothing
     I.FlagUseDropFile
-    I.defaultZebraChunkSize
-    I.defaultZebraAllocLimit
+    I.defaultZebraChunkFactCount
+    I.defaultZebraAllocLimitGB
   return (name, b)
 
 releaseBenchmarks :: [(String, Bench)] -> EitherT IcicleError IO ()

--- a/icicle-compiler/bench/bench.hs
+++ b/icicle-compiler/bench/bench.hs
@@ -146,6 +146,8 @@ createBenchmark (name, path) = do
     (1024*1024)
     Nothing
     I.FlagUseDropFile
+    I.defaultZebraChunkSize
+    I.defaultZebraAllocLimit
   return (name, b)
 
 releaseBenchmarks :: [(String, Bench)] -> EitherT IcicleError IO ()

--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -257,6 +257,7 @@ test-suite test
                      , temporary
                      , text
                      , transformers
+                     , unix                            == 2.7.*
                      , vector                          == 0.11.*
                      , semigroups                      >= 0.16       && < 0.19
 

--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -136,6 +136,7 @@ library
                        Icicle.Sea.Eval.Program
                        Icicle.Sea.Fleet
                        Icicle.Sea.IO
+                       Icicle.Sea.IO.Offset
                        Icicle.Sea.IO.Base
                        Icicle.Sea.IO.Psv
                        Icicle.Sea.IO.Psv.Input

--- a/icicle-compiler/main/icicle.hs
+++ b/icicle-compiler/main/icicle.hs
@@ -78,6 +78,8 @@ pQuery =
     <*> pLimit
     <*> pDrop
     <*> pFlagDrop
+    <*> pZebraChunkSize
+    <*> pZebraAllocLimit
 
 pDictionaryFile :: Parser DictionaryFile
 pDictionaryFile =
@@ -193,6 +195,20 @@ pFlagDrop =
   flag FlagUseDropFile FlagNoUseDropFile $
     long "drop-to-output" <>
     help "write partial results to dropped-X.txt or normal output"
+
+pZebraChunkSize :: Parser ZebraChunkSize
+pZebraChunkSize =
+  flip option (long "zebra-chunk-size" <> value defaultZebraChunkSize) $
+    readerAsk >>= \s -> case readMaybe s of
+      Just i  -> return (ZebraChunkSize i)
+      Nothing -> readerError "--chunk-size NUMBER_BYTES"
+
+pZebraAllocLimit :: Parser ZebraAllocLimit
+pZebraAllocLimit =
+  flip option (long "zebra-alloc-limit" <> value defaultZebraAllocLimit) $
+    readerAsk >>= \s -> case readMaybe s of
+      Just i  -> return (ZebraAllocLimit i)
+      Nothing -> readerError "--zebra-alloc-limit NUMBER_BYTES"
 
 ------------------------------------------------------------------------
 

--- a/icicle-compiler/main/icicle.hs
+++ b/icicle-compiler/main/icicle.hs
@@ -78,8 +78,8 @@ pQuery =
     <*> pLimit
     <*> pDrop
     <*> pFlagDrop
-    <*> pZebraChunkSize
-    <*> pZebraAllocLimit
+    <*> pZebraChunkFactCount
+    <*> pZebraAllocLimitGB
 
 pDictionaryFile :: Parser DictionaryFile
 pDictionaryFile =
@@ -196,19 +196,19 @@ pFlagDrop =
     long "drop-to-output" <>
     help "write partial results to dropped-X.txt or normal output"
 
-pZebraChunkSize :: Parser ZebraChunkSize
-pZebraChunkSize =
-  flip option (long "zebra-chunk-size" <> value defaultZebraChunkSize) $
+pZebraChunkFactCount :: Parser ZebraChunkFactCount
+pZebraChunkFactCount =
+  flip option (long "zebra-chunk-fact-count" <> value defaultZebraChunkFactCount) $
     readerAsk >>= \s -> case readMaybe s of
-      Just i  -> return (ZebraChunkSize i)
-      Nothing -> readerError "--chunk-size NUMBER_BYTES"
+      Just i  -> return (ZebraChunkFactCount i)
+      Nothing -> readerError "--zebra-chunk-fact-count NUMBER_FACTS"
 
-pZebraAllocLimit :: Parser ZebraAllocLimit
-pZebraAllocLimit =
-  flip option (long "zebra-alloc-limit" <> value defaultZebraAllocLimit) $
+pZebraAllocLimitGB :: Parser ZebraAllocLimitGB
+pZebraAllocLimitGB =
+  flip option (long "zebra-alloc-limit-gb" <> value defaultZebraAllocLimitGB) $
     readerAsk >>= \s -> case readMaybe s of
-      Just i  -> return (ZebraAllocLimit i)
-      Nothing -> readerError "--zebra-alloc-limit NUMBER_BYTES"
+      Just i  -> return (ZebraAllocLimitGB i)
+      Nothing -> readerError "--zebra-alloc-limit-gb NUMBER_GB"
 
 ------------------------------------------------------------------------
 

--- a/icicle-compiler/src/Icicle/Command.hs
+++ b/icicle-compiler/src/Icicle/Command.hs
@@ -93,9 +93,9 @@ data Query a = Query {
   -- ^ only applies to psv input
   , queryUseDrop         :: FlagUseDrop
   -- ^ only applies to psv input
-  , queryChunkSize       :: ZebraChunkSize
+  , queryChunkFactCount       :: ZebraChunkFactCount
   -- ^ only applies to zebra input
-  , queryAllocLimit      :: ZebraAllocLimit
+  , queryAllocLimitGB      :: ZebraAllocLimitGB
   -- ^ only applies to zebra input
   }
 
@@ -116,9 +116,9 @@ data QueryOptions = QueryOptions {
   -- ^ only applies to psv input
   , optDrop         :: Maybe FilePath
   , optUseDrop      :: FlagUseDrop
-  , optChunkSize    :: ZebraChunkSize
+  , optChunkFactCount    :: ZebraChunkFactCount
   -- ^ only applies to zebra input
-  , optAllocLimit   :: ZebraAllocLimit
+  , optAllocLimitGB   :: ZebraAllocLimitGB
   -- ^ only applies to zebra input
   } deriving (Eq, Ord, Show)
 
@@ -223,8 +223,8 @@ createQuery c = do
     , queryFactsLimit      = optFactsLimit c
     , queryDropPath        = dropPath
     , queryUseDrop         = optUseDrop c
-    , queryChunkSize       = optChunkSize c
-    , queryAllocLimit      = optAllocLimit c
+    , queryChunkFactCount       = optChunkFactCount c
+    , queryAllocLimitGB      = optAllocLimitGB c
     }
 
 mkQueryFleet ::
@@ -379,8 +379,8 @@ runZebraQuery b = do
       output     = queryOutputPath   b
       chordPath  = queryChordPath    b
       dropPath   = queryDropPath     b
-      chunkSize  = queryChunkSize    b
-      allocLimit = queryAllocLimit   b
+      chunkSize  = queryChunkFactCount b
+      allocLimit = queryAllocLimitGB   b
 
   start <- liftIO getCurrentTime
   stats <- firstEitherT IcicleSeaError $

--- a/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
+++ b/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
@@ -322,11 +322,9 @@ codeOfPrograms input attributes programs = do
               [ defOfPsvInput (psvInputConfig conf)
               , defOfPsvOutput (psvOutputConfig conf) ]
             -- FIXME property separate what is needed from psv
-            FormatZebra conf _ _ -> vsep
+            FormatZebra _ _ _ -> vsep
               [ "#define ICICLE_PSV_INPUT_SPARSE 1"
-              , "#define ICICLE_ZEBRA 1"
-              -- FIXME move to config
-              , "static const int zebra_chunk_fact_count = " <> (pretty (zebraChunkFactCount conf)) <> ";" ]
+              , "#define ICICLE_ZEBRA 1" ]
 
       pure . textOfDoc . vsep $ [ def, seaPreamble, defs ] <> progs <> ["", doc]
 

--- a/icicle-compiler/src/Icicle/Sea/IO.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO.hs
@@ -13,8 +13,8 @@ module Icicle.Sea.IO
   , defaultPsvInputBufferSize
   , defaultPsvOutputBufferSize
   , defaultZebraConfig
-  , defaultZebraChunkSize
-  , defaultZebraAllocLimit
+  , defaultZebraChunkFactCount
+  , defaultZebraAllocLimitGB
 
   , Mode(..)
   , IOFormat (..)
@@ -28,8 +28,10 @@ module Icicle.Sea.IO
   , PsvOutputConfig(..)
   , PsvOutputFormat(..)
   , ZebraConfig (..)
-  , ZebraChunkSize (..)
-  , ZebraAllocLimit (..)
+  , ZebraChunkFactCount (..)
+  , ZebraAllocLimitGB (..)
+
+  , module Icicle.Sea.IO.Offset
   ) where
 
 import           Icicle.Internal.Pretty
@@ -39,6 +41,7 @@ import           Icicle.Data
 import           Icicle.Sea.Error (SeaError(..))
 import           Icicle.Sea.FromAvalanche.State
 
+import           Icicle.Sea.IO.Offset
 import           Icicle.Sea.IO.Base
 import           Icicle.Sea.IO.Psv
 import           Icicle.Sea.IO.Zebra

--- a/icicle-compiler/src/Icicle/Sea/IO.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO.hs
@@ -13,6 +13,8 @@ module Icicle.Sea.IO
   , defaultPsvInputBufferSize
   , defaultPsvOutputBufferSize
   , defaultZebraConfig
+  , defaultZebraChunkSize
+  , defaultZebraAllocLimit
 
   , Mode(..)
   , IOFormat (..)
@@ -26,6 +28,8 @@ module Icicle.Sea.IO
   , PsvOutputConfig(..)
   , PsvOutputFormat(..)
   , ZebraConfig (..)
+  , ZebraChunkSize (..)
+  , ZebraAllocLimit (..)
   ) where
 
 import           Icicle.Internal.Pretty

--- a/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE NoImplicitPrelude #-}
-
--- * Offsets into statically defined or generated C structs.
 module Icicle.Sea.IO.Offset where
 
 import P

--- a/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
@@ -1,0 +1,228 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+
+-- * Offsets into statically defined or generated C structs.
+module Icicle.Sea.IO.Offset where
+
+import P
+
+import Icicle.Sea.FromAvalanche.State
+
+
+-- typedef struct {
+--     const char *input_path;
+--     iint_t output_fd;
+--     iint_t chord_fd;
+--     iint_t drop_fd;
+--     const char  *error;
+--     iint_t fact_count;
+--     iint_t entity_count;
+--     const size_t output_buffer_size;
+--     const size_t chunk_size;
+--     const size_t alloc_limit;
+-- } zebra_config_t;
+
+zebraConfigCount :: Int
+zebraConfigCount = 10
+
+zebraConfigInputPath :: Int
+zebraConfigInputPath = 0
+
+zebraConfigOutputFd :: Int
+zebraConfigOutputFd = 1
+
+zebraConfigChordFd :: Int
+zebraConfigChordFd = 2
+
+zebraConfigDropFd :: Int
+zebraConfigDropFd = 3
+
+zebraConfigError :: Int
+zebraConfigError = 4
+
+zebraConfigFactCount :: Int
+zebraConfigFactCount = 5
+
+zebraConfigEntityCount :: Int
+zebraConfigEntityCount = 6
+
+zebraConfigOutputBufferSize :: Int
+zebraConfigOutputBufferSize = 7
+
+zebraConfigChunkSize :: Int
+zebraConfigChunkSize = 8
+
+zebraConfigAllocLimit :: Int
+zebraConfigAllocLimit = 9
+
+--------------------------------------------------------------------------------
+
+-- typedef struct zebra_state {
+--     char *output_start;
+--     char *output_end;
+--     char *output_ptr;
+--     iint_t fact_count;
+--     iint_t entity_count;
+--     ifleet_t *fleet;
+--     int output_fd;
+--     int drop_fd;
+--     int64_t  attribute_count;
+--     int64_t *entity_fact_offset;
+--     int64_t *entity_fact_count;
+--     int64_t  chunk_size;
+--     int64_t  alloc_limit;
+--     int64_t  entity_alloc_count;
+-- } zebra_state_t;
+
+zebraStateCount :: Int
+zebraStateCount = 14
+
+zebraStateOutputStart :: Int
+zebraStateOutputStart = 0
+
+zebraStateOutputEnd :: Int
+zebraStateOutputEnd = 1
+
+zebraStateOutputPtr :: Int
+zebraStateOutputPtr = 2
+
+zebraStateFactCount :: Int
+zebraStateFactCount = 3
+
+zebraStateEntityCount :: Int
+zebraStateEntityCount = 4
+
+zebraStateFleet :: Int
+zebraStateFleet = 5
+
+zebraStateOutputFd :: Int
+zebraStateOutputFd = 6
+
+zebraStateDropFd :: Int
+zebraStateDropFd = 7
+
+zebraStateAttributeCount :: Int
+zebraStateAttributeCount = 8
+
+zebraStateEntityFactOffset :: Int
+zebraStateEntityFactOffset = 9
+
+zebraStateEntityFactCount :: Int
+zebraStateEntityFactCount = 10
+
+zebraStateChunkSize :: Int
+zebraStateChunkSize = 11
+
+zebraStateAllocLimit :: Int
+zebraStateAllocLimit = 12
+
+zebraStateEntityAllocCount :: Int
+zebraStateEntityAllocCount = 13
+
+--------------------------------------------------------------------------------
+
+--struct ifleet {
+--    anemone_mempool_t *mempool;
+--    iint_t           max_chord_count;
+--    iint_t           chord_count;
+--    itime_t         *chord_times;
+--    iprogram_0_t    *iprogram_0; /* a_double */
+--    iprogram_1_t    *iprogram_1; /* d_string */
+--    ...
+--    itime_t          last_time_0; /* a_double */
+--    itime_t          last_time_1; /* d_string */
+--    ...
+--    iint_t           icount_0; /* a_double */
+--    iint_t           icount_1; /* d_string */
+--    ...
+--};
+
+fleetMempool :: Int
+fleetMempool = 0
+
+fleetMaxChordCount :: Int
+fleetMaxChordCount = 1
+
+fleetChordCount :: Int
+fleetChordCount = 2
+
+fleetChordTimes :: Int
+fleetChordTimes = 3
+
+fleetProgramOf :: Int -> Int
+fleetProgramOf ix = 4 + ix
+
+fleetLastTimeOf :: Int -> Int
+fleetLastTimeOf ix = 4 + 2 * ix
+
+fleetCountOf :: Int -> Int
+fleetCountOf ix = 4 + 3 * ix
+
+--------------------------------------------------------------------------------
+
+--typedef struct {
+--    anemone_mempool_t *mempool;
+--    input_a_double_t input;
+--    ierror_t         a_ix_0;
+--    idouble_t        a_ix_1;
+--    ibool_t          has_acc_a_conv_4_simpflat_14;
+--    idouble_t        res_acc_a_conv_4_simpflat_14;
+--    ibool_t          has_acc_a_conv_4_simpflat_13;
+--    ierror_t         res_acc_a_conv_4_simpflat_13;
+--    ibool_t          has_acc_a_conv_8_simpflat_18;
+--    ierror_t         res_acc_a_conv_8_simpflat_18;
+--    ibool_t          has_acc_a_conv_8_simpflat_19;
+--    idouble_t        res_acc_a_conv_8_simpflat_19;
+--    ibool_t          has_acc_a_s_reify_4_conv_9_simpflat_26;
+--    idouble_t        res_acc_a_s_reify_4_conv_9_simpflat_26;
+--    ibool_t          has_acc_a_s_reify_4_conv_9_simpflat_25;
+--    ierror_t         res_acc_a_s_reify_4_conv_9_simpflat_25;
+--    ibool_t          has_acc_a_s_reify_4_conv_9_simpflat_27;
+--    idouble_t        res_acc_a_s_reify_4_conv_9_simpflat_27;
+--} iprogram_0_t;
+
+programMempool :: Int
+programMempool = 0
+
+programInput :: Int
+programInput = 1
+
+programOutputStart :: Int -> Int
+programOutputStart inputSize = 3 + inputSize
+
+--------------------------------------------------------------------------------
+
+-- typedef struct {
+--     itime_t          a_conv_3;
+--     iint_t           new_count;
+--     ierror_t         *new_a_conv_0_simpflat_96;
+--     idouble_t        *new_a_conv_0_simpflat_97;
+--     itime_t          *new_a_conv_0_simpflat_98;
+-- } input_a_double_t;
+
+inputFactTime :: Int
+inputFactTime = 0
+
+inputNewCount :: Int
+inputNewCount = 1
+
+inputError :: Int
+inputError = 2
+
+inputStart :: Int
+inputStart = 3
+
+inputFieldsCount :: SeaProgramState -> Int
+inputFieldsCount state =
+  length (stateInputVars state) - 2
+
+programInputFactTime :: Int
+programInputFactTime = 1
+
+programInputNewCount :: Int
+programInputNewCount = 2
+
+programInputError :: Int
+programInputError = 3
+
+programInputStart :: Int
+programInputStart = 4

--- a/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
@@ -48,11 +48,11 @@ zebraConfigEntityCount = 6
 zebraConfigOutputBufferSize :: Int
 zebraConfigOutputBufferSize = 7
 
-zebraConfigChunkSize :: Int
-zebraConfigChunkSize = 8
+zebraConfigChunkFactCount :: Int
+zebraConfigChunkFactCount = 8
 
-zebraConfigAllocLimit :: Int
-zebraConfigAllocLimit = 9
+zebraConfigAllocLimitBytes :: Int
+zebraConfigAllocLimitBytes = 9
 
 --------------------------------------------------------------------------------
 
@@ -109,11 +109,11 @@ zebraStateEntityFactOffset = 9
 zebraStateEntityFactCount :: Int
 zebraStateEntityFactCount = 10
 
-zebraStateChunkSize :: Int
-zebraStateChunkSize = 11
+zebraStateChunkFactCount :: Int
+zebraStateChunkFactCount = 11
 
-zebraStateAllocLimit :: Int
-zebraStateAllocLimit = 12
+zebraStateAllocLimitGB :: Int
+zebraStateAllocLimitGB = 12
 
 zebraStateEntityAllocCount :: Int
 zebraStateEntityAllocCount = 13
@@ -211,7 +211,7 @@ inputError = 2
 inputStart :: Int
 inputStart = 3
 
-inputFieldsCount :: SeaProgramState -> Int
+inputFieldsCount :: SeaProgramAttribute -> Int
 inputFieldsCount state =
   length (stateInputVars state) - 2
 

--- a/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
@@ -2,11 +2,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Icicle.Sea.IO.Zebra (
     ZebraConfig (..)
-  , ZebraChunkSize (..)
-  , ZebraAllocLimit (..)
+  , ZebraChunkFactCount (..)
+  , ZebraAllocLimitGB (..)
   , defaultZebraConfig
-  , defaultZebraChunkSize
-  , defaultZebraAllocLimit
+  , defaultZebraChunkFactCount
+  , defaultZebraAllocLimitGB
   , seaOfZebraDriver
   ) where
 
@@ -25,24 +25,24 @@ import           P
 
 
 data ZebraConfig = ZebraConfig {
-    zebraChunkSize  :: !ZebraChunkSize
-  , zebraAllocLimit :: !ZebraAllocLimit
+    zebraChunkFactCount  :: !ZebraChunkFactCount
+  , zebraAllocLimitGB :: !ZebraAllocLimitGB
   } deriving (Eq, Show)
 
-newtype ZebraChunkSize = ZebraChunkSize { unZebraChunkSize :: Int }
+newtype ZebraChunkFactCount = ZebraChunkFactCount { unZebraChunkFactCount :: Int }
   deriving (Eq, Ord, Show)
 
-newtype ZebraAllocLimit = ZebraAllocLimit { unZebraAllocLimit :: Int }
+newtype ZebraAllocLimitGB = ZebraAllocLimitGB { unZebraAllocLimitGB :: Int }
   deriving (Eq, Ord, Show)
 
 defaultZebraConfig :: ZebraConfig
-defaultZebraConfig = ZebraConfig defaultZebraChunkSize defaultZebraAllocLimit
+defaultZebraConfig = ZebraConfig defaultZebraChunkFactCount defaultZebraAllocLimitGB
 
-defaultZebraChunkSize :: ZebraChunkSize
-defaultZebraChunkSize = ZebraChunkSize 128
+defaultZebraChunkFactCount :: ZebraChunkFactCount
+defaultZebraChunkFactCount = ZebraChunkFactCount 128
 
-defaultZebraAllocLimit :: ZebraAllocLimit
-defaultZebraAllocLimit = ZebraAllocLimit (2 * 1024 * 1024 * 1024)
+defaultZebraAllocLimitGB :: ZebraAllocLimitGB
+defaultZebraAllocLimitGB = ZebraAllocLimitGB 2
 
 seaOfZebraDriver :: [Attribute] -> [SeaProgramAttribute] -> Either SeaError Doc
 seaOfZebraDriver concretes states = do

--- a/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
@@ -615,5 +615,5 @@ withSeaLibrary opts code =
 return []
 tests :: IO Bool
 tests = releaseLibraryAfterTests $ do
-  $checkAllWith TestRunMore checkArgs
+  $checkAllWith TestRunNormal checkArgs
 

--- a/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
@@ -15,6 +15,9 @@ import qualified Data.List as List
 import           Data.List.NonEmpty ( NonEmpty(..) )
 import qualified Data.ByteString.Char8 as ByteString
 import qualified Data.Text.Encoding as Text
+import qualified Data.Text.IO as Text
+import qualified Data.Text as Text
+import           Data.Map.Strict (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as Boxed
 import qualified Data.Vector.Storable as Storable
@@ -25,19 +28,23 @@ import           Foreign
 import           Foreign.C.String
 
 import           System.IO
+import           System.IO.Temp (createTempDirectory)
+import           System.Directory (getTemporaryDirectory, removeDirectoryRecursive)
+import qualified System.Posix as Posix
 
 import qualified Prelude as Savage
 
 import           P
 
-import           X.Control.Monad.Trans.Either (EitherT, hoistEither, firstEitherT, bracketEitherT')
+import           X.Control.Monad.Trans.Either (EitherT, hoistEither, firstEitherT, bracketEitherT', runEitherT, hoistMaybe)
 
 import           Disorder.Core.IO (testIO)
 import           Disorder.Jack (Property, Jack)
-import           Disorder.Jack (gamble, noShrink, arbitrary, (===), justOf, vectorOf, suchThat)
+import           Disorder.Jack (gamble, arbitrary, (===), justOf, vectorOf, suchThat, counterexample)
 
 import           Jetski
 
+import           Anemone.Foreign.Mempool (Mempool)
 import qualified Anemone.Foreign.Mempool as Mempool
 import           Anemone.Foreign.Segv (withSegv)
 
@@ -70,82 +77,153 @@ import qualified Icicle.Test.Foreign.Utils as Test
 --
 prop_read_entity :: Property
 prop_read_entity =
-  gamble (justOf zebra) $ \(ZebraWellTyped wt ty entity rows chunk_step) ->
-  testIO . withSegv (pp chunk_step wt entity rows) . bracket Mempool.create Mempool.free $ \pool -> do
-    c_entity <- Zebra.foreignOfEntity pool entity
-    Test.runRight $ do
-      code <- hoistEither $ codeOf chunk_step testAllocLimit wt
-      opts <- getCompilerOptions
-      bracketEitherT'
-        (firstEitherT SeaJetskiError $ compileLibrary NoCacheLibrary opts code)
-        (firstEitherT SeaJetskiError . releaseLibrary)
-        (\src -> do
-          init <- firstEitherT SeaJetskiError $ function src "zebra_alloc_state" (retPtr retVoid)
-          finish <- firstEitherT SeaJetskiError $ function src "zebra_collect_state" (retPtr retVoid)
-          test_read_entity <- firstEitherT SeaJetskiError $ function src "test_zebra_read_entity" (retPtr retWord8)
-          test_fleet <- firstEitherT SeaJetskiError $ function src "test_setup_fleet" (retPtr retVoid)
+  gamble jZebraChunkFactCount $ \chunkFactCount ->
+  gamble jZebraWellTyped $ \zwt ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> Test.runRight $ do
+    let
+      wt =
+        zWellTyped $ zwt
+      hasFacts =
+        fmap (atFact . snd) $ List.zip (wtEntities wt) (wtFacts wt)
+    Result inputs dropped <- runTest pool chunkFactCount testAllocLimitBytes zwt
+    return $ counterexample ("Read Inputs = " <> ppShow inputs)
+           $ counterexample ("Dropped Entities = " <> ppShow dropped)
+           $ counterexample ("Facts = " <> ppShow (zFacts zwt))
+           $ concatMap snd inputs === hasFacts
 
-          withWords 7 $ \config -> do
-            pokeWordOff config 6 defaultPsvOutputBufferSize
-            bracketEitherT'
-              (liftIO (init [ argPtr nullPtr, argPtr config, argInt64 1 ]))
-              (\state -> (liftIO (finish [ argPtr config, argPtr state ])))
-              (\state -> do
-                 fleet_ptr <- peekWordOff state 5
-                 struct_count <- (\x -> x - 2) . length . stateInputVars <$>
-                   hoistEither (stateOfPrograms 0 (wtAttribute wt) (wtAvalancheFlat wt :| []))
+--
+-- Each entity is either read or dropped if they exceed the allocation limit
+--
+prop_read_or_drop_entity :: Property
+prop_read_or_drop_entity =
+  gamble jZebraChunkFactCount $ \chunkFactCount ->
+  gamble jZebraAllocLimitBytes $ \allocLimitBytes ->
+  gamble jZebraWellTyped $ \zwt ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> Test.runRight $ do
+    let
+      wt =
+        zWellTyped $ zwt
+      hasFacts =
+        fmap fst $ List.zip (wtEntities wt) (wtFacts wt)
+    Result inputs dropped <- runTest pool chunkFactCount allocLimitBytes zwt
+    return $ counterexample ("Read Inputs = " <> ppShow inputs)
+           $ counterexample ("Dropped Entities = " <> ppShow dropped)
+           $ counterexample ("Facts = " <> ppShow (zFacts zwt))
+           $ List.sort (fmap fst inputs <> dropped) === List.sort hasFacts
 
-                 let
-                   facts =
-                     fmap atFact (wtFacts wt)
 
-                   n_facts =
-                     length facts
+data Result = Result {
+    resultRead :: [(Entity, [BaseValue])]
+  , resultDropped :: [Entity]
+  } deriving (Eq, Show)
 
-                   step =
-                     unZebraChunkSize chunk_step
+instance Monoid Result where
+  mempty =
+    Result mempty mempty
+  mappend (Result xs ys) (Result as bs) =
+    Result (xs <> as) (ys <> bs)
 
-                   chunk_lengths =
-                     List.replicate (n_facts `div` step) step <> [ n_facts `rem` step ]
+runTest ::
+     Mempool
+  -> ZebraChunkFactCount
+  -> Int
+  -> ZebraWellTyped
+  -> EitherT SeaError IO Result
+runTest pool chunk_step alloc_limit_bytes zwt@(ZebraWellTyped wt facts entities) =
+  join . liftIO . liftM hoistEither . withSegv (pp chunk_step alloc_limit_bytes zwt) $ do
+    results <- forM entities $ \(ty, entity) -> do
+      c_entity <- Zebra.foreignOfEntity pool entity
+      runEitherT $ do
+        code <- hoistEither $ codeOf wt
+        opts <- getCompilerOptions
 
-                   entity_id =
-                     ByteString.unpack . Zebra.unEntityId . Zebra.entityId $ entity
+        withSystemTempDirectory "zebra-test-" $ \dir -> let drop_fp = dir <> "/drop.txt" in
+          withWritableFd drop_fp $ \drop_fd ->
+            withSeaLibrary opts code $ \src -> do
+              init <- firstEitherT SeaJetskiError $ function src "zebra_alloc_state" (retPtr retVoid)
+              finish <- firstEitherT SeaJetskiError $ function src "zebra_collect_state" (retPtr retVoid)
+              test_read_entity <- firstEitherT SeaJetskiError $ function src "test_zebra_read_entity" (retPtr retWord8)
+              test_fleet <- firstEitherT SeaJetskiError $ function src "test_setup_fleet" (retPtr retVoid)
+              test_check_limit <- firstEitherT SeaJetskiError $ function src "test_check_limit" Test.retBool
 
-                 inputs <- forM chunk_lengths $ \len -> do
-                   liftIO . withCStringLen entity_id $ \(id_bytes, id_length) -> do
-                       e1 <- test_fleet
-                               [ argPtr id_bytes
-                               , argInt32 (fromIntegral id_length)
-                               , argPtr nullPtr
-                               , argPtr fleet_ptr ]
-                       when (e1 /= nullPtr) $
-                         fail "failed to configure fleet"
+              withWords zebraConfigCount $ \config -> do
+                pokeWordOff config zebraConfigDropFd drop_fd
+                pokeWordOff config zebraConfigOutputBufferSize defaultPsvOutputBufferSize
+                pokeWordOff config zebraConfigChunkFactCount (unZebraChunkFactCount chunk_step)
+                pokeWordOff config zebraConfigAllocLimitBytes alloc_limit_bytes
 
-                       e2 <- test_read_entity
-                               [ argPtr nullPtr
-                                , argPtr state
-                               , argPtr (Zebra.unCEntity c_entity) ]
-                       when (e2 /= nullPtr) $ do
-                         err <- peekCString (castPtr e2)
-                         fail $ "failed to read entity: " <> err
+                bracketEitherT'
+                  (liftIO (init [ argPtr nullPtr, argPtr config, argInt64 1 ]))
+                  (\state -> (liftIO (finish [ argPtr config, argPtr state ])))
+                  (\state -> do
+                     fleet_ptr <- peekWordOff state zebraStateFleet
+                     struct_count <- inputFieldsCount <$>
+                       hoistEither (stateOfPrograms 0 (wtAttribute wt) (wtAvalancheFlat wt :| []))
+                     fact_count <- hoistMaybe (SeaZebraError "test_impossible") . fmap length $
+                       Map.lookup (Entity . Text.decodeUtf8 . Zebra.unEntityId . Zebra.entityId $ entity) facts
 
-                   saveInputs ty struct_count len fleet_ptr
 
-                 return $ facts === List.concat inputs
-              )
-        )
+                     let
+                       step =
+                         unZebraChunkFactCount chunk_step
+
+                       chunk_lengths =
+                         List.replicate (fact_count `div` step) step <> [ fact_count `rem` step ]
+
+                       entity_id =
+                         ByteString.unpack . Zebra.unEntityId . Zebra.entityId $ entity
+
+                     read_inputs <- forM chunk_lengths $ \len -> do
+                       dropped <- liftIO . withCStringLen entity_id $ \(id_bytes, id_length) -> do
+                           e1 <- test_fleet
+                                   [ argPtr id_bytes
+                                   , argInt32 (fromIntegral id_length)
+                                   , argPtr nullPtr
+                                   , argPtr fleet_ptr ]
+                           when (e1 /= nullPtr) $
+                             fail "failed to configure fleet"
+
+                           e2 <- test_read_entity
+                                   [ argPtr nullPtr
+                                   , argPtr state
+                                   , argPtr (Zebra.unCEntity c_entity) ]
+                           when (e2 /= nullPtr) $ do
+                             err <- peekCString (castPtr e2)
+                             fail $ "failed to read entity: " <> err
+
+                           x <- test_check_limit
+                                  [ argPtr state
+                                  , argPtr (Zebra.unCEntity c_entity) ]
+                           return x
+
+                       let
+                         saveIt
+                           | dropped =
+                               return Nothing
+                           | otherwise = do
+                               x <- saveInputs ty struct_count len fleet_ptr
+                               return . Just $ (Entity . Text.pack $ entity_id, x)
+
+                       saveIt
+
+                     dropped_entity <- liftIO (fmap Entity . List.nub . Text.lines <$> Text.readFile drop_fp)
+
+                     let
+                       inputs = catMaybes read_inputs
+
+                     return (Result inputs dropped_entity)
+                  )
+    return . fmap mconcat . sequence $ results
 
 saveInputs :: ValType -> Int -> Int -> Ptr a -> EitherT SeaError IO [BaseValue]
 saveInputs ty struct_count fact_count fleet_ptr =
   bracketEitherT' (liftIO $ mallocBytes (struct_count * 8)) (liftIO . free) $ \buf -> do
-    -- iprogram: { *mempool, input, ... }
-    -- input: { *chord_time, *fact_count, *tombstone, *input_start, ... }
-    program_ptr <- peekWordOff fleet_ptr 4
-    tombstones_ptr <- peekWordOff program_ptr 3
+    program_ptr <- peekWordOff fleet_ptr (fleetProgramOf 0)
+    tombstones_ptr <- peekWordOff program_ptr programInputError
 
     let
       input_start
-        = 4
+        = programInputStart
 
       -- slice out the input fields at the index (kind of like a transpose)
       -- e.g slice out the second fact:
@@ -188,23 +266,37 @@ data TestError
   deriving (Show)
 
 data ZebraWellTyped = ZebraWellTyped {
-    zWelltyped    :: WellTyped
-  , zFactType     :: ValType -- wtFactType = Sum Error FactType
-  , zEntity       :: Zebra.Entity Schema
-  , zRows         :: [Zebra.Value]
-  , zChunkSize    :: ZebraChunkSize
+    zWellTyped    :: WellTyped
+  , zFacts        :: Map Entity [BaseValue]
+  -- ^ facts grouped by entity
+  , zEntity       :: [(ValType, Zebra.Entity Schema)]
+  -- ^ zebra entity and type where wtFactType = Sum Error type
   }
 
 instance Show ZebraWellTyped where
-  show (ZebraWellTyped wt _ e rs size) =
-    pp size wt e rs
+  show z =
+    let
+      wt = zWellTyped z
+    in
+      "Entities = " <> show (wtEntities wt) <> "\n" <>
+      "Fact type = " <> show (wtFactType wt) <> "\n" <>
+      "Facts = " <> ppShow (wtFacts wt) <> "\n" <>
+      -- "As Zebra values = \n" <> ppShow rows <> "\n" <>
+      "As Zebra entities = \n" <> ppShow (zEntity z) <>
+      -- "Avalanche program = \n" <> show (PP.pretty (wtAvalancheFlat wt)) <>
+      "\n"
 
-jZebraChunkSize :: Jack ZebraChunkSize
-jZebraChunkSize = ZebraChunkSize <$>
+jZebraChunkFactCount :: Jack ZebraChunkFactCount
+jZebraChunkFactCount = ZebraChunkFactCount <$>
   arbitrary `suchThat` (>= 1)
 
-zebra :: Jack (Maybe ZebraWellTyped)
-zebra = noShrink $ do
+-- Use bytes instead of GBs for testing
+jZebraAllocLimitBytes :: Jack Int
+jZebraAllocLimitBytes =
+  arbitrary `suchThat` (> 0)
+
+jZebraWellTyped :: Jack ZebraWellTyped
+jZebraWellTyped = justOf $ do
   -- we don't read arrays (except of bytes) in zebra
   let
     supportedInputType x =
@@ -214,22 +306,41 @@ zebra = noShrink $ do
   wt <- arbitrary `suchThat` supportedInputType
   zebraOfWellTyped wt
 
+-- FIXME ignoring fact times for now, but to test it we should convert icicle time to 1600 epoch secs here
+-- let ts = fmap (Zebra.Time . fromIntegral . Icicle.secondsCountJulian . atTime) (wtFacts wt)
 zebraOfWellTyped :: WellTyped -> Jack (Maybe ZebraWellTyped)
-zebraOfWellTyped wt =
-  case zebraOfFacts (wtFactType wt) (fmap atFact (wtFacts wt)) of
-    Left e ->
-      Savage.error (show e)
-    Right Nothing ->
-      return Nothing
-    Right (Just (ty, tombstones, rows, table)) -> do
-      -- FIXME ignoring fact times for now, but to test it we should convert icicle time to 1600 epoch secs here
-      -- let ts = fmap (Zebra.Time . fromIntegral . Icicle.secondsCountJulian . atTime) (wtFacts wt)
-      let ts = List.replicate (length (wtFacts wt)) 0
-      ps <- vectorOf (length ts) Zebra.jFactsetId
-      let attribute = Zebra.Attribute (Storable.fromList ts) (Storable.fromList ps) (Storable.fromList tombstones) table
-      entity <- uncurry Zebra.Entity <$> Zebra.jEntityHashId <*> pure (Boxed.singleton attribute)
-      size <- jZebraChunkSize
-      pure . Just $ ZebraWellTyped wt ty entity rows size
+zebraOfWellTyped wt@(WellTyped entities _ ty facts _ _ _ _)= do
+  let
+    ins (k, x) m =
+      Map.insertWith (<>) k [atFact x] m
+
+    grouped =
+      foldr ins Map.empty (List.zip entities facts)
+
+  xs <- forM (Map.toList grouped) $ \(entity, values) -> do
+    case zebraOfFacts ty values of
+      Left e ->
+        Savage.error (show e)
+      Right Nothing ->
+        return Nothing
+      Right (Just (t, tombstones, _, table)) -> do
+        let
+          e =
+            Zebra.EntityId (Text.encodeUtf8 (getEntity entity))
+
+          n =
+            length values
+
+        attribute <- Zebra.Attribute
+          <$> pure (Storable.fromList (List.replicate n 0))
+          <*> (Storable.fromList <$> vectorOf n Zebra.jFactsetId)
+          <*> pure (Storable.fromList tombstones)
+          <*> pure table
+
+        return . Just $ (t, Zebra.Entity (Zebra.hashEntityId e) e (Boxed.singleton attribute))
+
+  return (ZebraWellTyped wt grouped <$> sequence xs)
+
 
 -- we are not reading nested arrays in zebra right now
 schemaOfType' :: ValType -> Maybe Schema
@@ -422,19 +533,19 @@ zebraOfFacts ty facts
 
 --------------------------------------------------------------------------------
 
-testAllocLimit :: ZebraAllocLimit
-testAllocLimit = defaultZebraAllocLimit
+testAllocLimitBytes :: Int
+testAllocLimitBytes = 10 * 1024 * 1024 * 1024
 
 testSnapshotTime :: Time
 testSnapshotTime = Icicle.unsafeTimeOfYMD 9999 1 1
 
-codeOf :: ZebraChunkSize -> ZebraAllocLimit -> WellTyped -> Either SeaError SourceCode
-codeOf size limit wt = do
+codeOf :: WellTyped -> Either SeaError SourceCode
+codeOf wt = do
   let
-    input =
+    dummy =
       HasInput
         (FormatZebra
-          (ZebraConfig size limit)
+          (ZebraConfig (ZebraChunkFactCount 0) (ZebraAllocLimitGB 0))
           (Snapshot testSnapshotTime)
           (PsvOutputConfig (Snapshot testSnapshotTime) PsvOutputDense defaultOutputMissing))
         (InputOpts AllowDupTime Map.empty)
@@ -442,7 +553,7 @@ codeOf size limit wt = do
     attr = wtAttribute wt
     flat = wtAvalancheFlat wt :| []
 
-  src <- codeOfPrograms input [attr] [(attr, flat)]
+  src <- codeOfPrograms dummy [attr] [(attr, flat)]
 
   pure . textOfDoc . PP.vsep $
     [ PP.pretty src
@@ -461,23 +572,48 @@ codeOf size limit wt = do
     , "}"
     , ""
     , "ierror_msg_t test_zebra_read_entity (piano_t *piano, zebra_state_t *state, zebra_entity_t *entity) {"
-    , "    return zebra_read_entity (piano, state, entity);"
+    , "    if (!zebra_limit_exceeded (state)) {"
+    , "        return zebra_read_entity (piano, state, entity);"
+    , "    }"
+    , "    return 0;"
+    , "}"
+    , ""
+    , "int64_t test_check_limit (zebra_state_t *state, zebra_entity_t *entity) {"
+    , "    if (zebra_limit_exceeded (state)) {"
+    , "        zebra_write_dropped_entity (state, entity);"
+    , "        return 1;"
+    , "    }"
+    , "    return 0;"
     , "}"
     , ""
     ]
 
-pp :: ZebraChunkSize -> WellTyped -> Zebra.Entity Schema -> [Zebra.Value] -> String
-pp size wt entity rows =
+pp :: ZebraChunkFactCount -> Int -> ZebraWellTyped -> String
+pp size limit wt =
   "=== Entity ===\n" <>
-  "Zebra chunk size = " <> show (unZebraChunkSize size) <> "\n" <>
-  "Fact type = " <> show (wtFactType wt) <> "\n" <>
-  "Facts = " <> ppShow (wtFacts wt) <> "\n" <>
-  "As Zebra values = \n" <> ppShow rows <> "\n" <>
-  "As Zebra entity = \n" <> ppShow entity <>
-  "Avalanche program = \n" <> show (PP.pretty (wtAvalancheFlat wt))
+  "Zebra chunk size = " <> show (unZebraChunkFactCount size) <> " facts\n" <>
+  "Zebra alloc limit = " <> show limit  <> " bytes\n" <>
+  show wt
+
+withSystemTempDirectory :: FilePath -> (FilePath -> EitherT SeaError IO a) -> EitherT SeaError IO a
+withSystemTempDirectory template action = do
+  let acquire = liftIO (getTemporaryDirectory >>= \tmp -> createTempDirectory tmp template)
+      release = liftIO . removeDirectoryRecursive
+  bracketEitherT' acquire release action
+
+withWritableFd :: FilePath -> (Posix.Fd -> EitherT SeaError IO a) -> EitherT SeaError IO a
+withWritableFd path =
+  bracketEitherT' (liftIO $ Posix.createFile path (Posix.CMode 0O644))
+                  (liftIO . Posix.closeFd)
+
+withSeaLibrary :: [CompilerOption] -> SourceCode -> (Library -> EitherT SeaError IO a) -> EitherT SeaError IO a
+withSeaLibrary opts code =
+  bracketEitherT'
+    (firstEitherT SeaJetskiError $ compileLibrary NoCacheLibrary opts code)
+    (firstEitherT SeaJetskiError . releaseLibrary)
 
 return []
 tests :: IO Bool
 tests = releaseLibraryAfterTests $ do
   $checkAllWith TestRunMore checkArgs
-  
+


### PR DESCRIPTION
This allows an allocation limit (per entity) to be set for Zebra. If the limit is exceeded, we stop and write the entity to a log file. It will not appear in the snapshot/chord.

```
./dist/build/Icicle/icicle query --dictionary-toml test/cli/icicle/t6-zebra.toml --input-zebra test/cli/icicle/t6-input --snapshot 2017-1-1 --output-code foo/code.c --output-dense-psv foo/output.psv --zebra-chunk-size 2 --zebra-alloc-limit 10

$ cat foo/output_dropped.txt
ID00000001
```

! @jystic @amosr 
/jury approved @amosr