### PR TITLE
Fix Zebra attribute count

### DIFF
--- a/data/sea/54-zebra.h
+++ b/data/sea/54-zebra.h
@@ -49,6 +49,7 @@ typedef struct zebra_state {
 
 } zebra_state_t;
 
+static int64_t zebra_attribute_count ();
 
 static int64_t zebra_translate_table
   ( anemone_mempool_t *mempool
@@ -221,7 +222,7 @@ static int64_t zebra_translate_column
     return 0;
 }
 
-zebra_state_t *zebra_alloc_state (piano_t *piano, zebra_config_t *cfg, int64_t attribute_count)
+zebra_state_t *zebra_alloc_state (piano_t *piano, zebra_config_t *cfg)
 {
     zebra_state_t *state = malloc(sizeof(zebra_state_t));
 
@@ -254,6 +255,8 @@ zebra_state_t *zebra_alloc_state (piano_t *piano, zebra_config_t *cfg, int64_t a
     state->output_ptr   = output_ptr;
     state->output_fd    = output_fd;
     state->drop_fd      = drop_fd;
+
+    int64_t attribute_count = zebra_attribute_count ();
 
     state->attribute_count    = attribute_count;
     state->entity_fact_offset = calloc(attribute_count, sizeof (int64_t));

--- a/icicle-compiler/src/Icicle/Command.hs
+++ b/icicle-compiler/src/Icicle/Command.hs
@@ -264,7 +264,7 @@ mkQueryFleet input chord source = do
   let cfg = HasInput format (InputOpts AllowDupTime Map.empty) (inputPath input)
 
   code  <- liftIO $ Text.readFile source
-  fleet <- firstEitherT IcicleSeaError (seaCreate CacheSea cfg chord 0 code)
+  fleet <- firstEitherT IcicleSeaError (seaCreate CacheSea cfg chord code)
   return (code, fleet)
 
 compileFleet ::

--- a/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
+++ b/icicle-compiler/src/Icicle/Sea/Eval/Base.hs
@@ -223,19 +223,18 @@ seaCompileFleet ::
   -> EitherT SeaError m (SeaFleet st)
 seaCompileFleet options cache input attributes programs chords = do
   code <- hoistEither (codeOfPrograms input attributes (Map.toList programs))
-  seaCreateFleet options (fromCacheSea cache) input chords (length attributes) code
+  seaCreateFleet options (fromCacheSea cache) input chords code
 
 seaCreate ::
      (MonadIO m)
   => CacheSea
   -> Input FilePath
   -> Maybe FilePath
-  -> Int
   -> Text
   -> EitherT SeaError m (SeaFleet st)
-seaCreate cache input chords attribute_count code = do
+seaCreate cache input chords code = do
   options <- getCompilerOptions
-  seaCreateFleet options (fromCacheSea cache) input chords attribute_count code
+  seaCreateFleet options (fromCacheSea cache) input chords code
 
 fromCacheSea :: CacheSea -> CacheLibrary
 fromCacheSea = \case

--- a/icicle-compiler/src/Icicle/Sea/Fleet.hs
+++ b/icicle-compiler/src/Icicle/Sea/Fleet.hs
@@ -72,10 +72,9 @@ seaCreateFleet ::
   -> CacheLibrary
   -> Input FilePath
   -> Maybe FilePath
-  -> Int
   -> Text
   -> EitherT SeaError m (SeaFleet st)
-seaCreateFleet options cache input chords attribute_count code = do
+seaCreateFleet options cache input chords code = do
   lib                  <- firstEitherT SeaJetskiError (compileLibrary cache options code)
   imempool_create      <- firstEitherT SeaJetskiError (function lib "anemone_mempool_create" (retPtr retVoid))
   imempool_free        <- firstEitherT SeaJetskiError (function lib "anemone_mempool_free"   retVoid)
@@ -119,7 +118,7 @@ seaCreateFleet options cache input chords attribute_count code = do
           withPiano ptr cpiano = do
             let piano = unCPiano cpiano
 
-            state <- init [ argPtr piano, argPtr ptr, argInt64 (fromIntegral attribute_count) ]
+            state <- init [ argPtr piano, argPtr ptr ]
 
             let step' :: CEntity -> EitherT SeaError IO ()
                 step' e = do

--- a/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
@@ -48,7 +48,19 @@ seaOfZebraDriver :: [Attribute] -> [SeaProgramAttribute] -> Either SeaError Doc
 seaOfZebraDriver concretes states = do
   let lookup x = maybeToRight (SeaNoAttributeIndex x) $ List.elemIndex x concretes
   indices <- sequence $ fmap (lookup . stateAttribute) states
-  return $ seaOfDefRead (List.zip indices states)
+  return . vsep $
+    [ seaOfAttributeCount concretes
+    , seaOfDefRead (List.zip indices states)
+    ]
+
+seaOfAttributeCount :: [Attribute] -> Doc
+seaOfAttributeCount all_attributes = vsep
+  [ "static int64_t zebra_attribute_count()"
+  , "{"
+  , "    return " <> pretty (length all_attributes) <> ";"
+  , "}"
+  , ""
+  ]
 
 -- zebra_read_entity ( zebra_state_t *state, zebra_entity_t *entity ) {
 --   /* attribute 0 */

--- a/icicle-compiler/test/Icicle/Test/Sea/Psv.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Psv.hs
@@ -286,7 +286,7 @@ compileTest wt (TestOpts _ _ inputFormat allowDupTime) = do
         ]
       code' = code <> savage
 
-  S.seaCreateFleet options (S.fromCacheSea cache) input chords (length attrs) code'
+  S.seaCreateFleet options (S.fromCacheSea cache) input chords code'
 
 
 runTest :: WellTyped -> S.PsvConstants -> TestOpts -> EitherT S.SeaError IO ()

--- a/icicle-compiler/test/Icicle/Test/Sea/PsvFission.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/PsvFission.hs
@@ -102,7 +102,7 @@ compileTest2 wt1 wt2 (TestOpts _ _ inputFormat allowDupTime) = do
 
   let input = HasInput iformat iopts "dummy_path"
   code <- hoistEither (S.codeOfPrograms input attrs (Map.toList programs))
-  S.seaCreateFleet options (S.fromCacheSea S.NoCacheSea) input Nothing (length attrs) (code <> piano)
+  S.seaCreateFleet options (S.fromCacheSea S.NoCacheSea) input Nothing (code <> piano)
 
 runTest2 :: WellTyped -> WellTyped -> S.PsvConstants -> TestOpts -> EitherT S.SeaError IO ()
 runTest2 wt1 wt2 consts testOpts = do


### PR DESCRIPTION
This value (passed dynamically to Zebra) was wrong when the dictionary is already compiled. A case of a bad, careless default on the Haskell side.

Fixed by setting it in the generated Zebra code.

! @amosr @jystic 
/jury approved @jystic