### PR TITLE
Relax restrictions on nested groups

### DIFF
--- a/data/sea/52-psv.h
+++ b/data/sea/52-psv.h
@@ -582,16 +582,15 @@ void psv_snapshot (piano_t *piano, psv_config_t *cfg)
     psv_set_blocking_mode (drop_fd);
     psv_set_blocking_mode (chord_fd);
 
-    ichord_file_t chord_file;
-    ierror_msg_t chord_mmap_error = ichord_file_mmap (chord_fd, &chord_file);
-    if (chord_mmap_error) {
-        cfg->error        = chord_mmap_error;
-        cfg->fact_count   = 0;
-        cfg->entity_count = 0;
-        return;
+    /* If we have a piano, we know we are playing a chord */
+    int64_t max_chord_count;
+    if (piano) {
+        max_chord_count = piano_max_count(piano);
+    } else {
+        max_chord_count = 1;
     }
 
-    ifleet_t *fleet = psv_alloc_fleet (chord_file.max_chord_count, cfg->psv_max_row_count);
+    ifleet_t *fleet = psv_alloc_fleet (max_chord_count, cfg->psv_max_row_count);
 
     char *input_ptr  = calloc (cfg->psv_input_buffer_size + 1, 1);
     char *entity_cur = calloc (cfg->psv_input_buffer_size + 1, 1);
@@ -674,10 +673,6 @@ void psv_snapshot (piano_t *piano, psv_config_t *cfg)
     if (!cfg->error) {
         cfg->error = psv_flush_to_output_fd (&state);
     }
-
-    ierror_msg_t chord_unmap_error = ichord_file_unmap (&chord_file);
-    if (cfg->error == 0)
-        cfg->error = chord_unmap_error;
 
     cfg->fact_count   = state.fact_count;
     cfg->entity_count = state.entity_count;

--- a/data/sea/52-psv.h
+++ b/data/sea/52-psv.h
@@ -263,12 +263,12 @@ static ierror_loc_t psv_write_dropped_entity_cur (psv_state_t *s, const ierror_l
         msg = psv_write_output (fd, s->output_start, s->output_end, &s->output_ptr, s->entity_cur, s->entity_cur_size, s->fleet);
 
         if (msg)
-            return error;
+            return ierror_loc_format (0, 0, "%s", msg);
 
         msg = psv_flush_output (fd, s->output_start, &s->output_ptr);
 
         if (msg)
-            return error;
+            return ierror_loc_format (0, 0, "%s", msg);
 
         if (s->entity_dropped)
             free(s->entity_dropped);

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
@@ -13,6 +13,7 @@ module Icicle.Sea.FromAvalanche.State (
   , nameOfCompute'
   , nameOfCount
   , stateOfPrograms
+  , stateOfProgramCompute
   , seaOfState
   , seaOfStateInfo
   , nameOfStateType

--- a/icicle-compiler/test/Icicle/Test/Source/Convert.hs
+++ b/icicle-compiler/test/Icicle/Test/Source/Convert.hs
@@ -27,8 +27,8 @@ prop_convert_ok qwf
      -> property Discard
 
 
-xprop_convert_is_well_typed :: QueryWithFeature -> Property
-xprop_convert_is_well_typed qwf
+prop_convert_is_well_typed :: QueryWithFeature -> Property
+prop_convert_is_well_typed qwf
  = counterexample (qwfPretty qwf)
  $ case (qwfCheck qwf, qwfCheckKey qwf) of
     (Right qt', Right k')

--- a/icicle-source/src/Icicle/Source/Checker/Invariants.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Invariants.hs
@@ -34,7 +34,7 @@ invariantQ ctx (Query (c:cs) xfinal)
  = case c of
     Windowed{}
      | allowWindows inv
-     -> goBanWindowAndGroupFold
+     -> goBanWindow
      | otherwise
      -> errBanWindow "Consider moving the window to the start of the query"
 
@@ -48,16 +48,13 @@ invariantQ ctx (Query (c:cs) xfinal)
      -> errBanLatest
 
     GroupBy _ x
-     -> goX x >> goBanWindowAndGroupFold
+     -> goX x >> go
 
     Distinct _ x
-     -> goX x >> goBanWindowAndGroupFold
+     -> goX x >> go
 
     GroupFold _ _ _ x
-     | allowWindows inv
-     -> goX x >> goBanWindowAndGroupFold
-     | otherwise
-     -> errBanGroupFold
+     -> goX x >> go
 
     Filter _ x
      -> goX x >> go
@@ -78,10 +75,9 @@ invariantQ ctx (Query (c:cs) xfinal)
                                    , allowWindows = False
                                    , allowGroupFolds = False }}
 
-  goBanWindowAndGroupFold
+  goBanWindow
      = flip invariantQ q'
-     $ ctx { checkInvariants = inv { allowWindows = False
-                                   , allowGroupFolds = False }}
+     $ ctx { checkInvariants = inv { allowWindows = False }}
 
   errBanLatest
    = errorSuggestions
@@ -95,11 +91,6 @@ invariantQ ctx (Query (c:cs) xfinal)
       (ErrorContextNotAllowedHere (annotOfContext c) c)
       [ Suggest "Windows cannot be inside groups/latest"
       , Suggest sug]
-
-  errBanGroupFold
-   = errorSuggestions
-      (ErrorContextNotAllowedHere (annotOfContext c) c)
-      [ Suggest "Group folds are unsupported inside groups/latests" ]
 
 
 invariantX

--- a/icicle-source/src/Icicle/Source/Checker/Invariants.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Invariants.hs
@@ -48,13 +48,13 @@ invariantQ ctx (Query (c:cs) xfinal)
      -> errBanLatest
 
     GroupBy _ x
-     -> goX x >> go
+     -> goX x >> goBanWindow
 
     Distinct _ x
-     -> goX x >> go
+     -> goX x >> goBanWindow
 
     GroupFold _ _ _ x
-     -> goX x >> go
+     -> goX x >> goBanWindowLatest
 
     Filter _ x
      -> goX x >> go
@@ -78,6 +78,10 @@ invariantQ ctx (Query (c:cs) xfinal)
   goBanWindow
      = flip invariantQ q'
      $ ctx { checkInvariants = inv { allowWindows = False }}
+
+  goBanWindowLatest
+     = flip invariantQ q'
+     $ ctx { checkInvariants = inv { allowWindows = False, allowLatest = False }}
 
   errBanLatest
    = errorSuggestions

--- a/icicle-source/src/Icicle/Source/Checker/Invariants.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Invariants.hs
@@ -54,7 +54,7 @@ invariantQ ctx (Query (c:cs) xfinal)
      -> goX x >> goBanWindow
 
     GroupFold _ _ _ x
-     -> goX x >> goBanWindowLatest
+     -> goX x >> goBanAll
 
     Filter _ x
      -> goX x >> go
@@ -78,10 +78,6 @@ invariantQ ctx (Query (c:cs) xfinal)
   goBanWindow
      = flip invariantQ q'
      $ ctx { checkInvariants = inv { allowWindows = False }}
-
-  goBanWindowLatest
-     = flip invariantQ q'
-     $ ctx { checkInvariants = inv { allowWindows = False, allowLatest = False }}
 
   errBanLatest
    = errorSuggestions


### PR DESCRIPTION
I don't remember why it was restricted like this before (we support nested groups now). Some existing dictionaries won't compile with these restrictions.

! @amosr 