### PR TITLE
Repl: function bindings and typechecking info

### DIFF
--- a/icicle-repl/icicle-repl.cabal
+++ b/icicle-repl/icicle-repl.cabal
@@ -29,6 +29,7 @@ executable             icicle-repl
                      , transformers                    >= 0.3        && < 0.6
                      ,     parsec                      == 3.1.*
                      , semigroups                      >= 0.16       && < 0.19
+                     , containers                      == 0.5.*
 
 test-suite test-cli
   type:                exitcode-stdio-1.0

--- a/icicle-repl/src/Icicle/Repl.hs
+++ b/icicle-repl/src/Icicle/Repl.hs
@@ -268,7 +268,8 @@ handleLine state line = let st = sourceState state in
     let names  = Set.fromList $ fmap (snd . fst) parsed
     -- Remove the old bindings with these names
     let funEnv = filter (\(n,_) -> not $ Set.member n names)
-               $ dictionaryFunctions   d
+               $ toFunEnv
+               $ dictionaryFunctions d
 
     (funEnv',logs) <- hoist $ wrapSourceError $ Source.sourceCheckFunLog funEnv parsed
     let fundefs = filter (\(n,_) -> Set.member n names) funEnv'
@@ -279,7 +280,7 @@ handleLine state line = let st = sourceState state in
         Repl.prettyHL l
         Repl.nl
 
-    return $ state { sourceState = st { SourceRepl.dictionary = d { dictionaryFunctions = funEnv' } } }
+    return $ state { sourceState = st { SourceRepl.dictionary = d { dictionaryFunctions = fromFunEnv funEnv' } } }
 
   -- We use the simulator to evaluate the Icicle expression.
   Nothing -> withError $ do

--- a/icicle-repl/src/Icicle/Repl.hs
+++ b/icicle-repl/src/Icicle/Repl.hs
@@ -270,15 +270,15 @@ handleLine state line = let st = sourceState state in
     let funEnv = filter (\(n,_) -> not $ Set.member n names)
                $ dictionaryFunctions   d
 
-    (fun,logs) <- hoist $ wrapSourceError $ Source.sourceCheckFunLog funEnv parsed
-    forM_ (fun `L.zip` logs) $ \((nm, (typ, annot)),log0) -> do
+    (funEnv',logs) <- hoist $ wrapSourceError $ Source.sourceCheckFunLog funEnv parsed
+    let fundefs = filter (\(n,_) -> Set.member n names) funEnv'
+    forM_ (fundefs `L.zip` logs) $ \((nm, (typ, annot)),log0) -> do
       prettyOut (SourceRepl.hasType      . sourceState) ("- Type: " <> show (pretty nm))      typ
       prettyOut (SourceRepl.hasAnnotated . sourceState) ("- Annotated: " <> show (pretty nm)) (Source.PrettyAnnot annot)
       lift $ when (SourceRepl.hasTypeCheckLog $ sourceState state) $ forM_ log0 $ \l -> do
         Repl.prettyHL l
         Repl.nl
 
-    let funEnv' = fun <> funEnv
     return $ state { sourceState = st { SourceRepl.dictionary = d { dictionaryFunctions = funEnv' } } }
 
   -- We use the simulator to evaluate the Icicle expression.

--- a/icicle-repl/src/Icicle/Repl/Base.hs
+++ b/icicle-repl/src/Icicle/Repl/Base.hs
@@ -41,6 +41,7 @@ data Command setcmd
    | CommandImportLibrary  FilePath
    | CommandComment        String
    | CommandUnknown        String
+   | CommandLetFunction    String
    | CommandSetShow
 
 
@@ -63,6 +64,11 @@ readCommand readSetCommands ss = case words ss of
   [":dictionary-deprecated", f]    -> Just $ CommandLoadDictionary $ DictionaryLoadTextV1 f
   [":dictionary", f]               -> Just $ CommandLoadDictionary $ DictionaryLoadToml f
   [":import", f]                   -> Just $ CommandImportLibrary f
+  -- For :let function binding, make sure the text retains the same source positions.
+  -- ":let inc x = x + 1" ==>
+  -- "     inc x = x + 1"
+  (":let":_)                       -> Just $ CommandLetFunction ("    " <> drop 4 ss)
+
   ('-':'-':_):_                    -> Just $ CommandComment $ ss
   (':':_):_                        -> Just $ CommandUnknown $ ss
   _                                -> Nothing

--- a/icicle-repl/src/Icicle/Repl/Source.hs
+++ b/icicle-repl/src/Icicle/Repl/Source.hs
@@ -62,6 +62,7 @@ data SourceReplState
    , maxMapSize         :: Int
    , inlineOpt          :: Compiler.InlineOption
    , hasType            :: Bool
+   , hasTypeCheckLog    :: Bool
    , hasBigData         :: Bool
    , hasAnnotated       :: Bool
    , hasInlined         :: Bool
@@ -71,15 +72,13 @@ data SourceReplState
 
 defaultSourceReplState :: SourceReplState
 defaultSourceReplState
-  = (SourceReplState
+  = SourceReplState
        []
        demographics
        (unsafeTimeOfYMD 1970 1 1)
        (1024*1024)
        Compiler.InlineUsingSubst
-       False False False False False False )
-    { hasType = True
-    , hasBigData = False }
+       False False False False False False False
 
 stateEvalContext :: SourceReplState -> EvalContext
 stateEvalContext s = EvalContext (currentTime s) (maxMapSize s)

--- a/icicle-source/src/Icicle/Compiler/Source.hs
+++ b/icicle-source/src/Icicle/Compiler/Source.hs
@@ -43,6 +43,7 @@ module Icicle.Compiler.Source
   , sourceReifyQT
   , sourceCheckQT
   , sourceCheckF
+  , sourceCheckFunLog
   , sourceInline
 
     -- * Helpers
@@ -250,6 +251,13 @@ sourceCheckF :: FunEnvT Parsec.SourcePos Var
              -> Funs    Parsec.SourcePos Var
              -> Either  Error (FunEnvT Parsec.SourcePos Var)
 sourceCheckF env parsedImport
+ = second fst
+ $ sourceCheckFunLog env parsedImport
+
+sourceCheckFunLog :: FunEnvT Parsec.SourcePos Var
+             -> Funs    Parsec.SourcePos Var
+             -> Either  Error (FunEnvT Parsec.SourcePos Var, [[Check.CheckLog Parsec.SourcePos Var]])
+sourceCheckFunLog env parsedImport
  = first ErrorSourceCheck
  $ snd
  $ flip Fresh.runFresh (freshNamer "check")
@@ -276,6 +284,7 @@ readIcicleLibrary :: Var -> Parsec.SourceName -> Text -> Either Error (FunEnvT P
 readIcicleLibrary name source input
  = do input' <- first ErrorSourceParse $ Parse.parseFunctions source input
       first ErrorSourceCheck
+             $ second fst
              $ snd
              $ flip Fresh.runFresh (freshNamer name)
              $ runEitherT

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -125,7 +125,7 @@ data DischargeInfo a n = DischargeInfo
   }
  deriving Show
 
-instance (Pretty a, Pretty n) => Pretty (DischargeInfo a n) where
+instance (Pretty n) => Pretty (DischargeInfo a n) where
  pretty (DischargeInfo t cs s)
   = vsep ([ty] <> cons' <> subs')
   where

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE NoImplicitPrelude          #-}
 {-# LANGUAGE PatternGuards              #-}
+{-# LANGUAGE OverloadedStrings          #-}
 module Icicle.Source.Checker.Base (
     CheckEnv (..)
   , Invariants (..)
@@ -18,6 +19,11 @@ module Icicle.Source.Checker.Base (
   , Query'C
   , Exp'C
   , evalGen
+  , evalGenNoLog
+  , genHoistEither
+
+  , CheckLog(..)
+  , DischargeInfo(..)
 
   , require
   , discharge
@@ -42,16 +48,18 @@ import           Icicle.Source.Type
 
 import           Icicle.Common.Base
 import qualified Icicle.Common.Fresh         as Fresh
+import           Icicle.Internal.Pretty
 
 import           P
 
 import           Control.Monad.Trans.Class
 
-import           Data.Functor.Identity
 import qualified Data.Map                    as Map
 import           Data.Hashable (Hashable)
 
 import           X.Control.Monad.Trans.Either
+
+import           Control.Monad.Trans.State.Lazy
 
 
 -- | Type checking environment.
@@ -110,20 +118,59 @@ defaultCheckOptions = optionSmallData
 type GenEnv n             = Map.Map (Name n) (FunctionType n)
 type GenConstraintSet a n = [(a, Constraint n)]
 
+data DischargeInfo a n = DischargeInfo (GenConstraintSet a n) (SubstT n)
+ deriving Show
+
+instance (Pretty a, Pretty n) => Pretty (DischargeInfo a n) where
+ pretty (DischargeInfo cs s)
+  = "C: " <> indent 0 cons <> line <>
+    "S: " <> indent 0 sub
+  where
+   cons = vsep
+        $ fmap (pretty . snd)
+          cs
+   sub = vsep
+       $ fmap (\(k,v) -> pretty k <> " = " <> pretty v)
+       $ Map.toList s
+
+
+data CheckLog a n
+ = CheckLogDischargeOk Doc (DischargeInfo a n) (DischargeInfo a n)
+ | CheckLogDischargeError Doc (DischargeInfo a n) [(a,DischargeError n)]
+ deriving Show
+
+instance (Pretty a, Pretty n) => Pretty (CheckLog a n) where
+ pretty (CheckLogDischargeOk s i0 i1)
+  = "discharge " <> indent 0 (pretty s) <> line <>
+    "  before: " <> indent 0 (pretty i0) <> line <>
+    "  after:  " <> indent 0 (pretty i1)
+ pretty (CheckLogDischargeError s i0 errs)
+  = "discharge " <> indent 0 (pretty s) <> line <>
+    "  before: " <> indent 0 (pretty i0) <> line <>
+    "  errors: " <> indent 0 (pretty errs)
+
+
 newtype Gen a n t
- = Gen { constraintGen :: EitherT (CheckError a n) (Fresh.Fresh n) t }
+ = Gen { constraintGen :: StateT [CheckLog a n] (EitherT (CheckError a n) (Fresh.Fresh n)) t }
  deriving (Functor, Applicative, Monad)
 
 evalGen
     :: Gen a n t
-    -> EitherT (CheckError a n) (Fresh.Fresh n) t
+    -> EitherT (CheckError a n) (Fresh.Fresh n) (t, [CheckLog a n])
 evalGen f
- = EitherT
- $ Fresh.FreshT
- $ \ns -> Identity
- $ flip Fresh.runFresh ns
- $ runEitherT
+ = flip runStateT []
  $ constraintGen f
+
+evalGenNoLog
+    :: Gen a n t
+    -> EitherT (CheckError a n) (Fresh.Fresh n) t
+evalGenNoLog f = fst <$> evalGen f
+
+checkLog :: CheckLog a n -> Gen a n ()
+checkLog l = Gen $ modify (l:)
+
+genHoistEither :: Either (CheckError a n) t -> Gen a n t
+genHoistEither = Gen . lift . hoistEither
 
 type Query'C a n = Query (Annot a n) n
 type Exp'C   a n = Exp   (Annot a n) n
@@ -136,25 +183,28 @@ require a c = [(a,c)]
 -- | Discharge the constraints in some context after applying some type substitutions.
 --
 discharge
-  :: (Hashable n, Eq n)
+  :: (Hashable n, Eq n, Pretty q)
   => (q -> a)
   -> (SubstT n -> q -> q)
   -> (q, SubstT n, GenConstraintSet a n)
   -> Gen a n (q, SubstT n, GenConstraintSet a n)
 discharge annotOf sub (q, s, conset)
- = do let cs = nubConstraints $ fmap (\(a,c) -> (a, substC s c)) conset
+ = do let log_ppr   = pretty q
+      let log_info0 = DischargeInfo conset s
+      let cs = nubConstraints $ fmap (\(a,c) -> (a, substC s c)) conset
       case dischargeCS cs of
-       Left errs
-        -> Gen . hoistEither
-         $ errorNoSuggestions (ErrorConstraintsNotSatisfied (annotOf q) errs)
-       Right (s', cs')
-        -> do let s'' = compose s s'
-              --let e' = fmap (substFT s'') env
-              return (sub s'' q, s'', cs')
+       Left errs -> do
+        checkLog (CheckLogDischargeError log_ppr log_info0 errs) 
+        genHoistEither $ errorNoSuggestions (ErrorConstraintsNotSatisfied (annotOf q) errs)
+       Right (s', cs') -> do
+        let s'' = compose s s'
+        let log_info1 = DischargeInfo cs' s''
+        checkLog (CheckLogDischargeOk log_ppr log_info0 log_info1) 
+        return (sub s'' q, s'', cs')
 
 fresh :: Hashable n => Gen a n (Name n)
 fresh
- = Gen . lift $ Fresh.fresh
+ = Gen . lift . lift $ Fresh.fresh
 
 -- | Freshen function type by applying introduction rules to foralls.
 --
@@ -193,7 +243,7 @@ lookup ann n env
      Just t
       -> introForalls ann t
      Nothing
-      -> Gen . hoistEither
+      -> genHoistEither
        $ errorSuggestions (ErrorNoSuchVariable ann n)
                            [AvailableBindings n $ Map.toList env]
 

--- a/icicle-source/src/Icicle/Source/Checker/Base.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Base.hs
@@ -151,11 +151,11 @@ data CheckLog a n
  deriving Show
 
 instance (Pretty a, Pretty n) => Pretty (CheckLog a n) where
- pretty (CheckLogDischargeOk s i0 i1)
+ pretty (CheckLogDischargeOk e i0 i1)
   | emptyi i0 && emptyi i1
-  = "visit     " <> indent 0 (pretty s <> " : " <> pretty (dischargeType i0))
+  = "visit     " <> indent 0 (pretty e <> " : " <> pretty (dischargeType i0))
   | otherwise
-  = "discharge " <> indent 0 (pretty s) <> line <>
+  = "discharge " <> indent 0 (pretty e) <> line <>
     "  before: " <> indent 0 (pretty i0) <> line <>
     "  after:  " <> indent 0 (pretty i1)
   where
@@ -219,10 +219,10 @@ discharge annotOf sub (q, s, conset)
        Right (s', cs') -> do
         let s'' = compose s s'
         let q'  = sub s'' q
-        let annot' = annotOf q
+        let annot' = annotOf q'
         let log_info1 = DischargeInfo (annResult annot') cs' s''
         checkLog (CheckLogDischargeOk log_ppr log_info0 log_info1) 
-        return (sub s'' q, s'', cs')
+        return (q', s'', cs')
 
 fresh :: Hashable n => Gen a n (Name n)
 fresh

--- a/icicle-source/src/Icicle/Source/Checker/Checker.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Checker.hs
@@ -19,6 +19,7 @@ import                  Icicle.Source.Lexer.Token
 import                  Icicle.Data.Name
 
 import                  Icicle.Dictionary.Data
+import                  Icicle.Internal.Pretty (Pretty)
 
 import qualified        Icicle.Common.Fresh     as Fresh
 
@@ -35,7 +36,7 @@ type Result r a n = EitherT (CheckError a n) (Fresh.Fresh n) (r, Type n)
 
 
 -- | Check a top-level Query, returning the query with type annotations and casts inserted.
-checkQT :: (Hashable n, Eq n)
+checkQT :: (Hashable n, Eq n, Pretty n)
         => CheckOptions
         -> Features () n (InputKey ann Variable)
         -> QueryTop a n
@@ -63,7 +64,7 @@ checkQT opts features qt
    $ featuresConcretes features
 
 
-checkQ  :: (Hashable n, Eq n)
+checkQ  :: (Hashable n, Eq n, Pretty n)
         => CheckOptions
         -> CheckEnv a n
         -> Query    a n

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -179,7 +179,7 @@ generateQ (Query [] x) env
 -- Query with a context
 generateQ qq@(Query (c:_) _) env
  -- Discharge any constraints on the result
- =   discharge (annAnnot.annotOfQuery) substTQ
+ =   discharge annotOfQuery substTQ
  =<< case c of
     -- In the following "rules",
     --  x't stands for "temporality of x";
@@ -496,7 +496,7 @@ generateX
   -> GenEnv n
   -> Gen a n (Exp'C a n, SubstT n, GenConstraintSet a n)
 generateX x env
- =   discharge (annAnnot.annotOfExp) substTX
+ =   discharge annotOfExp substTX
  =<< case x of
     -- Variables can only be values, not functions.
     Var a n

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -162,7 +162,7 @@ checkF' fun env
         return (Annot a (substT subs t) [], n)
 
 
-dischargeF :: (Hashable n, Eq n, Pretty n) => a -> SubstT n -> [(a, Constraint n)] -> Gen a n (SubstT n, [(a, Constraint n)])
+dischargeF :: (Hashable n, Eq n) => a -> SubstT n -> [(a, Constraint n)] -> Gen a n (SubstT n, [(a, Constraint n)])
 dischargeF ann sub cons
  = case dischargeCS' dischargeC'toplevel cons of
     Left errs

--- a/icicle-source/src/Icicle/Source/Checker/Function.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Function.hs
@@ -16,6 +16,7 @@ import                  Icicle.Source.Type
 
 import                  Icicle.Common.Base
 import qualified        Icicle.Common.Fresh     as Fresh
+import                  Icicle.Internal.Pretty (Pretty)
 
 import                  P
 
@@ -32,34 +33,34 @@ type FunEnvT a n = [ ( Name n
                      , Function (Annot a n) n ) ) ]
 
 
-checkFs :: (Hashable n, Eq n)
+checkFs :: (Hashable n, Eq n, Pretty n)
         => FunEnvT a n
         -> Funs a n
         -> EitherT (CheckError a n) (Fresh.Fresh n)
-                   (FunEnvT a n)
+                   (FunEnvT a n, [[CheckLog a n]])
 
 checkFs env functions
- = foldlM go env functions
+ = foldlM go (env,[]) functions
  where
-  go env' (name,fun)
+  go (env0,logs0) (name,fun)
    = do
-    (annotfun, funtype) <- checkF (fst <$> Map.fromList env') fun
-    if List.elem (snd name) (fmap fst env')
+    ((annotfun, funtype),logs') <- checkF (fst <$> Map.fromList env0) fun
+    if List.elem (snd name) (fmap fst env0)
     then hoistEither $ Left $ CheckError (ErrorDuplicateFunctionNames (fst name) (snd name)) []
-    else pure (env' <> [(snd name , (funtype, annotfun))])
+    else pure (env0 <> [(snd name , (funtype, annotfun))], logs0 <> [logs'])
 
-checkF  :: (Hashable n, Eq n)
+checkF  :: (Hashable n, Eq n, Pretty n)
         => Map.Map (Name n) (FunctionType n)
         -> Function a n
         -> EitherT (CheckError a n) (Fresh.Fresh n)
-                   (Function (Annot a n) n, FunctionType n)
+                   ((Function (Annot a n) n, FunctionType n), [CheckLog a n])
 
 checkF env fun
  = evalGen $ checkF' fun env
 
 
 -- | Typecheck a function definition, generalising types and pulling out constraints
-checkF' :: (Hashable n, Eq n)
+checkF' :: (Hashable n, Eq n, Pretty n)
         => Function a n
         -> GenEnv n
         -> Gen a n (Function (Annot a n) n, FunctionType n)
@@ -161,11 +162,11 @@ checkF' fun env
         return (Annot a (substT subs t) [], n)
 
 
-dischargeF :: (Hashable n, Eq n) => a -> SubstT n -> [(a, Constraint n)] -> Gen a n (SubstT n, [(a, Constraint n)])
+dischargeF :: (Hashable n, Eq n, Pretty n) => a -> SubstT n -> [(a, Constraint n)] -> Gen a n (SubstT n, [(a, Constraint n)])
 dischargeF ann sub cons
  = case dischargeCS' dischargeC'toplevel cons of
     Left errs
-     -> Gen . hoistEither
+     -> genHoistEither
       $ errorNoSuggestions (ErrorConstraintsNotSatisfied ann errs)
     Right (sub', cons')
      -> return (compose sub sub', cons')

--- a/icicle-source/src/Icicle/Source/Checker/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Prim.hs
@@ -23,5 +23,5 @@ primLookup
  => a -> Prim
  -> Gen a n (FunctionType n, [Type n], Type n, GenConstraintSet a n)
 primLookup ann p
- = do ft <- Gen . lift $ primLookup' p
+ = do ft <- Gen . lift . lift $ primLookup' p
       introForalls ann ft

--- a/icicle-source/src/Icicle/Source/Parser.hs
+++ b/icicle-source/src/Icicle/Source/Parser.hs
@@ -11,6 +11,7 @@ module Icicle.Source.Parser (
 import Icicle.Source.Lexer.Lexer
 import Icicle.Source.Lexer.Token
 import Icicle.Source.Parser.Parser
+import Icicle.Source.Parser.Token
 
 import Icicle.Source.Query
 
@@ -29,12 +30,18 @@ import P
 parseFunctions :: SourceName -> Text -> Either ParseError [((SourcePos, Name Variable), (Function SourcePos Variable))]
 parseFunctions source inp
  = let toks = lexer source inp
-   in  runParser functions () source toks
+   in  runParser (consumeAll functions) () source toks
 
 parseQueryTop :: OutputId -> Text -> Either ParseError (QueryTop SourcePos Variable)
 parseQueryTop name inp
  = let toks = lexer "" inp
-   in  runParser (top name) () "" toks
+   in  runParser (consumeAll $ top name) () "" toks
+
+consumeAll :: Parser a -> Parser a
+consumeAll f = do
+ r <- f
+ eof
+ return r
 
 prettyParse :: OutputId -> Text -> [Char]
 prettyParse name inp

--- a/icicle-source/src/Icicle/Source/Parser/Parser.hs
+++ b/icicle-source/src/Icicle/Source/Parser/Parser.hs
@@ -30,7 +30,6 @@ top name
         v <- pUnresolvedInputId                                 <?> "input source"
         pFlowsInto
         q <- query                                              <?> "query"
-        eof
         return $ Q.QueryTop v name q
 
 functions :: Parser [((T.SourcePos, Name Var), (Q.Function T.SourcePos Var))]

--- a/icicle-source/src/Icicle/Source/Parser/Parser.hs
+++ b/icicle-source/src/Icicle/Source/Parser/Parser.hs
@@ -22,7 +22,7 @@ import                  Icicle.Data.Name
 
 import                  P hiding (exp)
 
-import                  Text.Parsec (many1, parserFail, getPosition, eof, (<?>), sepEndBy, try, notFollowedBy)
+import                  Text.Parsec (many1, parserFail, getPosition, (<?>), sepEndBy, try, notFollowedBy)
 
 top :: OutputId -> Parser (Q.QueryTop T.SourcePos Var)
 top name

--- a/icicle-source/src/Icicle/Source/PrettyAnnot.hs
+++ b/icicle-source/src/Icicle/Source/PrettyAnnot.hs
@@ -131,4 +131,10 @@ instance (Pretty a, Pretty n) => Pretty (PrettyAnnot (QueryTop (Annot a n) n)) w
   = case getPrettyAnnot qq of
      QueryTop f _ q -> "feature" <+> pretty (show (renderUnresolvedInputId f)) <> line <> "~>" <+> pretty (PrettyAnnot q)
 
+instance (Pretty a, Pretty n) => Pretty (PrettyAnnot (Function (Annot a n) n)) where
+ pretty (PrettyAnnot q) =
+  let p = fmap (\(a,n) -> annotate (AnnType a) (pretty n)) (arguments q)
+  in (sep p) <> line <> indent 2 ("=" <+> pretty (PrettyAnnot (body q)))
+
+
 


### PR DESCRIPTION
Function bindings
```
:set +type
:let sum x = fold s = 0 : s + x ~> s

- Type: sum
forall check/2. (Num check/2) => Element Definitely check/2 -> Aggregate Definitely check/2
```

Typechecking info

```
:set +type-check-log
:let sum x = fold s = 0 : s + x ~> s

discharge fold s = 0 : s + x ~> s
  before: T: Aggregate check/5 check/2
          C: Num check/4
             Num check/2
             Aggregate =: Aggregate
             Element =: Element
             check/4 =: check/2
             check/5 =: PossibilityJoin check/5 check/5
             check/5 =: Definitely
          S: check/0 = Element
             check/1 = check/5
             check/4 = check/2
             check/7 = check/2
  after:  T: Aggregate check/5 check/2
          C: Num check/2
          S: check/0 = Element
             check/1 = Definitely
             check/4 = check/2
             check/5 = Definitely
             check/7 = check/2

visit     s : Aggregate check/5 check/2

discharge s + x
  before: T: Element check/5 check/7
          C: Num check/7
             check/7 =: check/4
             check/7 =: check/2
             check/0 =: Element
             check/1 =: check/5
  after:  T: Element check/5 check/7
          C: Num check/2
          S: check/0 = Element
             check/1 = check/5
             check/4 = check/2
             check/7 = check/2

visit     x : check/0 check/1 check/2

visit     s : Element check/5 check/4

discharge 0
  before: T: check/4
          C: Num check/4
  after:  T: check/4
          C: Num check/4
```

! @jystic @tranma 
/jury approved @jystic