### PR TITLE
Show facts/second instead of millions facts/second

### DIFF
--- a/icicle-compiler/main/icicle.hs
+++ b/icicle-compiler/main/icicle.hs
@@ -278,13 +278,13 @@ runQuery f msrc query = do
       bytes    = queryBytes stats
       secs     = realToFrac (queryTime stats) :: Double
       mbps     = (fromIntegral bytes / secs) / (1024 * 1024)
-      mfps     = (fromIntegral facts / secs) / (1000 * 1000)
+      fps      = fromIntegral facts / secs
 
-  liftIO (printf "icicle: query time      = %.2fs\n"                secs)
-  liftIO (printf "icicle: total entities  = %d\n"                   entities)
-  liftIO (printf "icicle: total facts     = %d\n"                   facts)
-  liftIO (printf "icicle: fact throughput = %.2f million facts/s\n" mfps)
-  liftIO (printf "icicle: byte throughput = %.2f MB/s\n"            mbps)
+  liftIO (printf "icicle: query time      = %.2fs\n" secs)
+  liftIO (printf "icicle: total entities  = %d\n" entities)
+  liftIO (printf "icicle: total facts     = %d\n" facts)
+  liftIO (printf "icicle: fact throughput = %.0f facts/s\n" kfps)
+  liftIO (printf "icicle: byte throughput = %.2f MiB/s\n" mbps)
 
 writeUtf8 :: MonadIO m => FilePath -> Text -> m ()
 writeUtf8 path txt =


### PR DESCRIPTION
Given we usually run with fairly large dictionaries these days, I think the "millions facts/s" unit it too optimistic and so it doesn't show us very much.

This change makes the output in facts/second directly, which should be fine even if we hit the millions.

```
icicle: facts_limit = 1048576
icicle: starting compilation
icicle: compilation time = 0.09s
icicle: starting query
icicle: query time      = 0.00s
icicle: total entities  = 2
icicle: total facts     = 13
icicle: fact throughput = 44674 facts/s
icicle: byte throughput = 1.67 MiB/s
```

! @amosr @tranma 
/jury approved @amosr