### PR TITLE
Write out schema whenever we run a query

### DIFF
--- a/icicle-compiler/bench/bench.hs
+++ b/icicle-compiler/bench/bench.hs
@@ -144,9 +144,8 @@ createBenchmark (name, path) = do
   b <- createPsvQuery $ QueryOptions
     (DictionaryToml dict)
     (InputFile InputSparsePsv input)
-    (OutputFile OutputSparsePsv output)
+    (OutputFile OutputSparsePsv output Nothing)
     (Just c)
-    Nothing
     (ScopeSnapshot time)
     (1024*1024)
     Nothing

--- a/icicle-compiler/bench/bench.hs
+++ b/icicle-compiler/bench/bench.hs
@@ -146,6 +146,7 @@ createBenchmark (name, path) = do
     (InputFile InputSparsePsv input)
     (OutputFile OutputSparsePsv output)
     (Just c)
+    Nothing
     (ScopeSnapshot time)
     (1024*1024)
     Nothing

--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -31,6 +31,7 @@ library
                      , icicle-data
                      , icicle-source
                      , aeson                           >= 0.8        && < 1.2
+                     , aeson-pretty                    >= 0.8        && < 0.9
                      , annotated-wl-pprint             == 0.7.*
                      , ansi-terminal                   == 0.6.*
                      , bifunctors                      >= 4.2        && < 5.4
@@ -143,6 +144,7 @@ library
                        Icicle.Sea.IO.Psv
                        Icicle.Sea.IO.Psv.Input
                        Icicle.Sea.IO.Psv.Output
+                       Icicle.Sea.IO.Psv.Schema
                        Icicle.Sea.IO.Zebra
 
                        Icicle.Internal.Rename

--- a/icicle-compiler/main/icicle.hs
+++ b/icicle-compiler/main/icicle.hs
@@ -78,7 +78,6 @@ pQuery =
     <*> pInputFile
     <*> pOutputFile
     <*> optional pOutputCode
-    <*> optional pOutputSchema
     <*> (pSnapshot <|> pChordPath)
     <*> pLimit
     <*> pDrop
@@ -149,7 +148,7 @@ pOutputFormat =
 
 pOutputSparse :: Parser OutputFile
 pOutputSparse =
-  fmap (OutputFile OutputSparsePsv) $
+  fmap (\path -> OutputFile OutputSparsePsv path Nothing) $
     strOption (long "output-sparse-psv" <> metavar "OUTPUT_PSV")
 
 pOutputSparseFormat :: Parser OutputFormat
@@ -158,8 +157,9 @@ pOutputSparseFormat =
 
 pOutputDense :: Parser OutputFile
 pOutputDense =
-  fmap (OutputFile OutputDensePsv) $
-    strOption (long "output-dense-psv" <> metavar "OUTPUT_PSV")
+  OutputFile OutputDensePsv
+    <$> strOption (long "output-dense-psv" <> metavar "OUTPUT_PSV")
+    <*> optional pOutputSchema
 
 pOutputDenseFormat :: Parser OutputFormat
 pOutputDenseFormat =

--- a/icicle-compiler/src/Icicle/Command.hs
+++ b/icicle-compiler/src/Icicle/Command.hs
@@ -115,7 +115,6 @@ data QueryOptions = QueryOptions {
   , optInput        :: InputFile
   , optOutput       :: OutputFile
   , optOutputCode   :: Maybe FilePath
-  , optOutputSchema :: Maybe FilePath
   , optScope        :: Scope FilePath
   , optFactsLimit   :: Int
   -- ^ only applies to psv input
@@ -149,6 +148,7 @@ data OutputFile =
   OutputFile {
       outputFormat :: OutputFormat
     , outputPath :: FilePath
+    , outputSchema :: Maybe FilePath
     } deriving (Eq, Ord, Show)
 
 data OutputFormat =
@@ -201,7 +201,7 @@ createZebraQuery = createQuery
 createQuery :: QueryOptions -> EitherT IcicleError IO (Query a)
 createQuery c = do
   let dropPath = fromMaybe (outputPath (optOutput c) <> ".dropped") (optDrop c)
-  let schemaPath = fromMaybe (outputPath (optOutput c) <> ".schema.json") (optOutputSchema c)
+  let schemaPath = fromMaybe (outputPath (optOutput c) <> ".schema.json") (outputSchema (optOutput c))
   let chordPath = chordPathOfScope $ optScope c
   chordStart <- liftIO getCurrentTime
 

--- a/icicle-compiler/src/Icicle/Sea/Error.hs
+++ b/icicle-compiler/src/Icicle/Sea/Error.hs
@@ -17,6 +17,7 @@ import           Icicle.Data (Attribute)
 import qualified Icicle.Data as D
 import           Icicle.Internal.Pretty ((<+>), pretty, text, vsep, indent)
 import           Icicle.Internal.Pretty (Pretty)
+import           Icicle.Sea.IO.Psv.Schema
 
 import qualified Piano
 
@@ -60,6 +61,8 @@ data SeaError
   | SeaInvalidIdentitifier        Text
   | SeaNoFactLoop
   | SeaNoOutputs
+  | SeaCannotGenerateSchemaForSparseOutput
+  | SeaPsvSchemaDecodeError PsvSchemaDecodeError
   deriving (Eq, Show)
 
 instance Pretty SeaError where
@@ -122,6 +125,12 @@ instance Pretty SeaError where
 
     SeaNoOutputs
      -> text "No outputs"
+
+    SeaCannotGenerateSchemaForSparseOutput
+     -> text "Cannot generate output schema for sparse output"
+
+    SeaPsvSchemaDecodeError err
+     -> pretty $ renderPsvSchemaDecodeError err
 
     SeaProgramNotFound attr
      -> text "Program for attribute \"" <> pretty attr <> "\" not found"

--- a/icicle-compiler/src/Icicle/Sea/Fleet.hs
+++ b/icicle-compiler/src/Icicle/Sea/Fleet.hs
@@ -66,6 +66,7 @@ data SeaFleet config =
   SeaFleet {
       sfLibrary :: Library
     , sfSnapshot :: Ptr config -> EitherT SeaError IO ()
+    , sfOutputSchema :: Maybe PsvSchema
     , sfSegvInstall :: String -> IO ()
     , sfSegvRemove :: IO ()
     }
@@ -202,6 +203,25 @@ initSnapshot library piano = \case
   HasInput (FormatZebra _ _ _) _ input ->
     initZebraSnapshot library piano input
 
+getOutputSchema :: Library -> Input a -> EitherT SeaError IO (Maybe PsvSchema)
+getOutputSchema library = \case
+  NoInput ->
+    pure Nothing
+
+  HasInput _ _ _ -> do
+    c_psv_get_output_schema <-
+      firstT SeaJetskiError $ function library "psv_get_output_schema" (retPtr retCChar)
+
+    schemaPtr <- liftIO $ c_psv_get_output_schema []
+
+    if schemaPtr == nullPtr then
+      pure Nothing
+    else do
+      txt <- Text.pack <$> liftIO (peekCString schemaPtr)
+      schema <- hoistEither . first SeaPsvSchemaDecodeError $ parsePsvSchema txt
+      pure $
+        Just schema
+
 seaCreateFleet ::
      [CompilerOption]
   -> CacheLibrary
@@ -225,12 +245,18 @@ seaCreateFleet options cache input chordDescriptor code = do
   snapshot <-
     initSnapshot library piano input
 
+  schema <-
+    getOutputSchema library input
+
   pure SeaFleet {
       sfLibrary =
         library
 
     , sfSnapshot =
         snapshot
+
+    , sfOutputSchema =
+        schema
 
     , sfSegvInstall = \str ->
         withCStringLen str $ \(ptr, len) ->

--- a/icicle-compiler/src/Icicle/Sea/IO.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO.hs
@@ -33,6 +33,14 @@ module Icicle.Sea.IO
   , ZebraChunkFactCount (..)
   , ZebraAllocLimitGB (..)
 
+  , PsvSchema
+  , renderPrettyPsvSchema
+  , renderCompactPsvSchema
+  , parsePsvSchema
+
+  , PsvSchemaDecodeError
+  , renderPsvSchemaDecodeError
+
   , module Icicle.Sea.IO.Offset
   ) where
 

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
@@ -10,6 +10,7 @@ module Icicle.Sea.IO.Psv (
   , PsvOutputFormat(..)
   , PsvInputFormat(..)
   , PsvInputDenseDict(..)
+
   , seaOfPsvDriver
   , defaultPsvConstants
   , defaultOutputMissing
@@ -18,6 +19,14 @@ module Icicle.Sea.IO.Psv (
   , defaultPsvInputBufferSize
   , defaultPsvOutputBufferSize
   , defaultPsvMaxMapSize
+
+  , PsvSchema
+  , renderPrettyPsvSchema
+  , renderCompactPsvSchema
+  , parsePsvSchema
+
+  , PsvSchemaDecodeError
+  , renderPsvSchemaDecodeError
   ) where
 
 import           Icicle.Internal.Pretty
@@ -27,6 +36,7 @@ import           Icicle.Sea.FromAvalanche.State
 import           Icicle.Sea.IO.Base
 import           Icicle.Sea.IO.Psv.Input
 import           Icicle.Sea.IO.Psv.Output
+import           Icicle.Sea.IO.Psv.Schema
 
 import           P
 

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv/Output.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv/Output.hs
@@ -8,6 +8,7 @@ import qualified Data.List as List
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
 import qualified Data.Map as Map
+import qualified Data.Text as Text
 
 import           Icicle.Avalanche.Prim.Flat (Prim(..), PrimUnsafe(..))
 import           Icicle.Avalanche.Prim.Flat (meltType)
@@ -24,6 +25,7 @@ import           Icicle.Sea.FromAvalanche.Base hiding (assign)
 import           Icicle.Sea.FromAvalanche.Prim
 import           Icicle.Sea.FromAvalanche.State
 import           Icicle.Sea.IO.Base
+import           Icicle.Sea.IO.Psv.Schema
 
 import           P
 import           Prelude (String)
@@ -56,7 +58,10 @@ seaOfWriteFleetOutput config whitelist states = do
   let states' = case whitelist of
                   Nothing -> states
                   Just as -> filter (flip List.elem as . Source.takeAttributeName . stateAttribute) states
-  write_sea  <- traverse (seaOfWriteProgramOutput config) states'
+
+  write_sea <- traverse (seaOfWriteProgramOutput config) states'
+  schema_sea <- seaOfGetOutputSchema config states'
+
   let (beforeChord, inChord, afterChord)
          = case outputPsvFormat config of
              PsvOutputDense
@@ -95,6 +100,8 @@ seaOfWriteFleetOutput config whitelist states = do
     , ""
     , "    return 0;"
     , "}"
+    , ""
+    , schema_sea
     ]
 
 seaOfChordName :: Mode -> Doc
@@ -120,6 +127,42 @@ outputChord
   , indent 4 $ outputValue "string" ["chord_name", "chord_name_length"]
   , "}"
   ]
+
+seaOfConstantString :: Text -> Doc
+seaOfConstantString =
+  pretty . show -- FIXME this could be more robust, but I think it's OK for schemas
+
+textGroups80 :: Text -> [Text]
+textGroups80 xs =
+  let
+    (hd, tl) =
+      Text.splitAt 80 xs
+  in
+    if Text.null tl then
+      [hd]
+    else
+      hd : textGroups80 tl
+
+seaOfGetOutputSchema :: PsvOutputConfig -> [SeaProgramAttribute] -> Either SeaError Doc
+seaOfGetOutputSchema config programs =
+  case outputPsvFormat config of
+    PsvOutputSparse ->
+      pure $ vsep [
+          "istring_t psv_get_output_schema ()"
+        , "{"
+        , "    return NULL; /* no schema for sparse output */"
+        , "}"
+        ]
+
+    PsvOutputDense -> do
+      schema <- renderCompactPsvSchema <$> schemaOfFleet config programs
+      pure $ vsep [
+          "istring_t psv_get_output_schema ()"
+        , "{"
+        , "    return"
+        , indent 8 (vsep . fmap seaOfConstantString $ textGroups80 schema) <> ";"
+        , "}"
+        ]
 
 seaOfWriteProgramOutput :: PsvOutputConfig -> SeaProgramAttribute -> Either SeaError Doc
 seaOfWriteProgramOutput config state = do
@@ -555,3 +598,95 @@ outputDie = "if (error) return error;"
 quotedOutput :: IsInJSON -> Doc -> Doc
 quotedOutput NotInJSON out = out
 quotedOutput InJSON    out = vsep [outputChar '"', out, outputChar '"']
+
+------------------------------------------------------------------------
+
+schemaOfStructField :: StructField -> ValType -> Either SeaError PsvStructField
+schemaOfStructField (StructField name) typ =
+  PsvStructField name <$> schemaOfValType typ
+
+schemaOfValType :: ValType -> Either SeaError PsvEncoding
+schemaOfValType = \case
+  BoolT ->
+    pure $ PsvPrimitive PsvBoolean
+  IntT ->
+    pure $ PsvPrimitive PsvInt
+  DoubleT ->
+    pure $ PsvPrimitive PsvDouble
+  StringT ->
+    pure $ PsvPrimitive PsvString
+  TimeT ->
+    pure $ PsvPrimitive PsvString
+
+  UnitT ->
+    Left $ SeaUnsupportedOutputType UnitT
+  ErrorT ->
+    Left $ SeaUnsupportedOutputType ErrorT
+
+  ArrayT a ->
+    PsvList <$> schemaOfValType a
+
+  -- Map is just an array of size-two-array
+  MapT k v ->
+    PsvList <$> (PsvPair <$> schemaOfValType k <*> schemaOfValType v)
+
+  -- None becomes missing_value, Some is just the value
+  OptionT a ->
+    schemaOfValType a
+
+  PairT a b ->
+    PsvPair <$> schemaOfValType a <*> schemaOfValType b
+
+  -- In dense PSV, an error is always missing_value
+  SumT ErrorT v ->
+    schemaOfValType v
+  SumT x y ->
+    Left $ SeaUnsupportedOutputType (SumT x y)
+
+  StructT s ->
+    PsvStruct
+      <$> traverse (uncurry schemaOfStructField) (Map.toList $ getStructType s)
+
+  BufT _ a ->
+    PsvList <$> schemaOfValType a
+
+  FactIdentifierT ->
+    Left $ SeaUnsupportedOutputType FactIdentifierT
+
+schemaOfOutput :: OutputName -> ValType -> Either SeaError PsvColumn
+schemaOfOutput outputId typ =
+  let
+    name =
+      Source.takeNamespace (outputNamespace outputId) <> ":" <> outputName outputId
+  in
+    PsvColumn name <$> schemaOfValType typ
+
+schemaOfProgram :: SeaProgramAttribute -> Either SeaError [PsvColumn]
+schemaOfProgram =
+  -- NOTE the order of the columns here must match 'seaOfWriteProgramOutput' above
+  traverse (\(n, (t, _)) -> schemaOfOutput n t) . Map.toList . stateOutputsAll
+
+schemaOfLabel :: Mode -> [PsvColumn]
+schemaOfLabel = \case
+  Snapshot _ ->
+    []
+  Chords ->
+    [PsvColumn "timestamp" (PsvPrimitive PsvString)]
+
+schemaOfFleet :: PsvOutputConfig -> [SeaProgramAttribute] -> Either SeaError PsvSchema
+schemaOfFleet config programs =
+  case outputPsvFormat config of
+    PsvOutputSparse ->
+      Left SeaCannotGenerateSchemaForSparseOutput
+
+    PsvOutputDense -> do
+      columns0 <- concat <$> traverse schemaOfProgram programs
+
+      let
+        columns =
+          columns0 <> schemaOfLabel (outputPsvMode config)
+
+        missing =
+          PsvMissingValue $ outputPsvMissing config
+
+      pure $ PsvSchema missing columns

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv/Schema.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv/Schema.hs
@@ -1,0 +1,378 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Sea.IO.Psv.Schema (
+    PsvSchemaDecodeError(..)
+  , renderPsvSchemaDecodeError
+
+  , PsvSchema(..)
+  , PsvMissingValue(..)
+  , PsvColumn(..)
+  , PsvEncoding(..)
+  , PsvPrimitive(..)
+  , PsvStructField(..)
+
+  , renderPrettyPsvSchema
+  , renderCompactPsvSchema
+  , parsePsvSchema
+
+  , pSchema
+  , pColumn
+  , pEncoding
+  , pStructField
+  , pPrimitive
+
+  , ppSchema
+  , ppColumn
+  , ppEncoding
+  , ppStructField
+  , ppPrimitive
+  ) where
+
+import           Data.Aeson ((.=), (.:))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as Aeson
+import           Data.Aeson.Internal ((<?>))
+import qualified Data.Aeson.Internal as Aeson
+import qualified Data.Aeson.Parser as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.List as List
+import           Data.String (String)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Vector as Boxed
+
+import           P
+
+
+data PsvSchemaDecodeError =
+    PsvSchemaDecodeError !Aeson.JSONPath !Text
+    deriving (Eq, Show)
+
+renderPsvSchemaDecodeError :: PsvSchemaDecodeError -> Text
+renderPsvSchemaDecodeError = \case
+  PsvSchemaDecodeError path msg ->
+    Text.pack . Aeson.formatError path $ Text.unpack msg
+
+data PsvPrimitive =
+    PsvBoolean
+  | PsvInt
+  | PsvDouble
+  | PsvString
+  | PsvDate
+    deriving (Eq, Ord, Show)
+
+data PsvStructField =
+  PsvStructField {
+      fieldName :: !Text
+    , fieldEncoding :: !PsvEncoding
+    } deriving (Eq, Ord, Show)
+
+data PsvEncoding =
+    PsvPrimitive !PsvPrimitive
+  | PsvStruct ![PsvStructField]
+  | PsvList !PsvEncoding
+  | PsvPair !PsvEncoding !PsvEncoding
+    deriving (Eq, Ord, Show)
+
+data PsvColumn =
+  PsvColumn {
+      columnName :: !Text
+    , columnEncoding :: !PsvEncoding
+    } deriving (Eq, Ord, Show)
+
+newtype PsvMissingValue =
+  PsvMissingValue {
+      unPsvMissingValue :: Text
+    } deriving (Eq, Ord, Show)
+
+data PsvSchema =
+  PsvSchema {
+      schemaMissingValue :: !PsvMissingValue
+    , schemaColumns :: ![PsvColumn]
+    } deriving (Eq, Ord, Show)
+
+pText :: Aeson.Value -> Aeson.Parser Text
+pText =
+  Aeson.parseJSON
+
+ppText :: Text -> Aeson.Value
+ppText =
+  Aeson.toJSON
+
+pInt :: Aeson.Value -> Aeson.Parser Int
+pInt =
+  Aeson.parseJSON
+
+ppInt :: Int -> Aeson.Value
+ppInt =
+  Aeson.toJSON
+
+pEnum :: String -> (Text -> Maybe (Aeson.Value -> Aeson.Parser a)) -> Aeson.Value -> Aeson.Parser a
+pEnum expected mkParser =
+  Aeson.withObject expected $ \o ->
+    case HashMap.toList o of
+      [(name, value)] -> do
+        case mkParser name of
+          Nothing ->
+            fail (expected <> ": unknown variant: " <> Text.unpack name) <?> Aeson.Key name
+          Just parser ->
+            parser value <?> Aeson.Key name
+      [] ->
+        fail $
+          "Expected " <> expected <> " but found an object with no members."
+      kvs ->
+        fail $
+          "Expected " <> expected <> " but found an object with more than one member." <>
+          "\n  " <> List.intercalate ", " (fmap (Text.unpack . fst) kvs)
+
+ppEnum :: Text -> Aeson.Value -> Aeson.Value
+ppEnum name value =
+  Aeson.object [
+      name .= value
+    ]
+
+withKey :: Text -> Aeson.Object -> (Aeson.Value -> Aeson.Parser a) -> Aeson.Parser a
+withKey key o p = do
+  x <- o .: key
+  p x <?> Aeson.Key key
+
+pPrimitive :: Aeson.Value -> Aeson.Parser PsvPrimitive
+pPrimitive =
+  Aeson.withText "PsvPrimitive" $ \case
+    "boolean" ->
+      pure PsvBoolean
+    "int" ->
+      pure PsvInt
+    "double" ->
+      pure PsvDouble
+    "string" ->
+      pure PsvString
+    "date" ->
+      pure PsvDate
+    x ->
+      fail $ "Unknown primitive encoding: " <> Text.unpack x
+
+ppPrimitive :: PsvPrimitive -> Aeson.Value
+ppPrimitive = \case
+  PsvBoolean ->
+    ppText "boolean"
+  PsvInt ->
+    ppText "int"
+  PsvDouble ->
+    ppText "double"
+  PsvString ->
+    ppText "string"
+  PsvDate ->
+    ppText "date"
+
+pStructField :: Aeson.Value -> Aeson.Parser (Int, PsvStructField)
+pStructField =
+  Aeson.withObject "PsvStructField" $ \o -> do
+    name <- withKey "name" o pText
+    index <- withKey "index" o pInt
+    encoding <- withKey "encoding" o pEncoding
+    pure (index, PsvStructField name encoding)
+
+ppStructField :: Int -> PsvStructField -> Aeson.Value
+ppStructField ix (PsvStructField name encoding) =
+  Aeson.object [
+      "index" .=
+        ppInt ix -- this doesn't even make sense!
+
+    , "name" .=
+        ppText name
+
+    , "encoding" .=
+        ppEncoding encoding
+    ]
+
+pIndexedArray :: String -> (Aeson.Value -> Aeson.Parser (Int, a)) -> Aeson.Value -> Aeson.Parser [a]
+pIndexedArray expected p =
+  Aeson.withArray expected $ \xs -> do
+    ixs <- traverse p xs
+    pure .
+      fmap snd .
+      List.sortBy (comparing fst) $
+      Boxed.toList ixs
+
+pEncoding :: Aeson.Value -> Aeson.Parser PsvEncoding
+pEncoding =
+  pEnum "PsvEncoding" $ \case
+    "primitive" ->
+      Just $
+        fmap PsvPrimitive . pPrimitive
+
+    "struct" ->
+      Just $
+        fmap PsvStruct . pIndexedArray "PsvStruct (fields)" pStructField
+
+    "listof" ->
+      Just $
+        fmap PsvList . pEncoding
+
+    "pairof" ->
+      Just $
+        Aeson.withArray "PsvPair (contents)" $ \xs0 ->
+          case Boxed.toList xs0 of
+            [x, y] ->
+              PsvPair <$> pEncoding x <*> pEncoding y
+            xs ->
+              fail $
+                "Expected two element array for contents of pair fields but found: " <>
+                show (length xs) <> " element array"
+
+    x ->
+      fail $ "Unknown encoding: " <> Text.unpack x
+
+ppEncoding :: PsvEncoding -> Aeson.Value
+ppEncoding = \case
+  PsvPrimitive x ->
+    ppEnum "primitive" $
+      ppPrimitive x
+
+  PsvStruct fields ->
+    ppEnum "struct" . Aeson.Array .
+      Boxed.imap ppStructField $ Boxed.fromList fields
+
+  PsvList x ->
+    ppEnum "listof" $
+      ppEncoding x
+
+  PsvPair x y ->
+    ppEnum "pairof" . Aeson.Array $
+      Boxed.fromList [ppEncoding x, ppEncoding y]
+
+pColumn :: Aeson.Value -> Aeson.Parser (Int, PsvColumn)
+pColumn =
+  Aeson.withObject "PsvColumn" $ \o -> do
+    name <- withKey "name" o pText
+    index <- withKey "index" o pInt
+    encoding <- withKey "encoding" o pEncoding
+    pure (index, PsvColumn name encoding)
+
+ppColumn :: Int -> PsvColumn -> Aeson.Value
+ppColumn ix (PsvColumn name encoding) =
+  Aeson.object [
+      "index" .=
+        ppInt ix
+
+    , "name" .=
+        ppText name
+
+    , "encoding" .=
+        ppEncoding encoding
+    ]
+
+expect :: (Eq a, Show a) => Text -> Text -> Aeson.Object -> (Aeson.Value -> Aeson.Parser a) -> a -> Aeson.Parser ()
+expect prefix key o p expected = do
+  x <- withKey key o p
+  unless (x == expected) . fail $
+    "Expected " <> Text.unpack (prefix <> key) <> " to be <" <> show expected <> "> but was <" <> show x <> ">"
+
+pSchema :: Aeson.Value -> Aeson.Parser PsvSchema
+pSchema =
+  Aeson.withObject "PsvSchema" $ \o -> do
+    expect "" "version" o pText "1"
+    expect "" "encoding_version" o pText "1"
+
+    () <-
+      withKey "entity_id" o .
+      Aeson.withObject "entity_id" $ \x -> do
+        expect "entity_id/" "encoding" x pPrimitive PsvString
+        expect "entity_id/" "index" x pInt 0
+
+    missing <-
+      withKey "global_properties" o $
+      Aeson.withObject "global_properties" $ \x -> do
+        PsvMissingValue <$> withKey "missing_value" x pText
+
+    columns <-
+      withKey "attributes" o $
+        pIndexedArray "PsvSchema (columns)" pColumn
+
+    pure $
+      PsvSchema missing columns
+
+ppSchema :: PsvSchema -> Aeson.Value
+ppSchema x =
+  Aeson.object [
+      "version" .=
+        ppText "1"
+
+    , "encoding_version" .=
+        ppText "1"
+
+    , "global_properties" .=
+        Aeson.object [
+            "missing_value" .=
+              ppText (unPsvMissingValue $ schemaMissingValue x)
+          ]
+
+    , "entity_id" .=
+        Aeson.object [
+            "index" .=
+              ppInt 0
+          , "encoding" .=
+              ppPrimitive PsvString
+          ]
+
+    , "attributes" .=
+        Aeson.Array (Boxed.imap (ppColumn . (+ 1)) . Boxed.fromList $ schemaColumns x)
+    ]
+
+prettyConfig :: [Text] -> Aeson.Config
+prettyConfig keyOrder =
+  Aeson.defConfig {
+      Aeson.confIndent =
+        Aeson.Spaces 2
+    , Aeson.confCompare =
+        Aeson.keyOrder keyOrder
+    }
+
+compactConfig :: [Text] -> Aeson.Config
+compactConfig keyOrder =
+  (prettyConfig keyOrder) {
+      Aeson.confIndent =
+        Aeson.Spaces 0
+    }
+
+encodePrettyJson :: [Text] -> Aeson.Value -> Text
+encodePrettyJson keyOrder =
+  Text.decodeUtf8 . Lazy.toStrict . Aeson.encodePretty' (prettyConfig keyOrder)
+
+encodeCompactJson :: [Text] -> Aeson.Value -> Text
+encodeCompactJson keyOrder =
+  Text.decodeUtf8 . Lazy.toStrict . Aeson.encodePretty' (compactConfig keyOrder)
+
+decodeJson :: (Aeson.Value -> Aeson.Parser a) -> Text -> Either PsvSchemaDecodeError a
+decodeJson p =
+  first (uncurry PsvSchemaDecodeError . second Text.pack) .
+    Aeson.eitherDecodeStrictWith Aeson.value' (Aeson.iparse p) .
+    Text.encodeUtf8
+
+schemaKeyOrder :: [Text]
+schemaKeyOrder = [
+    "version"
+  , "encoding_version"
+  , "global_properties"
+  , "entity_id"
+  , "attributes"
+  , "index"
+  , "name"
+  , "encoding"
+  ]
+
+renderPrettyPsvSchema :: PsvSchema -> Text
+renderPrettyPsvSchema =
+  (<> "\n") . encodePrettyJson schemaKeyOrder . ppSchema
+
+renderCompactPsvSchema :: PsvSchema -> Text
+renderCompactPsvSchema =
+  encodeCompactJson schemaKeyOrder . ppSchema
+
+parsePsvSchema :: Text -> Either PsvSchemaDecodeError PsvSchema
+parsePsvSchema =
+  decodeJson pSchema

--- a/icicle-compiler/test/Icicle/Test/Sea/Psv/Schema.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Psv/Schema.hs
@@ -1,0 +1,72 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+module Icicle.Test.Sea.Psv.Schema where
+
+import           Disorder.Corpus (muppets, boats, viruses)
+import           Disorder.Jack (Property, Jack, quickCheckAll, tripping, gamble)
+import           Disorder.Jack (elements, listOfN, listOf, oneOfRec, sized)
+
+import           Icicle.Sea.IO.Psv.Schema
+
+import           P
+
+import           System.IO (IO)
+
+
+genPrimitive :: Jack PsvPrimitive
+genPrimitive =
+  elements [
+      PsvBoolean
+    , PsvInt
+    , PsvDouble
+    , PsvString
+    , PsvDate
+    ]
+
+genStructField :: Jack PsvStructField
+genStructField =
+  PsvStructField
+    <$> elements muppets
+    <*> genEncoding
+
+genEncoding :: Jack PsvEncoding
+genEncoding =
+  oneOfRec [
+      PsvPrimitive <$> genPrimitive
+    ] [
+      PsvStruct <$> sized (\n -> listOfN 0 (n `div` 5) genStructField)
+    , PsvList <$> genEncoding
+    , PsvPair <$> genEncoding <*> genEncoding
+    ]
+
+genColumn :: Jack PsvColumn
+genColumn =
+  PsvColumn
+    <$> elements boats
+    <*> genEncoding
+
+genMissingValue :: Jack PsvMissingValue
+genMissingValue =
+  PsvMissingValue
+    <$> elements viruses
+
+genSchema :: Jack PsvSchema
+genSchema =
+  PsvSchema
+    <$> genMissingValue
+    <*> listOf genColumn
+
+prop_psv_pretty_schema_roundtrip :: Property
+prop_psv_pretty_schema_roundtrip =
+  gamble genSchema $
+    tripping renderPrettyPsvSchema parsePsvSchema
+
+prop_psv_compact_schema_roundtrip :: Property
+prop_psv_compact_schema_roundtrip =
+  gamble genSchema $
+    tripping renderCompactPsvSchema parsePsvSchema
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll

--- a/icicle-compiler/test/cli/icicle/run
+++ b/icicle-compiler/test/cli/icicle/run
@@ -1,5 +1,16 @@
 #!/bin/sh -eu
 
+: ${UPDATE:="0"}
+
+diff_update () {
+    if [ "$UPDATE" = "1" ]; then
+        echo Updating $1
+        cat $2 > $1
+    else
+        diff -u $1 $2
+    fi
+}
+
 echo "1. Sanity test"
 
 t1_dict=test/cli/icicle/t1-dictionary.toml
@@ -11,7 +22,7 @@ t1_out_psv=`mktemp -t icicle-t1-out-XXXXXX`
 
 dist/build/icicle/icicle query --dictionary-toml $t1_dict --input-sparse-psv $t1_in --output-sparse-psv $t1_out_psv --output-code $t1_out_c --snapshot 2010-01-01
 
-diff -u $t1_expected $t1_out_psv
+diff_update $t1_expected $t1_out_psv
 
 rm $t1_out_c
 rm $t1_out_psv
@@ -36,8 +47,8 @@ t2_drop_0=`mktemp -t icicle-t2-drop-0-XXXXXX`
 
 dist/build/icicle/icicle query --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_0 --output-code $t2_c_0 --facts-limit 0 --drop $t2_drop_0 $t2_common_args
 
-diff -u $t2_expected_psv_0 $t2_psv_0
-diff -u $t2_expected_drop_0 $t2_drop_0
+diff_update $t2_expected_psv_0 $t2_psv_0
+diff_update $t2_expected_drop_0 $t2_drop_0
 
 rm $t2_c_0
 rm $t2_psv_0
@@ -53,8 +64,8 @@ t2_drop_1=`mktemp -t icicle-t2-drop-1-XXXXXX`
 
 dist/build/icicle/icicle query --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_1 --output-code $t2_c_1 --facts-limit 1 --drop $t2_drop_1 $t2_common_args
 
-diff -u $t2_expected_psv_1 $t2_psv_1
-diff -u $t2_expected_drop_1 $t2_drop_1
+diff_update $t2_expected_psv_1 $t2_psv_1
+diff_update $t2_expected_drop_1 $t2_drop_1
 
 rm $t2_c_1
 rm $t2_psv_1
@@ -70,8 +81,8 @@ t2_drop_2=`mktemp -t icicle-t2-drop-2-XXXXXX`
 
 dist/build/icicle/icicle query --dictionary-toml $t2_dict --input-sparse-psv $t2_in --output-sparse-psv $t2_psv_2 --output-code $t2_c_2 --facts-limit 2 --drop $t2_drop_2 $t2_common_args
 
-diff -u $t2_expected_psv_2 $t2_psv_2
-diff -u $t2_expected_drop_2 $t2_drop_2
+diff_update $t2_expected_psv_2 $t2_psv_2
+diff_update $t2_expected_drop_2 $t2_drop_2
 
 rm $t2_c_2
 rm $t2_psv_2
@@ -84,18 +95,22 @@ t2b_dict=test/cli/icicle/t2b-dictionary.toml
 t2b_in=test/cli/icicle/t2b-in.psv
 
 t2b_expected_psv=test/cli/icicle/t2b-expected.psv
+t2b_expected_schema=test/cli/icicle/t2b-expected.schema.json
 t2b_expected_drop=test/cli/icicle/t2b-drop.txt
 t2b_c=`mktemp -t icicle-t2b-c-XXXXXX`
 t2b_psv=`mktemp -t icicle-t2b-out-XXXXXX`
+t2b_schema=`mktemp -t icicle-t2b-out-schema-XXXXXX`
 t2b_drop=`mktemp -t icicle-t2b-drop-XXXXXX`
 
-dist/build/icicle/icicle query --dictionary-toml $t2b_dict --input-sparse-psv $t2b_in --output-dense-psv $t2b_psv --output-code $t2b_c --facts-limit 1 --drop $t2b_drop $t2b_common_args
+dist/build/icicle/icicle query --dictionary-toml $t2b_dict --input-sparse-psv $t2b_in --output-dense-psv $t2b_psv --output-schema $t2b_schema --output-code $t2b_c --facts-limit 1 --drop $t2b_drop $t2b_common_args
 
-diff -u $t2b_expected_psv $t2b_psv
-diff -u $t2b_expected_drop $t2b_drop
+diff_update $t2b_expected_psv $t2b_psv
+diff_update $t2b_expected_schema $t2b_schema
+diff_update $t2b_expected_drop $t2b_drop
 
 rm $t2b_c
 rm $t2b_psv
+rm $t2b_schema
 rm $t2b_drop
 
 echo "OK!"
@@ -118,8 +133,8 @@ t3_drop_2=`mktemp -t icicle-t3-drop-XXXXXX`
 
 dist/build/icicle/icicle query --dictionary-toml $t3_dict --input-dense-psv $t3_in --output-sparse-psv $t3_psv_2 --output-code $t3_c_2 --facts-limit 2 --drop $t3_drop_2 $t3_common_args
 
-diff -u $t3_expected_psv_2 $t3_psv_2
-diff -u $t3_expected_drop_2 $t3_drop_2
+diff_update $t3_expected_psv_2 $t3_psv_2
+diff_update $t3_expected_drop_2 $t3_drop_2
 
 rm $t3_c_2
 rm $t3_psv_2
@@ -132,18 +147,22 @@ t3b_dict=test/cli/icicle/t3b-dictionary.toml
 t3b_in=test/cli/icicle/t3b-in.psv
 
 t3b_expected_psv_2=test/cli/icicle/t3b-expected.psv
+t3b_expected_schema_2=test/cli/icicle/t3b-expected.schema.json
 t3b_expected_drop_2=test/cli/icicle/t3b-drop.txt
 t3b_c_2=`mktemp -t icicle-t3b-c-XXXXXX`
 t3b_psv_2=`mktemp -t icicle-t3b-out-XXXXXX`
+t3b_schema_2=`mktemp -t icicle-t3b-out-schema-XXXXXX`
 t3b_drop_2=`mktemp -t icicle-t3b-drop-XXXXXX`
 
-dist/build/icicle/icicle query --dictionary-toml $t3b_dict --input-dense-psv $t3b_in --output-dense-psv $t3b_psv_2 --output-code $t3b_c_2 --facts-limit 2 --drop $t3b_drop_2 $t3b_common_args
+dist/build/icicle/icicle query --dictionary-toml $t3b_dict --input-dense-psv $t3b_in --output-dense-psv $t3b_psv_2 --output-schema $t3b_schema_2 --output-code $t3b_c_2 --facts-limit 2 --drop $t3b_drop_2 $t3b_common_args
 
-diff -u $t3b_expected_psv_2 $t3b_psv_2
-diff -u $t3b_expected_drop_2 $t3b_drop_2
+diff_update $t3b_expected_psv_2 $t3b_psv_2
+diff_update $t3b_expected_schema_2 $t3b_schema_2
+diff_update $t3b_expected_drop_2 $t3b_drop_2
 
 rm $t3b_c_2
 rm $t3b_psv_2
+rm $t3b_schema_2
 rm $t3b_drop_2
 
 echo "OK!"
@@ -156,17 +175,21 @@ t4_common_args="--snapshot 2010-01-01"
 t4_dict=test/cli/icicle/t4-dictionary.toml
 t4_in=test/cli/icicle/t4-in.psv
 
-t4_expected=test/cli/icicle/t4-expected.psv
+t4_expected_psv=test/cli/icicle/t4-expected.psv
+t4_expected_schema=test/cli/icicle/t4-expected.schema.json
 t4_out_c=`mktemp -t icicle-t4-c-XXXXXX`
 t4_out_psv=`mktemp -t icicle-t4-out-XXXXXX`
+t4_out_schema=`mktemp -t icicle-t4-out-schema-XXXXXX`
 t4_drop=`mktemp -t icicle-t4-drop-XXXXXX`
 
-dist/build/icicle/icicle query --dictionary-toml $t4_dict --input-sparse-psv $t4_in --output-dense-psv $t4_out_psv --output-code $t4_out_c --facts-limit 1000 --drop $t4_drop $t4_common_args
+dist/build/icicle/icicle query --dictionary-toml $t4_dict --input-sparse-psv $t4_in --output-dense-psv $t4_out_psv --output-schema $t4_out_schema --output-code $t4_out_c --facts-limit 1000 --drop $t4_drop $t4_common_args
 
-diff -u $t4_expected $t4_out_psv
+diff_update $t4_expected_psv $t4_out_psv
+diff_update $t4_expected_schema $t4_out_schema
 
 rm $t4_out_c
 rm $t4_out_psv
+rm $t4_out_schema
 rm $t4_drop
 
 echo "OK!"
@@ -180,23 +203,30 @@ t5_common_args="--snapshot 2010-01-01"
 t5_dict=test/cli/icicle/t5-dictionary.toml
 t5_in=test/cli/icicle/t5-in.psv
 
-t5_expected=test/cli/icicle/t5-expected.psv
+t5_expected_psv=test/cli/icicle/t5-expected.psv
+t5_expected_schema=test/cli/icicle/t5-expected.schema.json
 t5_out_c=`mktemp -t icicle-t5-c-XXXXXX`
 t5_out_psv_1=`mktemp -t icicle-t5-out-1-XXXXXX`
 t5_out_psv_2=`mktemp -t icicle-t5-out-2-XXXXXX`
+t5_out_schema_1=`mktemp -t icicle-t5-out-schema-1-XXXXXX`
+t5_out_schema_2=`mktemp -t icicle-t5-out-schema-2-XXXXXX`
 t5_drop=`mktemp -t icicle-t5-drop-XXXXXX`
 
-dist/build/icicle/icicle query --dictionary-toml $t5_dict --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_1 $t5_common_args
+dist/build/icicle/icicle query --dictionary-toml $t5_dict --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_1 --output-schema $t5_out_schema_1 $t5_common_args
 
 dist/build/icicle/icicle compile --dictionary-toml $t5_dict --input-sparse-psv --output-dense-psv --output-code $t5_out_c $t5_common_args
-dist/build/icicle/icicle query --dictionary-code $t5_out_c --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_2 $t5_common_args
+dist/build/icicle/icicle query --dictionary-code $t5_out_c --input-sparse-psv $t5_in --output-dense-psv $t5_out_psv_2 --output-schema $t5_out_schema_2 $t5_common_args
 
-diff -u $t5_expected $t5_out_psv_1
-diff -u $t5_expected $t5_out_psv_2
+diff_update $t5_expected_psv $t5_out_psv_1
+diff_update $t5_expected_psv $t5_out_psv_2
+diff_update $t5_expected_schema $t5_out_schema_1
+diff_update $t5_expected_schema $t5_out_schema_2
 
 rm $t5_out_c
 rm $t5_out_psv_1
 rm $t5_out_psv_2
+rm $t5_out_schema_1
+rm $t5_out_schema_2
 rm $t5_drop
 
 ################################################################################
@@ -206,16 +236,20 @@ echo "7. Chord labels"
 t7_dict=test/cli/icicle/t7-chord-name-dictionary.toml
 t7_in=test/cli/icicle/t7-chord-name-input.psv
 t7_chord=test/cli/icicle/t7-chord-name-chord.psv
-t7_expect=test/cli/icicle/t7-expected.psv
+t7_expected_psv=test/cli/icicle/t7-expected.psv
+t7_expected_schema=test/cli/icicle/t7-expected.schema.json
 
 t7_out_c=`mktemp -t icicle-t7-c-XXXXXX`
 t7_out_psv=`mktemp -t icicle-t7-out-1-XXXXXX`
+t7_out_schema=`mktemp -t icicle-t7-out-schema-1-XXXXXX`
 
-dist/build/icicle/icicle query --dictionary-toml $t7_dict --input-dense-psv $t7_in --output-dense-psv $t7_out_psv --chord $t7_chord
+dist/build/icicle/icicle query --dictionary-toml $t7_dict --input-dense-psv $t7_in --output-dense-psv $t7_out_psv --output-schema $t7_out_schema --chord $t7_chord
 
-diff -u $t7_expect $t7_out_psv
+diff_update $t7_expected_psv $t7_out_psv
+diff_update $t7_expected_schema $t7_out_schema
 
 rm $t7_out_c
 rm $t7_out_psv
+rm $t7_out_schema
 
 echo "OK!"

--- a/icicle-compiler/test/cli/icicle/t2b-expected.schema.json
+++ b/icicle-compiler/test/cli/icicle/t2b-expected.schema.json
@@ -1,0 +1,27 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": ":long_output",
+      "encoding": {
+        "primitive": "int"
+      }
+    },
+    {
+      "index": 2,
+      "name": ":more_long_output",
+      "encoding": {
+        "primitive": "int"
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/icicle/t3b-expected.schema.json
+++ b/icicle-compiler/test/cli/icicle/t3b-expected.schema.json
@@ -1,0 +1,27 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "miserables:count",
+      "encoding": {
+        "primitive": "int"
+      }
+    },
+    {
+      "index": 2,
+      "name": "miserables:newest_misery",
+      "encoding": {
+        "primitive": "int"
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/icicle/t4-expected.schema.json
+++ b/icicle-compiler/test/cli/icicle/t4-expected.schema.json
@@ -1,0 +1,95 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "default:latest_four",
+      "encoding": {
+        "listof": {
+          "primitive": "string"
+        }
+      }
+    },
+    {
+      "index": 2,
+      "name": "default:newest",
+      "encoding": {
+        "primitive": "string"
+      }
+    },
+    {
+      "index": 3,
+      "name": "default:test_map",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "listof": {
+                "primitive": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 4,
+      "name": "default:test_map_delete",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 5,
+      "name": "default:test_map_delete_end",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 6,
+      "name": "default:test_map_double",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/icicle/t5-expected.schema.json
+++ b/icicle-compiler/test/cli/icicle/t5-expected.schema.json
@@ -1,0 +1,95 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "default:latest_four",
+      "encoding": {
+        "listof": {
+          "primitive": "string"
+        }
+      }
+    },
+    {
+      "index": 2,
+      "name": "default:newest",
+      "encoding": {
+        "primitive": "string"
+      }
+    },
+    {
+      "index": 3,
+      "name": "default:test_map",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "listof": {
+                "primitive": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 4,
+      "name": "default:test_map_delete",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 5,
+      "name": "default:test_map_delete_end",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 6,
+      "name": "default:test_map_double",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/icicle/t7-expected.schema.json
+++ b/icicle-compiler/test/cli/icicle/t7-expected.schema.json
@@ -1,0 +1,43 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "default:mean_misery_by_state",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 2,
+      "name": "miserables:newest_misery",
+      "encoding": {
+        "primitive": "int"
+      }
+    },
+    {
+      "index": 3,
+      "name": "timestamp",
+      "encoding": {
+        "primitive": "string"
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/zebra-nested/expected.schema.json
+++ b/icicle-compiler/test/cli/zebra-nested/expected.schema.json
@@ -1,0 +1,47 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "default:latest_couple",
+      "encoding": {
+        "listof": {
+          "listof": {
+            "primitive": "string"
+          }
+        }
+      }
+    },
+    {
+      "index": 2,
+      "name": "default:length",
+      "encoding": {
+        "primitive": "int"
+      }
+    },
+    {
+      "index": 3,
+      "name": "default:length_outer",
+      "encoding": {
+        "primitive": "int"
+      }
+    },
+    {
+      "index": 4,
+      "name": "default:newest_strings",
+      "encoding": {
+        "listof": {
+          "primitive": "string"
+        }
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/zebra-nested/run
+++ b/icicle-compiler/test/cli/zebra-nested/run
@@ -1,5 +1,16 @@
 #!/bin/sh -eu
 
+: ${UPDATE:="0"}
+
+diff_update () {
+    if [ "$UPDATE" = "1" ]; then
+        echo Updating $1
+        cat $2 > $1
+    else
+        diff -u $1 $2
+    fi
+}
+
 ################################################################################
 
 echo "====\n"
@@ -10,34 +21,40 @@ dict=test/cli/zebra-nested/dictionary.toml
 zebra_v2=test/cli/zebra-nested/input.zbin2
 zebra_v3=test/cli/zebra-nested/input.zbin3
 
-expected=test/cli/zebra-nested/expected.psv
+expected_psv=test/cli/zebra-nested/expected.psv
+expected_schema=test/cli/zebra-nested/expected.schema.json
 out_c=`mktemp -t icicle-c-XXXXXX`
 out_psv_1=`mktemp -t icicle-out-1-XXXXXX`
 out_psv_2=`mktemp -t icicle-out-2-XXXXXX`
+out_schema_1=`mktemp -t icicle-out-schema-1-XXXXXX`
+out_schema_2=`mktemp -t icicle-out-schema-2-XXXXXX`
 drop=`mktemp -t icicle-drop-XXXXXX`
 
 echo "Zebra v2"
-dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v2 --output-dense-psv $out_psv_1 $common_args
+dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v2 --output-dense-psv $out_psv_1 --output-schema $out_schema_1 $common_args
 
 dist/build/icicle/icicle compile --dictionary-toml $dict --input-zebra  --output-dense-psv --output-code $out_c $common_args
-dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v2 --output-dense-psv $out_psv_2 $common_args
+dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v2 --output-dense-psv $out_psv_2 --output-schema $out_schema_2 $common_args
 
-diff -u $expected $out_psv_1
-diff -u $expected $out_psv_2
+diff_update $expected_psv $out_psv_1
+diff_update $expected_psv $out_psv_2
+diff_update $expected_schema $out_schema_1
+diff_update $expected_schema $out_schema_2
 
 echo "Zebra v3"
-dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v3 --output-dense-psv $out_psv_1 $common_args
+dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v3 --output-dense-psv $out_psv_1 --output-schema $out_schema_1 $common_args
 
 dist/build/icicle/icicle compile --dictionary-toml $dict --input-zebra  --output-dense-psv --output-code $out_c $common_args
-dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v3 --output-dense-psv $out_psv_2 $common_args
+dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v3 --output-dense-psv $out_psv_2 --output-schema $out_schema_2 $common_args
 
-diff -u $expected $out_psv_1
-diff -u $expected $out_psv_2
-
+diff_update $expected_psv $out_psv_1
+diff_update $expected_psv $out_psv_2
+diff_update $expected_schema $out_schema_1
+diff_update $expected_schema $out_schema_2
 
 rm $out_c
 rm $out_psv_1
 rm $out_psv_2
+rm $out_schema_1
+rm $out_schema_2
 rm $drop
-
-

--- a/icicle-compiler/test/cli/zebra/expected.schema.json
+++ b/icicle-compiler/test/cli/zebra/expected.schema.json
@@ -1,0 +1,95 @@
+{
+  "version": "1",
+  "encoding_version": "1",
+  "global_properties": {
+    "missing_value": "NA"
+  },
+  "entity_id": {
+    "index": 0,
+    "encoding": "string"
+  },
+  "attributes": [
+    {
+      "index": 1,
+      "name": "default:latest_four",
+      "encoding": {
+        "listof": {
+          "primitive": "string"
+        }
+      }
+    },
+    {
+      "index": 2,
+      "name": "default:newest",
+      "encoding": {
+        "primitive": "string"
+      }
+    },
+    {
+      "index": 3,
+      "name": "default:test_map",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "listof": {
+                "primitive": "string"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 4,
+      "name": "default:test_map_delete",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 5,
+      "name": "default:test_map_delete_end",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "int"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "index": 6,
+      "name": "default:test_map_double",
+      "encoding": {
+        "listof": {
+          "pairof": [
+            {
+              "primitive": "string"
+            },
+            {
+              "primitive": "double"
+            }
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/icicle-compiler/test/cli/zebra/run
+++ b/icicle-compiler/test/cli/zebra/run
@@ -1,5 +1,16 @@
 #!/bin/sh -eu
 
+: ${UPDATE:="0"}
+
+diff_update () {
+    if [ "$UPDATE" = "1" ]; then
+        echo Updating $1
+        cat $2 > $1
+    else
+        diff -u $1 $2
+    fi
+}
+
 ################################################################################
 
 echo "====\n"
@@ -10,34 +21,40 @@ dict=test/cli/zebra/dictionary.toml
 zebra_v2=test/cli/zebra/input.zbin2
 zebra_v3=test/cli/zebra/input.zbin3
 
-expected=test/cli/zebra/expected.psv
+expected_psv=test/cli/zebra/expected.psv
+expected_schema=test/cli/zebra/expected.schema.json
 out_c=`mktemp -t icicle-c-XXXXXX`
 out_psv_1=`mktemp -t icicle-out-1-XXXXXX`
 out_psv_2=`mktemp -t icicle-out-2-XXXXXX`
+out_schema_1=`mktemp -t icicle-out-schema-1-XXXXXX`
+out_schema_2=`mktemp -t icicle-out-schema-2-XXXXXX`
 drop=`mktemp -t icicle-drop-XXXXXX`
 
 echo "Zebra v2"
-dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v2 --output-dense-psv $out_psv_1 $common_args
+dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v2 --output-dense-psv $out_psv_1 --output-schema $out_schema_1 $common_args
 
 dist/build/icicle/icicle compile --dictionary-toml $dict --input-zebra  --output-dense-psv --output-code $out_c $common_args
-dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v2 --output-dense-psv $out_psv_2 $common_args
+dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v2 --output-dense-psv $out_psv_2 --output-schema $out_schema_2 $common_args
 
-diff -u $expected $out_psv_1
-diff -u $expected $out_psv_2
+diff_update $expected_psv $out_psv_1
+diff_update $expected_psv $out_psv_2
+diff_update $expected_schema $out_schema_1
+diff_update $expected_schema $out_schema_2
 
 echo "Zebra v3"
-dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v3 --output-dense-psv $out_psv_1 $common_args
+dist/build/icicle/icicle query --dictionary-toml $dict --input-zebra $zebra_v3 --output-dense-psv $out_psv_1 --output-schema $out_schema_1 $common_args
 
 dist/build/icicle/icicle compile --dictionary-toml $dict --input-zebra  --output-dense-psv --output-code $out_c $common_args
-dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v3 --output-dense-psv $out_psv_2 $common_args
+dist/build/icicle/icicle query --dictionary-code $out_c --input-zebra $zebra_v3 --output-dense-psv $out_psv_2 --output-schema $out_schema_2 $common_args
 
-diff -u $expected $out_psv_1
-diff -u $expected $out_psv_2
-
+diff_update $expected_psv $out_psv_1
+diff_update $expected_psv $out_psv_2
+diff_update $expected_schema $out_schema_1
+diff_update $expected_schema $out_schema_2
 
 rm $out_c
 rm $out_psv_1
 rm $out_psv_2
+rm $out_schema_1
+rm $out_schema_2
 rm $drop
-
-

--- a/icicle-compiler/test/test.hs
+++ b/icicle-compiler/test/test.hs
@@ -33,6 +33,7 @@ import qualified Icicle.Test.Source.History
 
 import qualified Icicle.Test.Sea.Name
 import qualified Icicle.Test.Sea.Psv
+import qualified Icicle.Test.Sea.Psv.Schema
 import qualified Icicle.Test.Sea.PsvFission
 import qualified Icicle.Test.Sea.Zebra
 import qualified Icicle.Test.Sea.Seaworthy
@@ -71,6 +72,7 @@ main
 
         , Icicle.Test.Sea.Name.tests
         , Icicle.Test.Sea.Psv.tests
+        , Icicle.Test.Sea.Psv.Schema.tests
         , Icicle.Test.Sea.PsvFission.tests
         , Icicle.Test.Sea.Zebra.tests
         , Icicle.Test.Sea.Seaworthy.tests


### PR DESCRIPTION
This change includes a formation/walrus schema in the compiled C dictionary. Which means we have access to it when running a query. As such, we can now write out a schema alongside the data 🎆 

! @tranma @amosr

/cc @nhibberd 
/jury approved @amosr