### PR TITLE
Data types for zebra <-> icicle runtime translation

### DIFF
--- a/icicle-compiler/src/Icicle/Runtime/Data.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data.hs
@@ -1,0 +1,47 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+module Icicle.Runtime.Data (
+    Bool64(..)
+  , Time64(..)
+  , Error64(..)
+  ) where
+
+import           Data.Word (Word64)
+
+import           Foreign.Storable (Storable)
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+
+newtype Bool64 =
+  Bool64 {
+      unBool64 :: Word64
+    } deriving (Eq, Ord, Generic, Storable)
+
+newtype Time64 =
+  Time64 {
+      unTime64 :: Word64
+    } deriving (Eq, Ord, Generic, Storable)
+
+newtype Error64 =
+  Error64 {
+      unError64 :: Word64
+    } deriving (Eq, Ord, Generic, Storable)
+
+instance Show Bool64 where
+  showsPrec =
+    gshowsPrec
+
+instance Show Time64 where
+  showsPrec =
+    gshowsPrec
+
+instance Show Error64 where
+  showsPrec =
+    gshowsPrec

--- a/icicle-compiler/src/Icicle/Runtime/Logical.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Logical.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+module Icicle.Runtime.Logical (
+    Value(..)
+  ) where
+
+import           Data.ByteString (ByteString)
+import           Data.Map (Map)
+import qualified Data.Vector as Boxed
+
+import           GHC.Generics (Generic)
+
+import           Icicle.Runtime.Data
+
+import           P
+
+
+data Value =
+    Unit
+  | Bool !Bool64
+  | Int !Int64
+  | Double !Double
+  | Time !Time64
+
+  | Left !Value
+  | Right !Value
+
+  | None
+  | Some !Value
+
+  | Error !Error64
+  | Success !Value
+
+  | Pair !Value !Value
+  | Struct !(Boxed.Vector Value)
+
+  | String !ByteString
+  | Array !(Boxed.Vector Value)
+  | Map !(Map Value Value)
+    deriving (Eq, Ord, Show, Generic)

--- a/icicle-compiler/src/Icicle/Runtime/Striped.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Striped.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# OPTIONS_GHC -funbox-strict-fields #-}
+module Icicle.Runtime.Striped (
+    Table(..)
+  , Column(..)
+  , Field(..)
+  ) where
+
+import           Data.ByteString (ByteString)
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
+
+import           GHC.Generics (Generic)
+
+import           Icicle.Runtime.Data
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+
+data Table =
+    String !ByteString
+  | Array !Column
+  | Map !Column !Column
+    deriving (Eq, Ord, Show, Generic)
+
+data Column =
+    Unit !Int
+  | Bool !(Storable.Vector Bool64)
+  | Int !(Storable.Vector Int64)
+  | Double !(Storable.Vector Double)
+  | Time !(Storable.Vector Time64)
+
+  | Sum !(Storable.Vector Bool64) !Column !Column
+  | Option !(Storable.Vector Bool64) !Column
+  | Result !(Storable.Vector Error64) !Column
+
+  | Pair !(Storable.Vector Bool64) !Column !Column
+  | Struct !(Boxed.Vector Field)
+
+  | Nested !(Storable.Vector Int64) !Table
+    deriving (Eq, Ord, Show, Generic)
+
+data Field =
+  Field {
+      fieldName :: !Text
+    , fieldColumn :: !Column
+    } deriving (Eq, Ord, Generic)
+
+instance Show Field where
+  showsPrec =
+    gshowsPrec


### PR DESCRIPTION
These data types are designed to be as close as we can get to the Icicle runtime representation.

They are designed to be easy to translate to/from zebra as well as to icicle runtime.

`Time64` for example will be the packed representation we use in C for example.

! @amosr @tranma 