### PR TITLE
Embed anemone sources as strings

### DIFF
--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -1,10 +1,5 @@
 #include "06-segv.h"
-#ifdef ICICLE_DEP
-#include "../../../../lib/anemone/csrc/anemone_mempool.h"
-#else
 #include "../../lib/anemone/csrc/anemone_mempool.h"
-#endif
-
 
 #define ibool_and(x, y) (x) && (y)
 #define ibool_or(x, y)  (x) || (y)

--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -25,6 +25,7 @@ library
                      , ambiata-x-file-embed
                      , ambiata-x-show
                      , ambiata-zebra
+                     , ambiata-anemone
                      , icicle-core
                      , icicle-data
                      , icicle-source

--- a/icicle-compiler/src/Icicle/Sea/Preamble.hs
+++ b/icicle-compiler/src/Icicle/Sea/Preamble.hs
@@ -23,6 +23,8 @@ import           System.IO (FilePath)
 
 import           X.Data.FileEmbed (embedWhen)
 
+import           Anemone.Embed
+
 
 seaPreamble :: Doc
 seaPreamble
@@ -34,17 +36,10 @@ seaPreamble
   files
    = List.sortBy (compare `on` fst)
    $ $(embedWhen (liftA2 (&&) (/= "00-includes.h") ((== ".h") . takeExtension)) "data/sea/")
-#ifdef ICICLE_DEP
   externals
-   =  $(embedWhen ((== "anemone_base.h"))    "../../../lib/anemone/csrc/")
-   <> $(embedWhen ((== "anemone_mempool.h")) "../../../lib/anemone/csrc/")
-   <> $(embedWhen ((== "anemone_mempool.c")) "../../../lib/anemone/csrc/")
-#else
-  externals
-   =  $(embedWhen ((== "anemone_base.h"))    "../lib/anemone/csrc/")
-   <> $(embedWhen ((== "anemone_mempool.h")) "../lib/anemone/csrc/")
-   <> $(embedWhen ((== "anemone_mempool.c")) "../lib/anemone/csrc/")
-#endif
+   = [ ("anemone_base.h", anemone_base_h)
+     , ("anemone_mempool.h", anemone_mempool_h)
+     , ("anemone_mempool.c", anemone_mempool_c) ]
 
 seaOfExternal :: FilePath -> ByteString -> Doc
 seaOfExternal path bs


### PR DESCRIPTION
this will make it easier for other packages to build `icicle` as a library dependency.

! @jystic @amosr 
/jury approved @jystic