### PR TITLE
Source evaluator: `latest` returns array sometimes

### DIFF
--- a/icicle-source/src/Icicle/Source/Eval.hs
+++ b/icicle-source/src/Icicle/Source/Eval.hs
@@ -72,11 +72,14 @@ evalQ q vs env
                  -- and
                  -- > q' : t'
                  -- then we need to wrap the result in an Array.
+                 -- There is another case for possiblies, where result has type
+                 -- > latest i ~> q' : Array (Sum Error t')
+                 -- These correspond to the "dataOfLatest" rules in Source.Type.Constraints.
                  | t  <- annResult $ annotOfQuery q
                  , t' <- annResult $ annotOfQuery q'
                  , Just (ArrayT t0) <- getBaseType t
                  , Just t0' <- getBaseType t'
-                 , t0 == t0'
+                 , t0 == t0' || t0 == SumT ErrorT t0'
                  -> let vs' = reverse $ take i $ reverse vs
                     in  VArray <$> mapM (evalQ q' []) vs'
                  | otherwise

--- a/icicle-source/src/Icicle/Source/Eval.hs
+++ b/icicle-source/src/Icicle/Source/Eval.hs
@@ -65,8 +65,18 @@ evalQ q vs env
                     in  evalQ q' vs' env
 
                 Latest _ i
-                 | t' <- annResult $ annotOfQuery q'
-                 , TemporalityElement <- getTemporalityOrPure t'
+                 -- Latest can return either an array or a value, depending on the temporality of its argument.
+                 -- We need to know whether to return an array here, so we might as well just look at the return type.
+                 -- If the return type of the
+                 -- > latest i ~> q' : Array t'
+                 -- and
+                 -- > q' : t'
+                 -- then we need to wrap the result in an Array.
+                 | t  <- annResult $ annotOfQuery q
+                 , t' <- annResult $ annotOfQuery q'
+                 , Just (ArrayT t0) <- getBaseType t
+                 , Just t0' <- getBaseType t'
+                 , t0 == t0'
                  -> let vs' = reverse $ take i $ reverse vs
                     in  VArray <$> mapM (evalQ q' []) vs'
                  | otherwise


### PR DESCRIPTION
The `latest` returns an array if the input is an element, or a single value if it's an aggregate. The evaluator was not making the check as the type checker, so some cases where type said array but evaluator said single value. They should agree now, because the evaluator is using the result of typechecking to decide.

! @tranma @jystic 
/jury approved @jystic