### PR TITLE
Simplify group conversion in Source-to-Core

### DIFF
--- a/icicle-repl/test/cli/repl/t10-avalanche/expected
+++ b/icicle-repl/test/cli/repl/t10-avalanche/expected
@@ -66,43 +66,43 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (conv$32@{(Sum Error (Int
 > - Avalanche (simplified):
 conv$3 = TIME
 conv$4 = MAX_MAP_SIZE
-init acc$conv$5@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
-load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$5;
+init acc$conv$40@{Map Time (Buf 2 ((Sum Error Int), Time))} = Map []@{Map Time (Buf 2 ((Sum Error Int), Time))};
+load_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$40;
 
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0@{((Sum Error Int), Time)}) in new
 {
-  read conv$5$aval$0 = acc$conv$5 [Map Time (Buf 2 ((Sum Error Int), Time))];
+  read conv$40$aval$0 = acc$conv$40 [Map Time (Buf 2 ((Sum Error Int), Time))];
   let anf$0 = Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0;
   let anf$1 = snd#@{(Sum Error Int), Time} conv$0;
-  write acc$conv$5 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
-    (\conv$7@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$7 conv$1 conv$0) anf$0 anf$1 conv$5$aval$0;
+  write acc$conv$40 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
+    (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) anf$0 anf$1 conv$40$aval$0;
 }
-save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$5;
+save_resumable@{Map Time (Buf 2 ((Sum Error Int), Time))} acc$conv$40;
 
-read conv$5 = acc$conv$5 [Map Time (Buf 2 ((Sum Error Int), Time))];
-let conv$40 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
-  (\conv$37@{(Sum Error (Map Time Int))} \conv$32@{Time} \conv$34@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
+read conv$40 = acc$conv$40 [Map Time (Buf 2 ((Sum Error Int), Time))];
+let conv$41 = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
+  (\conv$32@{(Sum Error (Map Time Int))} \conv$34@{Time} \conv$36@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
     (\conv$39@{Error} left#@{Error, Map Time Int} conv$39) 
-    (\conv$38@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
+    (\conv$33@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
       (\conv$39@{Error} left#@{Error, Map Time Int} conv$39) 
-      (\conv$35@{Int} right#@{Error, Map Time Int} (Map_insertOrUpdate#@{(Time,Int)} 
-        (\conv$36@{Int} conv$36) conv$35 conv$32 conv$38)) (
-      let conv$11 = 
-        let conv$6 = Latest_read#@{Array ((Sum Error Int), Time)} conv$34
+      (\conv$37@{Int} right#@{Error, Map Time Int} (Map_insertOrUpdate#@{(Time,Int)} 
+        (\conv$38@{Int} conv$38) conv$37 conv$34 conv$33)) (
+      let conv$10 = 
+        let conv$5 = Latest_read#@{Array ((Sum Error Int), Time)} conv$36
          in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} 
-          (\conv$10@{((Sum Error Int), (Sum Error Int))} \conv$9@{((Sum Error Int), Time)} 
-            let conv$28 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
-            let v$inline$0$conv$13 = fst#@{(Sum Error Int), Time} conv$9
-             in pair#@{(Sum Error Int), (Sum Error Int)} v$inline$0$conv$13 (
-              let s$conv$22 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
-                (\reify$0$conv$15@{Error} left#@{Error, Int} reify$0$conv$15) 
-                (\reify$1$conv$16@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
-                  (\reify$2$conv$17@{Error} left#@{Error, Int} reify$2$conv$17) 
-                  (\reify$3$conv$18@{Int} right#@{Error, Int} (add#@{Int} reify$1$conv$16 reify$3$conv$18)) conv$28) v$inline$0$conv$13
-               in s$conv$22)) ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))}) conv$6
-      let conv$31 = snd#@{(Sum Error Int), (Sum Error Int)} conv$11
-       in conv$31)) conv$37) (Right Map []@{(Sum Error (Map Time Int))}) conv$5;
-output@{(Sum Error (Map Time Int))} repl (conv$40@{(Sum Error (Map Time Int))});
+          (\conv$9@{((Sum Error Int), (Sum Error Int))} \conv$8@{((Sum Error Int), Time)} 
+            let conv$27 = snd#@{(Sum Error Int), (Sum Error Int)} conv$9
+            let v$inline$0$conv$12 = fst#@{(Sum Error Int), Time} conv$8
+             in pair#@{(Sum Error Int), (Sum Error Int)} v$inline$0$conv$12 (
+              let s$conv$21 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
+                (\reify$0$conv$14@{Error} left#@{Error, Int} reify$0$conv$14) 
+                (\reify$1$conv$15@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
+                  (\reify$2$conv$16@{Error} left#@{Error, Int} reify$2$conv$16) 
+                  (\reify$3$conv$17@{Int} right#@{Error, Int} (add#@{Int} reify$1$conv$15 reify$3$conv$17)) conv$27) v$inline$0$conv$12
+               in s$conv$21)) ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))}) conv$5
+      let conv$30 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
+       in conv$30)) conv$32) (Right Map []@{(Sum Error (Map Time Int))}) conv$40;
+output@{(Sum Error (Map Time Int))} repl (conv$41@{(Sum Error (Map Time Int))});
 
 - Core evaluation:
 [homer, [(1989-12-17,100)

--- a/icicle-repl/test/cli/repl/t10.2-core/expected
+++ b/icicle-repl/test/cli/repl/t10.2-core/expected
@@ -85,7 +85,7 @@ Precomputations:
 
 
 Streams:
-  STREAM_FOLD (conv$5 : Map Time (Buf 2 ((Sum Error Int), Time)))
+  STREAM_FOLD (conv$40 : Map Time (Buf 2 ((Sum Error Int), Time)))
     INIT:
       Map []@{Map Time (Buf 2 ((Sum Error Int), Time))}
     KONS:
@@ -93,35 +93,35 @@ Streams:
         let simp$0 = Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv$1 conv$0
         let simp$1 = snd#@{(Sum Error Int), Time} conv$0
          in Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
-          (\conv$7@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$7 conv$1 conv$0) simp$0 simp$1 conv$5
+          (\conv$6@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv$6 conv$1 conv$0) simp$0 simp$1 conv$40
   
 
 Postcomputations:
-  conv$40              = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
-                           (\conv$37@{(Sum Error (Map Time Int))} \conv$32@{Time} \conv$34@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
+  conv$41              = Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
+                           (\conv$32@{(Sum Error (Map Time Int))} \conv$34@{Time} \conv$36@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
                              (\conv$39@{Error} left#@{Error, Map Time Int} conv$39) 
-                             (\conv$38@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
+                             (\conv$33@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
                                (\conv$39@{Error} left#@{Error, Map Time Int} conv$39) 
-                               (\conv$35@{Int} right#@{Error, Map Time Int} (Map_insertOrUpdate#@{(Time,Int)} 
-                                 (\conv$36@{Int} conv$36) conv$35 conv$32 conv$38)) (
-                               let conv$11 = 
-                                 let conv$6 = Latest_read#@{Array ((Sum Error Int), Time)} conv$34
+                               (\conv$37@{Int} right#@{Error, Map Time Int} (Map_insertOrUpdate#@{(Time,Int)} 
+                                 (\conv$38@{Int} conv$38) conv$37 conv$34 conv$33)) (
+                               let conv$10 = 
+                                 let conv$5 = Latest_read#@{Array ((Sum Error Int), Time)} conv$36
                                   in Array_fold#@{((Sum Error Int), Time)}@{((Sum Error Int), (Sum Error Int))} 
-                                   (\conv$10@{((Sum Error Int), (Sum Error Int))} \conv$9@{((Sum Error Int), Time)} 
-                                     let conv$28 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
-                                     let v$inline$0$conv$13 = fst#@{(Sum Error Int), Time} conv$9
-                                      in pair#@{(Sum Error Int), (Sum Error Int)} v$inline$0$conv$13 (
-                                       let s$conv$22 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
-                                         (\reify$0$conv$15@{Error} left#@{Error, Int} reify$0$conv$15) 
-                                         (\reify$1$conv$16@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
-                                           (\reify$2$conv$17@{Error} left#@{Error, Int} reify$2$conv$17) 
-                                           (\reify$3$conv$18@{Int} right#@{Error, Int} (add#@{Int} reify$1$conv$16 reify$3$conv$18)) conv$28) v$inline$0$conv$13
-                                        in s$conv$22)) ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))}) conv$6
-                               let conv$31 = snd#@{(Sum Error Int), (Sum Error Int)} conv$11
-                                in conv$31)) conv$37) (Right Map []@{(Sum Error (Map Time Int))}) conv$5
+                                   (\conv$9@{((Sum Error Int), (Sum Error Int))} \conv$8@{((Sum Error Int), Time)} 
+                                     let conv$27 = snd#@{(Sum Error Int), (Sum Error Int)} conv$9
+                                     let v$inline$0$conv$12 = fst#@{(Sum Error Int), Time} conv$8
+                                      in pair#@{(Sum Error Int), (Sum Error Int)} v$inline$0$conv$12 (
+                                       let s$conv$21 = Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
+                                         (\reify$0$conv$14@{Error} left#@{Error, Int} reify$0$conv$14) 
+                                         (\reify$1$conv$15@{Int} Sum_fold#@{(Error,Int)}@{(Sum Error Int)} 
+                                           (\reify$2$conv$16@{Error} left#@{Error, Int} reify$2$conv$16) 
+                                           (\reify$3$conv$17@{Int} right#@{Error, Int} (add#@{Int} reify$1$conv$15 reify$3$conv$17)) conv$27) v$inline$0$conv$12
+                                        in s$conv$21)) ((Left ExceptNotAnError, Right 0)@{((Sum Error Int), (Sum Error Int))}) conv$5
+                               let conv$30 = snd#@{(Sum Error Int), (Sum Error Int)} conv$10
+                                in conv$30)) conv$32) (Right Map []@{(Sum Error (Map Time Int))}) conv$40
 
 Returning:
-  repl                 = conv$40
+  repl                 = conv$41
 
 
 - Core type:

--- a/icicle-repl/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-repl/test/cli/repl/t10.3-flatten/expected
@@ -311,30 +311,30 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl (flat$23$simpflat$56@{Err
 > - Flattened (simplified), not typechecked:
 conv$3 = TIME
 conv$4 = MAX_MAP_SIZE
-init acc$conv$5$simpflat$38@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
-init acc$conv$5$simpflat$39@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
-init acc$conv$5$simpflat$40@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
-init acc$conv$5$simpflat$41@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-load_resumable@{Array Time} acc$conv$5$simpflat$38;
-load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$5$simpflat$39;
-load_resumable@{Array (Buf 2 Error)} acc$conv$5$simpflat$40;
-load_resumable@{Array (Buf 2 Int)} acc$conv$5$simpflat$41;
+init acc$conv$40$simpflat$38@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init acc$conv$40$simpflat$39@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
+init acc$conv$40$simpflat$40@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
+init acc$conv$40$simpflat$41@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
+load_resumable@{Array Time} acc$conv$40$simpflat$38;
+load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$40$simpflat$39;
+load_resumable@{Array (Buf 2 Error)} acc$conv$40$simpflat$40;
+load_resumable@{Array (Buf 2 Int)} acc$conv$40$simpflat$41;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, conv$0$simpflat$128@{Int}, conv$0$simpflat$129@{Time}) in new
 {
-  read conv$5$aval$0$simpflat$43 = acc$conv$5$simpflat$38 [Array Time];
-  read conv$5$aval$0$simpflat$44 = acc$conv$5$simpflat$39 [Array (Buf 2 FactIdentifier)];
-  read conv$5$aval$0$simpflat$45 = acc$conv$5$simpflat$40 [Array (Buf 2 Error)];
-  read conv$5$aval$0$simpflat$46 = acc$conv$5$simpflat$41 [Array (Buf 2 Int)];
+  read conv$40$aval$0$simpflat$43 = acc$conv$40$simpflat$38 [Array Time];
+  read conv$40$aval$0$simpflat$44 = acc$conv$40$simpflat$39 [Array (Buf 2 FactIdentifier)];
+  read conv$40$aval$0$simpflat$45 = acc$conv$40$simpflat$40 [Array (Buf 2 Error)];
+  read conv$40$aval$0$simpflat$46 = acc$conv$40$simpflat$41 [Array (Buf 2 Int)];
   let simpflat$475 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
   let simpflat$268 = Buf_push#@{Buf 2 FactIdentifier} simpflat$475 conv$1;
   let simpflat$476 = Buf_make#@{Buf 2 Error} (()@{Unit});
   let simpflat$271 = Buf_push#@{Buf 2 Error} simpflat$476 conv$0$simpflat$127;
   let simpflat$477 = Buf_make#@{Buf 2 Int} (()@{Unit});
   let simpflat$274 = Buf_push#@{Buf 2 Int} simpflat$477 conv$0$simpflat$128;
-  init map_insert_acc_keys$flat$1@{Array Time} = conv$5$aval$0$simpflat$43;
-  init map_insert_acc_vals$flat$2$simpflat$48@{Array (Buf 2 FactIdentifier)} = conv$5$aval$0$simpflat$44;
-  init map_insert_acc_vals$flat$2$simpflat$49@{Array (Buf 2 Error)} = conv$5$aval$0$simpflat$45;
-  init map_insert_acc_vals$flat$2$simpflat$50@{Array (Buf 2 Int)} = conv$5$aval$0$simpflat$46;
+  init map_insert_acc_keys$flat$1@{Array Time} = conv$40$aval$0$simpflat$43;
+  init map_insert_acc_vals$flat$2$simpflat$48@{Array (Buf 2 FactIdentifier)} = conv$40$aval$0$simpflat$44;
+  init map_insert_acc_vals$flat$2$simpflat$49@{Array (Buf 2 Error)} = conv$40$aval$0$simpflat$45;
+  init map_insert_acc_vals$flat$2$simpflat$50@{Array (Buf 2 Int)} = conv$40$aval$0$simpflat$46;
   init map_insert_acc_bs_found$flat$4@{Bool} = False@{Bool};
   init map_insert_acc_bs_index$flat$3@{Int} = -1@{Int};
   read map_insert_loc_keys$flat$5 = map_insert_acc_keys$flat$1 [Array Time];
@@ -491,39 +491,39 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, 
   read map_insert_loc_vals$flat$6$simpflat$72 = map_insert_acc_vals$flat$2$simpflat$48 [Array (Buf 2 FactIdentifier)];
   read map_insert_loc_vals$flat$6$simpflat$73 = map_insert_acc_vals$flat$2$simpflat$49 [Array (Buf 2 Error)];
   read map_insert_loc_vals$flat$6$simpflat$74 = map_insert_acc_vals$flat$2$simpflat$50 [Array (Buf 2 Int)];
-  write acc$conv$5$simpflat$38 = map_insert_loc_keys$flat$5;
-  write acc$conv$5$simpflat$39 = map_insert_loc_vals$flat$6$simpflat$72;
-  write acc$conv$5$simpflat$40 = map_insert_loc_vals$flat$6$simpflat$73;
-  write acc$conv$5$simpflat$41 = map_insert_loc_vals$flat$6$simpflat$74;
+  write acc$conv$40$simpflat$38 = map_insert_loc_keys$flat$5;
+  write acc$conv$40$simpflat$39 = map_insert_loc_vals$flat$6$simpflat$72;
+  write acc$conv$40$simpflat$40 = map_insert_loc_vals$flat$6$simpflat$73;
+  write acc$conv$40$simpflat$41 = map_insert_loc_vals$flat$6$simpflat$74;
 }
-read acc$conv$5$flat$36$simpflat$77 = acc$conv$5$simpflat$39 [Array (Buf 2 FactIdentifier)];
-foreach (flat$38 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$5$flat$36$simpflat$77)
+read acc$conv$40$flat$36$simpflat$77 = acc$conv$40$simpflat$39 [Array (Buf 2 FactIdentifier)];
+foreach (flat$38 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$40$flat$36$simpflat$77)
 {
-  let simpflat$409 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$5$flat$36$simpflat$77 flat$38;
+  let simpflat$409 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$40$flat$36$simpflat$77 flat$38;
   let flat$39 = Buf_read#@{Array FactIdentifier} simpflat$409;
   foreach (flat$40 in 0@{Int} .. Array_length#@{FactIdentifier} flat$39)
   {
     keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$39 flat$40;
   }
 }
-save_resumable@{Array Time} acc$conv$5$simpflat$38;
-save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$5$simpflat$39;
-save_resumable@{Array (Buf 2 Error)} acc$conv$5$simpflat$40;
-save_resumable@{Array (Buf 2 Int)} acc$conv$5$simpflat$41;
-read conv$5$simpflat$81 = acc$conv$5$simpflat$38 [Array Time];
-read conv$5$simpflat$83 = acc$conv$5$simpflat$40 [Array (Buf 2 Error)];
-read conv$5$simpflat$84 = acc$conv$5$simpflat$41 [Array (Buf 2 Int)];
+save_resumable@{Array Time} acc$conv$40$simpflat$38;
+save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$40$simpflat$39;
+save_resumable@{Array (Buf 2 Error)} acc$conv$40$simpflat$40;
+save_resumable@{Array (Buf 2 Int)} acc$conv$40$simpflat$41;
+read conv$40$simpflat$81 = acc$conv$40$simpflat$38 [Array Time];
+read conv$40$simpflat$83 = acc$conv$40$simpflat$40 [Array (Buf 2 Error)];
+read conv$40$simpflat$84 = acc$conv$40$simpflat$41 [Array (Buf 2 Int)];
 init flat$48$simpflat$86@{Error} = ExceptNotAnError@{Error};
 init flat$48$simpflat$87@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
 init flat$48$simpflat$88@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$5$simpflat$81)
+foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$40$simpflat$81)
 {
   read flat$48$simpflat$89 = flat$48$simpflat$86 [Error];
   read flat$48$simpflat$90 = flat$48$simpflat$87 [Array Time];
   read flat$48$simpflat$91 = flat$48$simpflat$88 [Array Int];
-  let simpflat$424 = unsafe_Array_index#@{Time} conv$5$simpflat$81 for_counter$flat$49;
-  let simpflat$428 = unsafe_Array_index#@{Buf 2 Error} conv$5$simpflat$83 for_counter$flat$49;
-  let simpflat$430 = unsafe_Array_index#@{Buf 2 Int} conv$5$simpflat$84 for_counter$flat$49;
+  let simpflat$424 = unsafe_Array_index#@{Time} conv$40$simpflat$81 for_counter$flat$49;
+  let simpflat$428 = unsafe_Array_index#@{Buf 2 Error} conv$40$simpflat$83 for_counter$flat$49;
+  let simpflat$430 = unsafe_Array_index#@{Buf 2 Int} conv$40$simpflat$84 for_counter$flat$49;
   init flat$51$simpflat$92@{Error} = ExceptNotAnError@{Error};
   init flat$51$simpflat$93@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat$51$simpflat$94@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
@@ -730,30 +730,30 @@ output@{(Sum Error (Map Time Int))} repl (flat$48$simpflat$124@{Error}, flat$48$
 - Flattened Avalanche (simplified), typechecked:
 conv$3 = TIME
 conv$4 = MAX_MAP_SIZE
-init acc$conv$5$simpflat$38@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
-init acc$conv$5$simpflat$39@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
-init acc$conv$5$simpflat$40@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
-init acc$conv$5$simpflat$41@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-load_resumable@{Array Time} acc$conv$5$simpflat$38;
-load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$5$simpflat$39;
-load_resumable@{Array (Buf 2 Error)} acc$conv$5$simpflat$40;
-load_resumable@{Array (Buf 2 Int)} acc$conv$5$simpflat$41;
+init acc$conv$40$simpflat$38@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init acc$conv$40$simpflat$39@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
+init acc$conv$40$simpflat$40@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
+init acc$conv$40$simpflat$41@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
+load_resumable@{Array Time} acc$conv$40$simpflat$38;
+load_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$40$simpflat$39;
+load_resumable@{Array (Buf 2 Error)} acc$conv$40$simpflat$40;
+load_resumable@{Array (Buf 2 Int)} acc$conv$40$simpflat$41;
 for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, conv$0$simpflat$128@{Int}, conv$0$simpflat$129@{Time}) in new
 {
-  read conv$5$aval$0$simpflat$43 = acc$conv$5$simpflat$38 [Array Time];
-  read conv$5$aval$0$simpflat$44 = acc$conv$5$simpflat$39 [Array (Buf 2 FactIdentifier)];
-  read conv$5$aval$0$simpflat$45 = acc$conv$5$simpflat$40 [Array (Buf 2 Error)];
-  read conv$5$aval$0$simpflat$46 = acc$conv$5$simpflat$41 [Array (Buf 2 Int)];
+  read conv$40$aval$0$simpflat$43 = acc$conv$40$simpflat$38 [Array Time];
+  read conv$40$aval$0$simpflat$44 = acc$conv$40$simpflat$39 [Array (Buf 2 FactIdentifier)];
+  read conv$40$aval$0$simpflat$45 = acc$conv$40$simpflat$40 [Array (Buf 2 Error)];
+  read conv$40$aval$0$simpflat$46 = acc$conv$40$simpflat$41 [Array (Buf 2 Int)];
   let simpflat$475 = Buf_make#@{Buf 2 FactIdentifier} (()@{Unit});
   let simpflat$268 = Buf_push#@{Buf 2 FactIdentifier} simpflat$475 conv$1;
   let simpflat$476 = Buf_make#@{Buf 2 Error} (()@{Unit});
   let simpflat$271 = Buf_push#@{Buf 2 Error} simpflat$476 conv$0$simpflat$127;
   let simpflat$477 = Buf_make#@{Buf 2 Int} (()@{Unit});
   let simpflat$274 = Buf_push#@{Buf 2 Int} simpflat$477 conv$0$simpflat$128;
-  init map_insert_acc_keys$flat$1@{Array Time} = conv$5$aval$0$simpflat$43;
-  init map_insert_acc_vals$flat$2$simpflat$48@{Array (Buf 2 FactIdentifier)} = conv$5$aval$0$simpflat$44;
-  init map_insert_acc_vals$flat$2$simpflat$49@{Array (Buf 2 Error)} = conv$5$aval$0$simpflat$45;
-  init map_insert_acc_vals$flat$2$simpflat$50@{Array (Buf 2 Int)} = conv$5$aval$0$simpflat$46;
+  init map_insert_acc_keys$flat$1@{Array Time} = conv$40$aval$0$simpflat$43;
+  init map_insert_acc_vals$flat$2$simpflat$48@{Array (Buf 2 FactIdentifier)} = conv$40$aval$0$simpflat$44;
+  init map_insert_acc_vals$flat$2$simpflat$49@{Array (Buf 2 Error)} = conv$40$aval$0$simpflat$45;
+  init map_insert_acc_vals$flat$2$simpflat$50@{Array (Buf 2 Int)} = conv$40$aval$0$simpflat$46;
   init map_insert_acc_bs_found$flat$4@{Bool} = False@{Bool};
   init map_insert_acc_bs_index$flat$3@{Int} = -1@{Int};
   read map_insert_loc_keys$flat$5 = map_insert_acc_keys$flat$1 [Array Time];
@@ -910,39 +910,39 @@ for_facts (conv$2@{Time}, conv$1@{FactIdentifier}, conv$0$simpflat$127@{Error}, 
   read map_insert_loc_vals$flat$6$simpflat$72 = map_insert_acc_vals$flat$2$simpflat$48 [Array (Buf 2 FactIdentifier)];
   read map_insert_loc_vals$flat$6$simpflat$73 = map_insert_acc_vals$flat$2$simpflat$49 [Array (Buf 2 Error)];
   read map_insert_loc_vals$flat$6$simpflat$74 = map_insert_acc_vals$flat$2$simpflat$50 [Array (Buf 2 Int)];
-  write acc$conv$5$simpflat$38 = map_insert_loc_keys$flat$5;
-  write acc$conv$5$simpflat$39 = map_insert_loc_vals$flat$6$simpflat$72;
-  write acc$conv$5$simpflat$40 = map_insert_loc_vals$flat$6$simpflat$73;
-  write acc$conv$5$simpflat$41 = map_insert_loc_vals$flat$6$simpflat$74;
+  write acc$conv$40$simpflat$38 = map_insert_loc_keys$flat$5;
+  write acc$conv$40$simpflat$39 = map_insert_loc_vals$flat$6$simpflat$72;
+  write acc$conv$40$simpflat$40 = map_insert_loc_vals$flat$6$simpflat$73;
+  write acc$conv$40$simpflat$41 = map_insert_loc_vals$flat$6$simpflat$74;
 }
-read acc$conv$5$flat$36$simpflat$77 = acc$conv$5$simpflat$39 [Array (Buf 2 FactIdentifier)];
-foreach (flat$38 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$5$flat$36$simpflat$77)
+read acc$conv$40$flat$36$simpflat$77 = acc$conv$40$simpflat$39 [Array (Buf 2 FactIdentifier)];
+foreach (flat$38 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc$conv$40$flat$36$simpflat$77)
 {
-  let simpflat$409 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$5$flat$36$simpflat$77 flat$38;
+  let simpflat$409 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc$conv$40$flat$36$simpflat$77 flat$38;
   let flat$39 = Buf_read#@{Array FactIdentifier} simpflat$409;
   foreach (flat$40 in 0@{Int} .. Array_length#@{FactIdentifier} flat$39)
   {
     keep_fact_in_history unsafe_Array_index#@{FactIdentifier} flat$39 flat$40;
   }
 }
-save_resumable@{Array Time} acc$conv$5$simpflat$38;
-save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$5$simpflat$39;
-save_resumable@{Array (Buf 2 Error)} acc$conv$5$simpflat$40;
-save_resumable@{Array (Buf 2 Int)} acc$conv$5$simpflat$41;
-read conv$5$simpflat$81 = acc$conv$5$simpflat$38 [Array Time];
-read conv$5$simpflat$83 = acc$conv$5$simpflat$40 [Array (Buf 2 Error)];
-read conv$5$simpflat$84 = acc$conv$5$simpflat$41 [Array (Buf 2 Int)];
+save_resumable@{Array Time} acc$conv$40$simpflat$38;
+save_resumable@{Array (Buf 2 FactIdentifier)} acc$conv$40$simpflat$39;
+save_resumable@{Array (Buf 2 Error)} acc$conv$40$simpflat$40;
+save_resumable@{Array (Buf 2 Int)} acc$conv$40$simpflat$41;
+read conv$40$simpflat$81 = acc$conv$40$simpflat$38 [Array Time];
+read conv$40$simpflat$83 = acc$conv$40$simpflat$40 [Array (Buf 2 Error)];
+read conv$40$simpflat$84 = acc$conv$40$simpflat$41 [Array (Buf 2 Int)];
 init flat$48$simpflat$86@{Error} = ExceptNotAnError@{Error};
 init flat$48$simpflat$87@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
 init flat$48$simpflat$88@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$5$simpflat$81)
+foreach (for_counter$flat$49 in 0@{Int} .. Array_length#@{Time} conv$40$simpflat$81)
 {
   read flat$48$simpflat$89 = flat$48$simpflat$86 [Error];
   read flat$48$simpflat$90 = flat$48$simpflat$87 [Array Time];
   read flat$48$simpflat$91 = flat$48$simpflat$88 [Array Int];
-  let simpflat$424 = unsafe_Array_index#@{Time} conv$5$simpflat$81 for_counter$flat$49;
-  let simpflat$428 = unsafe_Array_index#@{Buf 2 Error} conv$5$simpflat$83 for_counter$flat$49;
-  let simpflat$430 = unsafe_Array_index#@{Buf 2 Int} conv$5$simpflat$84 for_counter$flat$49;
+  let simpflat$424 = unsafe_Array_index#@{Time} conv$40$simpflat$81 for_counter$flat$49;
+  let simpflat$428 = unsafe_Array_index#@{Buf 2 Error} conv$40$simpflat$83 for_counter$flat$49;
+  let simpflat$430 = unsafe_Array_index#@{Buf 2 Int} conv$40$simpflat$84 for_counter$flat$49;
   init flat$51$simpflat$92@{Error} = ExceptNotAnError@{Error};
   init flat$51$simpflat$93@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat$51$simpflat$94@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});

--- a/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
@@ -158,142 +158,11 @@ convertQuery q
             let bs' = filt e' (streams bs) <> bs { streams = [] }
             return (bs', b)
 
-
-    -- TODO: latest can actually have multiple 'aggregate passes',
-    -- eg you should be able to do
-    --
-    -- > latest 5 ~> value / sum value
-    --
-    -- since this only requires a second pass over the small array that is
-    -- already in memory.
-    --
-    -- However, at the moment we only support folds with single pass,
-    -- and not returning the whole array.
     (Latest _ _ : _)
-     -> do  -- We can cheat!
-            -- Convert the entire latest query as a fold.
-            res        <- convertFold q
-            n'red      <- lift fresh
-            n'ret      <- lift fresh
+     -> convertAsFold
 
-            let k'      = beta
-                        ( foldKons res CE.@~ CE.xVar n'red)
-
-            let b'red   = sfold  n'red (typeFold res) (foldZero res) k'
-            let b'ret   = post n'ret $ beta (mapExtract res CE.@~ CE.xVar n'red)
-
-            return (b'red <> b'ret, n'ret)
-
-    -- Convert a group by into the construction of a Map.
-    -- The key is the "by" of the group, while the value is the result of the
-    -- aggregate over the partitioned results.
-    --
-    -- The result of a group by must be an aggregate, which means we have a
-    -- relatively good idea of an upper bound on memory here,
-    -- as long as the "by" is something like an enum, and the "value" has bounded memory.
-    --
-    (GroupBy (Annot { annAnnot = ann, annResult = retty }) e : _)
-     -> do  n'      <- lift fresh
-
-            -- Convert the rest of the query into a fold.
-            -- We have the "k"onstructor, the "z"ero, and the e"x"tract,
-            -- as well as the intermediate result type before extraction.
-            -- See convertFold.
-            res     <- convertFold q'
-
-            tK      <- convertValType' $ annResult $ annotOfExp e
-            let tV   = typeFold res
-
-            -- Convert the "by" to a simple expression.
-            -- This becomes the map insertion key.
-            e'      <- convertExp e
-
-            let mapt = T.MapT tK tV
-
-            -- For each input element, we use the group by as the key, and insert into a map.
-            --
-            -- If the map already has the key, we perform the "k" on the current element
-            -- and the existing value - the fold accumulator.
-            --
-            -- If the map doesn't have the key, we insert the "k" of the current element
-            -- with the zero accumulator.
-            -- This is because the map doesn't start with "zero"s in it, unlike a normal fold.
-            let priminsert
-                    = C.PrimMapInsertOrUpdate tK tV
-
-            let insertOrUpdate
-                    = beta
-                    $ CE.makeApps () (CE.xPrim $ C.PrimMap $ priminsert)
-                    [ foldKons res
-                    , foldKons res `CE.xApp` foldZero res
-                    , e'
-                    , CE.xVar n']
-
-            let emptyMap
-                    = CE.emptyMap tK tV
-
-            -- Perform the map fold
-            let r = sfold n' mapt emptyMap insertOrUpdate
-
-            -- After all the elements have been seen, we go through the map and perform
-            -- the "extract" on each value.
-            -- This performs any fixups that couldn't be performed during the fold.
-
-            -- Unwrapped results
-            (tKr,tXr) <- getGroupByMapType ann retty
-            let isPossibly = PossibilityPossibly == getPossibilityOrDefinitely retty
-                sumt | isPossibly
-                     = T.SumT T.ErrorT $ T.MapT tKr tXr
-                     | otherwise
-                     = T.MapT tKr tXr
-                emptyResult
-                     | isPossibly
-                     = CE.xValue sumt $ VRight $ VMap Map.empty
-                     | otherwise
-                     = CE.xValue sumt $ VMap Map.empty
-
-            nkey    <- lift fresh
-            nkey'   <- lift fresh
-            nval    <- lift fresh
-            nval'   <- lift fresh
-            nval''  <- lift fresh
-            nmap    <- lift fresh
-            nmap'   <- lift fresh
-
-            nErr    <- lift fresh
-
-            let unwrapSum' chk = unwrapSum chk sumt nErr
-
-            let rewrapSum' = rewrapSum isPossibly sumt
-
-            let ins = CE.xLam nmap sumt
-                    $ CE.xLam nkey tK
-                    $ CE.xLam nval tV
-                    $ unwrapSum' isPossibly
-                                 (CE.xVar nmap) nmap' sumt
-                    $ unwrapSum' (isAnnotPossibly $ annotOfExp e)
-                                 (CE.xVar nkey) nkey' tK
-                    $ unwrapSum' (isAnnotPossibly $ annotOfQuery q')
-                                 (beta (mapExtract res CE.@~ CE.xVar nval)) nval' (typeExtract res)
-                    $ rewrapSum'
-                    $ CE.makeApps () (CE.xPrim $ C.PrimMap $ C.PrimMapInsertOrUpdate tKr tXr)
-                    [ CE.xLam nval'' tXr $ CE.xVar nval''
-                    , CE.xVar nval'
-                    , CE.xVar nkey'
-                    , CE.xVar nmap']
-
-
-            let mapResult
-                    = CE.xPrim (C.PrimFold (C.PrimFoldMap tK tV) sumt)
-                    CE.@~ beta ins
-                    CE.@~ emptyResult
-                    CE.@~ CE.xVar n'
-
-            n''     <- lift fresh
-            let p   = post n'' mapResult
-
-            return (r <> p, n'')
-
+    (GroupBy _ _ : _)
+     -> convertAsFold
 
     -- Convert a group fold using a Map. Very similar to Group By, with an additional
     -- postcomputation.
@@ -333,74 +202,8 @@ convertQuery q
 
             return (bs <> p, n')
 
-    -- Distinct is very similar to a group by, except instead of performing the fold
-    -- as the elements are seen into the map,
-    -- we insert/update the element in the map, then fold over essentially the last-seen
-    -- for each group.
     (Distinct _ e : _)
-     -> do  tkey <- convertValType' $ annResult $ annotOfExp e
-
-            n'      <- lift fresh
-            n''     <- lift fresh
-            n'key   <- lift fresh
-            n'ignore<- lift fresh
-            n'ignore2<- lift fresh
-
-            -- Convert the rest of the query into a fold.
-            -- This is executed as a Map fold at the end, rather than
-            -- as a stream fold.
-            res     <- convertFold q'
-
-            let tV'  = typeFold res
-
-            -- Convert the "by" to a simple expression.
-            -- This becomes the map insertion key.
-            e'      <- convertExp e
-
-            let mapt    = T.MapT tkey T.UnitT
-            let pairt   = T.PairT mapt tV'
-
-            let xfst    = CE.xApp
-                        $ CE.xPrim $ C.PrimMinimal $ Min.PrimPair $ Min.PrimPairFst mapt tV'
-            let xsnd    = CE.xApp
-                        $ CE.xPrim $ C.PrimMinimal $ Min.PrimPair $ Min.PrimPairSnd mapt tV'
-
-            let pair x y= (CE.xPrim $ C.PrimMinimal $ Min.PrimConst $ Min.PrimConstPair mapt tV')
-                        CE.@~ x CE.@~ y
-
-            -- This is a little bit silly -
-            -- this "insertOrUpdate" should really just be an insert.
-            -- Just put each element in the map, potentially overwriting the last one.
-            let insert_map mm kk vv
-                  = CE.xPrim (C.PrimMap $ C.PrimMapInsertOrUpdate tkey T.UnitT)
-                    CE.@~ (CE.xLam n'ignore T.UnitT $ vv)
-                    CE.@~ vv
-                    CE.@~ kk
-                    CE.@~ mm
-
-            let update_step
-                        = pair
-                        ( insert_map (xfst $ CE.xVar n') (CE.xVar n'key) (CE.xValue T.UnitT VUnit) )
-                        ( foldKons res CE.@~ xsnd (CE.xVar n') )
-
-            let check_if_exists
-                        = CE.xPrim (C.PrimMap (C.PrimMapLookup tkey T.UnitT))
-                        CE.@~ xfst (CE.xVar n')
-                        CE.@~ CE.xVar n'key
-
-            let kons    = CE.xLet n'key e'
-                        ( CE.xPrim (C.PrimFold (C.PrimFoldOption T.UnitT) pairt)
-                        CE.@~ CE.xLam n'ignore2 T.UnitT (CE.xVar n')
-                        CE.@~ CE.xLam n'ignore2 T.UnitT update_step
-                        CE.@~ check_if_exists )
-
-            -- Perform the map fold
-            let r = sfold n' pairt (pair (CE.emptyMap tkey T.UnitT) (foldZero res)) (beta kons)
-
-            -- Perform a fold over that map
-            let p = post n'' $ beta (mapExtract res CE.@~ xsnd (CE.xVar n'))
-
-            return (r <> p, n'')
+     -> convertAsFold
 
     (Let _ b def : _)
      -> case getTemporalityOrPure $ annResult $ annotOfExp def of
@@ -494,6 +297,20 @@ convertQuery q
 
   getGroupByMapType = groupMapType convertValType'
   getGroupFoldType  = groupFoldType convertValType'
+
+  -- When the convertFold and convertQuery are exactly the same, just use convertFold instead.
+  convertAsFold = do
+    res        <- convertFold q
+    n'red      <- lift fresh
+    n'ret      <- lift fresh
+
+    let k'      = beta
+                ( foldKons res CE.@~ CE.xVar n'red)
+
+    let b'red   = sfold  n'red (typeFold res) (foldZero res) k'
+    let b'ret   = post n'ret $ beta (mapExtract res CE.@~ CE.xVar n'red)
+
+    return (b'red <> b'ret, n'ret)
 
 
 -- | Convert an Aggregate computation at the end of a query.

--- a/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
@@ -202,7 +202,7 @@ convertQuery q
 
             return (bs <> p, n')
 
-    (Distinct _ e : _)
+    (Distinct _ _ : _)
      -> convertAsFold
 
     (Let _ b def : _)
@@ -295,7 +295,6 @@ convertQuery q
 
   convertValType' = convertValType (annAnnot $ annotOfQuery q)
 
-  getGroupByMapType = groupMapType convertValType'
   getGroupFoldType  = groupFoldType convertValType'
 
   -- When the convertFold and convertQuery are exactly the same, just use convertFold instead.


### PR DESCRIPTION
The test changes are just renaming.

Conversion to Core had the group and distinct code more or less copied across `convertFold` and `convertQuery`, but we can just call the `convertFold` case from `convertQuery`.

! @jystic @tranma 
/jury approved @jystic