### PR TITLE
Outputs should be ordered alphabetically within each attribute

### DIFF
--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
@@ -38,6 +38,7 @@ module Icicle.Sea.FromAvalanche.State (
   ) where
 
 import qualified Data.List          as List
+import           Data.Map (Map)
 import qualified Data.Map           as Map
 import qualified Data.Text          as T
 
@@ -72,6 +73,7 @@ data SeaProgramAttribute = SeaProgramAttribute {
   , stateTimeVar        :: Text
   , stateInputVars      :: [(Text, ValType)]
   , stateComputes       :: NonEmpty SeaProgramCompute
+  , stateOutputsAll     :: Map OutputName (ValType, [ValType])
   } deriving (Eq, Ord, Show)
 
 data SeaProgramCompute = SeaProgramCompute {
@@ -102,6 +104,7 @@ stateOfPrograms name attrib programs@(program :| _)
         , stateInputType      = factType
         , stateInputVars      = fmap (first textOfName) factVars
         , stateComputes       = NonEmpty.zipWith (stateOfProgramCompute name) (0 :| [1..]) programs
+        , stateOutputsAll     = Map.fromList . concatMap outputsOfProgram $ NonEmpty.toList programs
         }
 
 stateOfProgramCompute

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv/Output.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv/Output.hs
@@ -143,7 +143,7 @@ seaOfWriteProgramOutput config state = do
 
   let computes = NonEmpty.toList $ stateComputes state
   let resumeables  = fmap clearResumables computes
-  outputs         <- traverse outputState (concatMap stateOutputs computes)
+  outputs         <- traverse outputState . Map.toList $ stateOutputsAll state
   let callComputes = fmap (\i -> pretty (nameOfCompute i) <+> "(" <> ps <> ");") computes
 
   pure $ vsep

--- a/icicle-compiler/test/Icicle/Test/Sea/PsvFission.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/PsvFission.hs
@@ -9,7 +9,7 @@
 
 module Icicle.Test.Sea.PsvFission where
 
-import Icicle.Test.Sea.Psv
+import           Icicle.Test.Sea.Psv hiding (tests)
 
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Resource (runResourceT, ResourceT)
@@ -110,11 +110,11 @@ runTest2 :: WellTyped -> WellTyped -> S.PsvConstants -> TestOpts -> EitherT S.Se
 runTest2 wt1 wt2 consts testOpts = do
   let compile  = compileTest2 wt1 wt2 testOpts
       release  = S.seaRelease
-      expect_values1 = evalWellTyped wt1
-      expect_values2 = evalWellTyped wt1 { wtCore = wtCore wt2 }
+      expect_values1 = Map.fromList $ evalWellTyped wt1
+      expect_values2 = Map.fromList $ evalWellTyped wt1 { wtCore = wtCore wt2 }
       expect   
        | length (wtFacts wt1) <= S.psvFactsLimit consts
-       = textOfOutputs (wtEntities wt1) (expect_values1 <> expect_values2)
+       = textOfOutputs (wtEntities wt1) (Map.toList $ Map.union expect_values1 expect_values2)
        | otherwise
        = ""
 


### PR DESCRIPTION
I think this is the simplest fix, just ensure that outputs are always sorted by `OutputName` within an attribute.

I think ideally this should really be configurable, but this will do for the moment.

! @amosr @tranma
/jury approved @amosr