### PR TITLE
Haskell interface for creating Icicle runtime arrays

### DIFF
--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -49,6 +49,7 @@ library
                      , old-locale                      == 1.0.*
                      , parallel                        == 3.2.*
                      , pretty-show                     == 1.6.*
+                     , primitive                       == 0.6.*
                      , resourcet                       >= 1.1        && < 2
                      , scientific                      == 0.3.*
                      , semigroups                      >= 0.16       && < 0.19
@@ -117,11 +118,17 @@ library
                        Icicle.Avalanche.Prim.Eval
                        Icicle.Avalanche.Prim.Compounds
 
-                       Icicle.Command
-
                        Icicle.Benchmark.Generator
 
+                       Icicle.Command
+
+                       Icicle.Compiler
+
                        Icicle.Debug
+
+                       Icicle.Internal.Rename
+
+                       Icicle.Runtime.Array
 
                        Icicle.Simulator
 
@@ -146,10 +153,6 @@ library
                        Icicle.Sea.IO.Psv.Output
                        Icicle.Sea.IO.Psv.Schema
                        Icicle.Sea.IO.Zebra
-
-                       Icicle.Internal.Rename
-
-                       Icicle.Compiler
 
 
 executable icicle
@@ -181,7 +184,7 @@ executable icicle
                      , text                            == 1.2.*
                      , time                            >= 1.5        && < 1.7
                      , transformers                    >= 0.3        && < 0.6
- 
+
     -- The parallel GC prior to GHC 8.0.1 has pathological behaviour for
     -- unbalanced workloads:
     --

--- a/icicle-compiler/src/Icicle/Runtime/Array.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Array.hs
@@ -1,0 +1,362 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DoAndIfThenElse #-}
+{-# LANGUAGE ForeignFunctionInterface #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+module Icicle.Runtime.Array (
+    Array(..)
+  , ArrayIndex(..)
+  , ArrayLength(..)
+  , ArrayCapacity(..)
+  , ArrayFootprint(..)
+
+  , new
+  , length
+  , read
+  , write
+  , grow
+  , fromVector
+  , fromList
+  , toVector
+  , toList
+
+  , unsafeRead
+  , unsafeWrite
+  , unsafeFromMVector
+  , unsafeFromVector
+  , unsafeToMVector
+  , unsafeToVector
+
+  , ArrayError(..)
+  , renderArrayError
+
+  -- * Internal
+  , headerSize
+  , elementSize
+  , calculateCapacity
+  , calculateFootprint
+  , unsafeWriteLength
+  , unsafeLengthPtr
+  , unsafeElementPtr
+  , unsafeAllocate
+  , checkElementSize
+  , checkBounds
+  ) where
+
+import           Anemone.Foreign.Mempool (Mempool)
+import qualified Anemone.Foreign.Mempool as Mempool
+
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Primitive (PrimState)
+
+import           Data.Bits (countLeadingZeros, shiftL)
+import qualified Data.Text as Text
+import qualified Data.Vector.Storable as Storable
+import qualified Data.Vector.Storable.Mutable as MStorable
+import           Data.Void (Void)
+
+import           Foreign.C.Types (CSize(..))
+import           Foreign.ForeignPtr (newForeignPtr_)
+import           Foreign.Ptr (Ptr, plusPtr, castPtr)
+import           Foreign.Storable (Storable(..))
+
+import           GHC.Generics (Generic)
+
+import           P hiding (length, toList)
+
+import qualified Prelude as Savage
+
+import           System.IO (IO)
+
+import           X.Text.Show (gshowsPrec)
+import           X.Control.Monad.Trans.Either (EitherT, left)
+
+
+-- | An Icicle runtime array.
+--
+newtype Array =
+  Array {
+      unArray :: Ptr Void
+    } deriving (Eq, Ord, Generic, Storable)
+
+-- | An index in to an array.
+--
+newtype ArrayIndex =
+  ArrayIndex {
+      unArrayIndex :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Storable)
+
+-- | The number of elements in the array.
+--
+newtype ArrayLength =
+  ArrayLength {
+      unArrayCount :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Storable)
+
+-- | The number of elements the array can store without needing to allocate.
+--
+newtype ArrayCapacity =
+  ArrayCapacity {
+      unArrayCapacity :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Storable)
+
+-- | The number of bytes the array occupies in memory, including the header.
+--
+newtype ArrayFootprint =
+  ArrayFootprint {
+      unArrayFootprint :: Int64
+    } deriving (Eq, Ord, Enum, Num, Real, Integral, Generic, Storable)
+
+data ArrayError =
+    ArrayElementsMustBeWordSize !Int
+  | ArrayIndexOutOfBounds !ArrayIndex !ArrayLength
+    deriving (Eq, Ord, Show)
+
+renderArrayError :: ArrayError -> Text
+renderArrayError = \case
+  ArrayElementsMustBeWordSize n ->
+    "Array elements must be exactly 8 bytes, found element with <" <> Text.pack (show n) <> " bytes>"
+  ArrayIndexOutOfBounds (ArrayIndex ix) (ArrayLength len) ->
+    "Array index <" <> Text.pack (show ix) <> "> was out of bounds [0, " <> Text.pack (show len) <> ")"
+
+instance Show Array where
+  showsPrec =
+    gshowsPrec
+
+instance Show ArrayIndex where
+  showsPrec =
+    gshowsPrec
+
+instance Show ArrayLength where
+  showsPrec =
+    gshowsPrec
+
+instance Show ArrayCapacity where
+  showsPrec =
+    gshowsPrec
+
+instance Show ArrayFootprint where
+  showsPrec =
+    gshowsPrec
+
+headerSize :: Num a => a
+headerSize =
+  8
+{-# INLINE headerSize #-}
+
+elementSize :: Num a => a
+elementSize =
+  8
+{-# INLINE elementSize #-}
+
+-- | Calculate an array's capacity, from its current element count.
+--
+calculateCapacity :: ArrayLength -> ArrayCapacity
+calculateCapacity (ArrayLength len) =
+  if len < 4 then
+    4
+  else
+    let
+      !bits =
+        64 - countLeadingZeros (len - 1)
+    in
+      ArrayCapacity (1 `shiftL` bits)
+{-# INLINE calculateCapacity #-}
+
+calculateFootprint :: ArrayCapacity -> ArrayFootprint
+calculateFootprint (ArrayCapacity capacity) =
+  ArrayFootprint $
+    headerSize + elementSize * capacity
+{-# INLINE calculateFootprint #-}
+
+unsafeWriteLength :: Array -> ArrayLength -> IO ()
+unsafeWriteLength (Array ptr) (ArrayLength len) =
+  pokeByteOff ptr 0 len
+{-# INLINE unsafeWriteLength #-}
+
+unsafeLengthPtr :: Array -> Ptr Int64
+unsafeLengthPtr (Array ptr) =
+  castPtr ptr
+{-# INLINE unsafeLengthPtr #-}
+
+unsafeElementPtr :: Array -> Ptr a
+unsafeElementPtr (Array ptr) =
+  ptr `plusPtr` headerSize
+{-# INLINE unsafeElementPtr #-}
+
+unsafeAllocate :: Mempool -> ArrayFootprint -> IO Array
+unsafeAllocate pool bytes =
+  Array <$> Mempool.callocBytes pool (fromIntegral bytes) 1
+{-# INLINE unsafeAllocate #-}
+
+-- | Allocate an initialised array of the specified length.
+--
+new :: Mempool -> ArrayLength -> IO Array
+new pool len = do
+  let
+    !bytes =
+      calculateFootprint (calculateCapacity len)
+
+  array <- unsafeAllocate pool bytes
+  unsafeWriteLength array len
+
+  pure array
+{-# INLINABLE new #-}
+
+length :: Array -> IO ArrayLength
+length =
+  fmap ArrayLength . peek . unsafeLengthPtr
+{-# INLINE length #-}
+
+checkElementSize :: Storable a => a -> EitherT ArrayError IO ()
+checkElementSize x = do
+ if sizeOf x /= elementSize then
+   left $ ArrayElementsMustBeWordSize (sizeOf x)
+ else
+   pure ()
+{-# INLINE checkElementSize #-}
+
+checkBounds :: Array -> ArrayIndex -> EitherT ArrayError IO ()
+checkBounds array (ArrayIndex ix) = do
+  ArrayLength n <- liftIO $ length array
+  if ix >= 0 && ix < n then
+    pure ()
+  else
+    left $ ArrayIndexOutOfBounds (ArrayIndex ix) (ArrayLength n)
+{-# INLINE checkBounds #-}
+
+unsafeRead :: Storable a => Array -> ArrayIndex -> IO a
+unsafeRead array (ArrayIndex ix) =
+  peekByteOff (unsafeElementPtr array) (fromIntegral (elementSize * ix))
+{-# INLINE unsafeRead #-}
+
+read :: forall a. Storable a => Array -> ArrayIndex -> EitherT ArrayError IO a
+read array ix = do
+  checkElementSize (Savage.undefined :: a)
+  checkBounds array ix
+  liftIO $ unsafeRead array ix
+{-# INLINE read #-}
+
+unsafeWrite :: Storable a => Array -> ArrayIndex -> a -> IO ()
+unsafeWrite array (ArrayIndex ix) x = do
+  pokeByteOff (unsafeElementPtr array) (fromIntegral (elementSize * ix)) x
+{-# INLINE unsafeWrite #-}
+
+write :: forall a. Storable a => Array -> ArrayIndex -> a -> EitherT ArrayError IO ()
+write array ix x = do
+  checkElementSize x
+  checkBounds array ix
+  liftIO $ unsafeWrite array ix x
+{-# INLINE write #-}
+
+grow :: Mempool -> Array -> ArrayLength -> IO Array
+grow pool arrayOld@(Array ptrOld) lengthNew = do
+  lengthOld <- length arrayOld
+
+  let
+    !capacityOld =
+      calculateCapacity lengthOld
+
+    !capacityNew =
+      calculateCapacity lengthNew
+
+  if capacityOld >= capacityNew then do
+    unsafeWriteLength arrayOld lengthNew
+    pure arrayOld
+  else do
+    let
+      !bytesOld =
+        calculateFootprint capacityOld
+
+      !bytesNew =
+        calculateFootprint capacityNew
+
+    arrayNew@(Array ptrNew) <- unsafeAllocate pool bytesNew
+
+    c_memcpy ptrNew ptrOld (fromIntegral bytesOld)
+    unsafeWriteLength arrayNew lengthNew
+
+    pure arrayNew
+{-# INLINABLE grow #-}
+
+unsafeToMVector :: Storable a => Array -> IO (MStorable.MVector (PrimState IO) a)
+unsafeToMVector array = do
+  !n <- length array
+  !fp <- newForeignPtr_ (unsafeElementPtr array)
+  pure $! MStorable.unsafeFromForeignPtr0 fp (fromIntegral n)
+{-# INLINE unsafeToMVector #-}
+
+unsafeToVector :: Storable a => Array -> IO (Storable.Vector a)
+unsafeToVector array =
+  Storable.unsafeFreeze =<<! unsafeToMVector array
+{-# INLINE unsafeToVector #-}
+
+toVector :: forall a. Storable a => Array -> EitherT ArrayError IO (Storable.Vector a)
+toVector array = do
+  checkElementSize (Savage.undefined :: a)
+  liftIO $!
+    Storable.freeze =<<! unsafeToMVector array
+{-# INLINE toVector #-}
+
+seqList :: [a] -> b -> b
+seqList xs0 o =
+  case xs0 of
+    [] ->
+      o
+    x : xs ->
+      x `seq` xs `seqList` o
+{-# INLINE seqList #-}
+
+unsafeToList :: Storable a => Array -> IO [a]
+unsafeToList array = do
+  xs <- Storable.toList <$> unsafeToVector array
+  xs `seqList` pure xs
+{-# INLINE unsafeToList #-}
+
+toList :: forall a. Storable a => Array -> EitherT ArrayError IO [a]
+toList array = do
+  checkElementSize (Savage.undefined :: a)
+  liftIO $! unsafeToList array
+{-# INLINE toList #-}
+
+unsafeFromMVector :: Storable a => Mempool -> MStorable.MVector (PrimState IO) a -> IO Array
+unsafeFromMVector pool vector = do
+  let
+    !n =
+      MStorable.length vector
+
+  !array <- new pool (fromIntegral n)
+
+  let
+    !dst =
+      unsafeElementPtr array
+
+  MStorable.unsafeWith vector $ \src ->
+    c_memcpy dst src (fromIntegral (n * elementSize))
+
+  pure array
+{-# INLINABLE unsafeFromMVector #-}
+
+unsafeFromVector :: Storable a => Mempool -> Storable.Vector a -> IO Array
+unsafeFromVector pool vector =
+  unsafeFromMVector pool =<<! Storable.unsafeThaw vector
+{-# INLINE unsafeFromVector #-}
+
+fromVector :: forall a. Storable a => Mempool -> Storable.Vector a -> EitherT ArrayError IO Array
+fromVector pool vector = do
+  checkElementSize (Savage.undefined :: a)
+  liftIO $! unsafeFromVector pool vector
+{-# INLINE fromVector #-}
+
+fromList :: forall a. Storable a => Mempool -> [a] -> EitherT ArrayError IO Array
+fromList pool xs =
+  fromVector pool $! Storable.fromList xs
+{-# INLINE fromList #-}
+
+foreign import ccall unsafe "string.h memcpy"
+  c_memcpy :: Ptr a -> Ptr a -> CSize -> IO ()

--- a/icicle-compiler/test/Icicle/Test/Runtime/Array.hs
+++ b/icicle-compiler/test/Icicle/Test/Runtime/Array.hs
@@ -1,0 +1,96 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Icicle.Test.Runtime.Array where
+
+import qualified Anemone.Foreign.Mempool as Mempool
+
+import           Control.Monad.Catch (bracket)
+
+import qualified Data.List as List
+
+import           Disorder.Jack
+import           Disorder.Core.IO (testIO)
+
+import           Icicle.Runtime.Array (ArrayLength(..))
+import qualified Icicle.Runtime.Array as Array
+import           Icicle.Test.Arbitrary.Run
+
+import           P
+
+import           System.IO (IO)
+
+import           X.Control.Monad.Trans.Either (EitherT, runEitherT)
+
+
+runEitherIO :: Show x => EitherT x IO a -> IO a
+runEitherIO io = do
+  e <- runEitherT io
+  case e of
+    Left err ->
+      fail (show err)
+    Right x ->
+      pure x
+
+prop_capacity :: Property
+prop_capacity =
+  gamble (choose (2, 62) :: Jack Int64) $ \ n ->
+     2 ^ n === Array.calculateCapacity (ArrayLength (2 ^ n))
+
+prop_roundtrip_writes :: Property
+prop_roundtrip_writes =
+  gamble (listOf (bounded :: Jack Int64)) $ \xs0 ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> do
+    array <- Array.new pool (fromIntegral (length xs0))
+
+    for_ (List.zip [0..] xs0) $ \(i, x) ->
+      runEitherIO $ Array.write array i x
+
+    xs <- runEitherIO $ Array.toList array
+
+    pure $
+      xs0 === xs
+
+prop_roundtrip_writes_grow :: Property
+prop_roundtrip_writes_grow =
+  gamble (listOf (bounded :: Jack Int64)) $ \xs0 ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> do
+    array00 <- Array.new pool 0
+
+    array <-
+      flip (flip foldM array00) (List.zip [0..] xs0) $ \array0 (i, x) -> do
+        array <- Array.grow pool array0 (fromIntegral i + 1)
+        runEitherIO $ Array.write array i x
+        pure array
+
+    xs <- runEitherIO $ Array.toList array
+
+    pure $
+      xs0 === xs
+
+prop_roundtrip_reads :: Property
+prop_roundtrip_reads =
+  gamble (listOf (bounded :: Jack Int64)) $ \xs0 ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> do
+    array <- runEitherIO $ Array.fromList pool xs0
+
+    xs <-
+      for [0..length xs0 - 1] $ \i ->
+        runEitherIO $ Array.read array (fromIntegral i)
+
+    pure $
+      xs0 === xs
+
+prop_roundtrip_lists :: Property
+prop_roundtrip_lists =
+  gamble (listOf (bounded :: Jack Int64)) $ \xs0 ->
+  testIO . bracket Mempool.create Mempool.free $ \pool -> do
+    array <- runEitherIO $ Array.fromList pool xs0
+    xs <- runEitherIO $ Array.toList array
+
+    pure $
+      xs0 === xs
+
+return []
+tests :: IO Bool
+tests =
+  $checkAllWith TestRunMore checkArgs

--- a/icicle-compiler/test/test.hs
+++ b/icicle-compiler/test/test.hs
@@ -23,6 +23,8 @@ import qualified Icicle.Test.Avalanche.MeltPrim
 import qualified Icicle.Test.Data.Time
 import qualified Icicle.Test.Internal.EditDistance
 
+import qualified Icicle.Test.Runtime.Array
+
 import qualified Icicle.Test.Source.PrettyParse
 import qualified Icicle.Test.Source.Progress
 import qualified Icicle.Test.Source.Convert
@@ -90,8 +92,10 @@ sundry =
     , Icicle.Test.Data.Time.tests
     , Icicle.Test.Encoding.tests
     , Icicle.Test.Foreign.Array.tests
+    , Icicle.Test.Foreign.Array.tests
     , Icicle.Test.Internal.EditDistance.tests
     , Icicle.Test.Language.tests
+    , Icicle.Test.Runtime.Array.tests
     , Icicle.Test.Serial.tests
     , Icicle.Test.Source.Convert.tests
     , Icicle.Test.Source.History.tests


### PR DESCRIPTION
This is the start of doing the Zebra -> Icicle runtime conversion in Haskell.

Thought it would be useful to have a decent interface to Icicle's runtime array representation.

The Haskell interface is untyped, so it's equivalent to `iarray_iany_t`. The safe interface checks that the `Storable` you are writing is indeed 8-bytes wide.

! @amosr @tranma 
/jury approved @amosr