### PR TITLE
 Add CPP flags so anemone header files can be included

### DIFF
--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -1,5 +1,10 @@
 #include "06-segv.h"
+#ifdef ICICLE_DEP
+#include "../../../../lib/anemone/csrc/anemone_mempool.h"
+#else
 #include "../../lib/anemone/csrc/anemone_mempool.h"
+#endif
+
 
 #define ibool_and(x, y) (x) && (y)
 #define ibool_or(x, y)  (x) || (y)

--- a/icicle-compiler/src/Icicle/Sea/Preamble.hs
+++ b/icicle-compiler/src/Icicle/Sea/Preamble.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 module Icicle.Sea.Preamble (
     seaPreamble
   , seaOfExternal
@@ -33,10 +34,17 @@ seaPreamble
   files
    = List.sortBy (compare `on` fst)
    $ $(embedWhen (liftA2 (&&) (/= "00-includes.h") ((== ".h") . takeExtension)) "data/sea/")
+#ifdef ICICLE_DEP
   externals
-   =  $(embedWhen ((== "anemone_base.h")) "../lib/anemone/csrc/")
+   =  $(embedWhen ((== "anemone_base.h"))    "../../../lib/anemone/csrc/")
+   <> $(embedWhen ((== "anemone_mempool.h")) "../../../lib/anemone/csrc/")
+   <> $(embedWhen ((== "anemone_mempool.c")) "../../../lib/anemone/csrc/")
+#else
+  externals
+   =  $(embedWhen ((== "anemone_base.h"))    "../lib/anemone/csrc/")
    <> $(embedWhen ((== "anemone_mempool.h")) "../lib/anemone/csrc/")
    <> $(embedWhen ((== "anemone_mempool.c")) "../lib/anemone/csrc/")
+#endif
 
 seaOfExternal :: FilePath -> ByteString -> Doc
 seaOfExternal path bs


### PR DESCRIPTION
… when icicle used as a dependency. Any package that depends on `icicle` will need to define:

```
cpp-options: -DICICLE_DEP
```

This is a bit awkward. If I flip the flag around, and have `-DICICLE_NOT_DEP` defined in `icicle.cabal`, I'm not sure how to turn it off when icicle is built as a dependency.

! @jystic @amosr 
/jury approved @jystic