### PR TITLE
Run compute after any successful read from zebra

### DIFF
--- a/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Zebra.hs
@@ -167,8 +167,9 @@ seaOfDefReadProgram state = vsep
   , "        if (error) return error;"
   , ""
   , "        /* run compute on the facts read so far */"
-  , "        if (state->entity_fact_offset[attribute_ix] != state->entity_fact_count[attribute_ix]) {"
+  , "        if (*fact_count != 0) {"
   , indent 12 $ vsep $ fmap (\i -> pretty (nameOfCompute i) <+> " (program);") computes
+  , "            *fact_count = 0;"
   , "        }"
   , ""
   , "        state->entity_alloc_count = mempool->total_alloc_size;"


### PR DESCRIPTION
When we have queries for two different facts and one of them has >128 (the chunk count) while the other has <128 then you get a situation where `zebra_translate` is called on a program which hasn't been run yet (the one with <128 facts). This causes the `new_count` to be reset to zero and the facts are never processed.

This change fixes the issue by running compute every time we detect new facts, at the cost of potentially running it more times than necessary because it is always run during `psv_write_output`. This isn't ideal but i'm not sure how to fix this without doing something convoluted. Maybe we need to keep a flag somewhere to keep track of whether compute has ever been run for this entity / attribute combo.

! @amosr @tranma 