### PR TITLE
Rename SeaProgramAttribute -> Cluster and move to its own area

### DIFF
--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -130,7 +130,12 @@ library
 
                        Icicle.Simulator
 
+                       Icicle.Sea.Data
                        Icicle.Sea.Error
+                       Icicle.Sea.Eval
+                       Icicle.Sea.Eval.Base
+                       Icicle.Sea.Eval.Program
+                       Icicle.Sea.Fleet
                        Icicle.Sea.FromAvalanche
                        Icicle.Sea.FromAvalanche.Analysis
                        Icicle.Sea.FromAvalanche.Base
@@ -138,19 +143,16 @@ library
                        Icicle.Sea.FromAvalanche.Program
                        Icicle.Sea.FromAvalanche.State
                        Icicle.Sea.FromAvalanche.Type
-                       Icicle.Sea.Preamble
-                       Icicle.Sea.Eval
-                       Icicle.Sea.Eval.Base
-                       Icicle.Sea.Eval.Program
-                       Icicle.Sea.Fleet
                        Icicle.Sea.IO
-                       Icicle.Sea.IO.Offset
                        Icicle.Sea.IO.Base
+                       Icicle.Sea.IO.Offset
                        Icicle.Sea.IO.Psv
                        Icicle.Sea.IO.Psv.Input
                        Icicle.Sea.IO.Psv.Output
                        Icicle.Sea.IO.Psv.Schema
                        Icicle.Sea.IO.Zebra
+                       Icicle.Sea.Name
+                       Icicle.Sea.Preamble
 
 
 executable icicle

--- a/icicle-compiler/src/Icicle/Sea/Data.hs
+++ b/icicle-compiler/src/Icicle/Sea/Data.hs
@@ -1,0 +1,112 @@
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Sea.Data (
+    Cluster(..)
+  , ClusterId(..)
+  , renderClusterId
+  , prettyClusterId
+
+  , Kernel(..)
+  , KernelId(..)
+  , KernelIndex(..)
+  , renderKernelId
+  , prettyKernelId
+  , renderKernelIndex
+  , prettyKernelIndex
+
+  , MeltedType(..)
+  ) where
+
+import           Data.List.NonEmpty (NonEmpty)
+import           Data.Map (Map)
+import qualified Data.Text as Text
+
+import           GHC.Generics (Generic)
+
+import           Icicle.Common.Type
+import           Icicle.Data.Name
+import           Icicle.Internal.Pretty
+import           Icicle.Sea.Name
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+
+data Cluster =
+  Cluster {
+      clusterId :: !ClusterId
+    , clusterInputId :: !InputId
+    , clusterInputType :: !ValType
+    , clusterInputVars :: ![(SeaName, ValType)]
+    , clusterTimeVar :: !SeaName
+    , clusterKernels :: !(NonEmpty Kernel)
+    , clusterOutputs :: !(Map OutputId MeltedType)
+    } deriving (Eq, Ord, Show, Generic)
+
+data Kernel =
+  Kernel {
+      kernelId :: !KernelId
+    , kernelResumables :: ![(SeaName, ValType)]
+    , kernelOutputs :: ![(OutputId, MeltedType)]
+    } deriving (Eq, Ord, Show, Generic)
+
+newtype ClusterId =
+  ClusterId {
+      unClusterId :: Int
+    } deriving (Eq, Ord, Generic, Num, Enum, Real, Integral)
+
+newtype KernelIndex =
+  KernelIndex {
+      unKernelIndex :: Int
+    } deriving (Eq, Ord, Generic, Num, Enum, Real, Integral)
+
+data KernelId =
+  KernelId {
+      kernelCluster :: !ClusterId
+    , kernelIndex :: !KernelIndex
+    } deriving (Eq, Ord, Generic)
+
+data MeltedType =
+  MeltedType {
+      typeLogical :: !ValType
+    , typeMelted :: ![ValType]
+    } deriving (Eq, Ord, Show, Generic)
+
+instance Show ClusterId where
+  showsPrec =
+    gshowsPrec
+
+instance Show KernelIndex where
+  showsPrec =
+    gshowsPrec
+
+instance Show KernelId where
+  showsPrec =
+    gshowsPrec
+
+renderClusterId :: ClusterId -> Text
+renderClusterId =
+  Text.pack . show . unClusterId
+
+prettyClusterId :: ClusterId -> Doc
+prettyClusterId =
+  text . show . unClusterId
+
+renderKernelIndex :: KernelIndex -> Text
+renderKernelIndex =
+  Text.pack . show . unKernelIndex
+
+prettyKernelIndex :: KernelIndex -> Doc
+prettyKernelIndex =
+  text . show . unKernelIndex
+
+renderKernelId :: KernelId -> Text
+renderKernelId (KernelId cid kix) =
+  renderClusterId cid <> "/" <> renderKernelIndex kix
+
+prettyKernelId :: KernelId -> Doc
+prettyKernelId =
+  text . Text.unpack . renderKernelId

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
-
 module Icicle.Sea.FromAvalanche (
     seaOfPrograms
   , factVarsOfProgram

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Analysis.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Analysis.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE PatternGuards #-}
-
 module Icicle.Sea.FromAvalanche.Analysis (
     factVarsOfProgram
   , resumablesOfProgram
@@ -21,6 +20,8 @@ import           Icicle.Common.Exp
 import           Icicle.Common.Type
 
 import           Icicle.Data.Name
+
+import           Icicle.Sea.Data
 
 import           P
 
@@ -157,10 +158,10 @@ readsOfStatement stmt
 
 ------------------------------------------------------------------------
 
-outputsOfProgram :: Program (Annot a) n Prim -> [(OutputId, (ValType, [ValType]))]
+outputsOfProgram :: Program (Annot a) n Prim -> [(OutputId, MeltedType)]
 outputsOfProgram = Map.toList . outputsOfStatement . statements
 
-outputsOfStatement :: Statement (Annot a) n Prim -> Map OutputId (ValType, [ValType])
+outputsOfStatement :: Statement (Annot a) n Prim -> Map OutputId MeltedType
 outputsOfStatement stmt
  = case stmt of
      Block []                -> Map.empty
@@ -180,7 +181,7 @@ outputsOfStatement stmt
      KeepFactInHistory _     -> Map.empty
 
      Output n t xts
-      -> Map.singleton n (t, fmap snd xts)
+      -> Map.singleton n $ MeltedType t (fmap snd xts)
 
 ------------------------------------------------------------------------
 

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Base.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Base.hs
@@ -4,15 +4,8 @@
 {-# LANGUAGE PatternGuards #-}
 {-# LANGUAGE ViewPatterns #-}
 module Icicle.Sea.FromAvalanche.Base (
-    SeaName
-  , SeaString
-  , takeSeaName
+    SeaString
   , takeSeaString
-  , asSeaName
-  , mangleToSeaName
-  , mangleToSeaNameIx
-  , unmangleSeaName
-  , inputIdAsSeaString
   , seaOfChar
   , seaOfString
   , seaOfEscaped
@@ -37,63 +30,17 @@ import           Numeric (showHex)
 
 import           P
 
-import           Text.Encoding.Z (zEncodeString, zDecodeString)
 import           Text.Printf (printf)
 
 ------------------------------------------------------------------------
-
--- | A legal C identifier.
-newtype SeaName = SeaName {
-    getSeaName :: Text
- } deriving (Eq, Ord, Show)
 
 -- | A value that will need be quoted in C.
 newtype SeaString = SeaString {
     getSeaString :: Text
  } deriving (Eq, Ord, Show)
 
-takeSeaName :: SeaName -> Text
-takeSeaName = getSeaName
-
 takeSeaString :: SeaString -> Text
 takeSeaString = getSeaString
-
-seaNameValidHead :: Char -> Bool
-seaNameValidHead c =
-  (c >= 'a' && c <= 'z') ||
-  (c >= 'A' && c <= 'Z') ||
-  (c == '_')
-{-# INLINE seaNameValidHead #-}
-
-seaNameValidTail :: Char -> Bool
-seaNameValidTail c =
-  seaNameValidHead c ||
-  (c >= '0' && c <= '9') ||
-  (c == '_')
-{-# INLINE seaNameValidTail #-}
-
-asSeaName :: Text -> Maybe SeaName
-asSeaName t =
-  case Text.unpack t of
-    x:xs | seaNameValidHead x && all seaNameValidTail xs ->
-      Just (SeaName t)
-    _ ->
-      Nothing
-
-mangleToSeaName :: Pretty n => n -> SeaName
-mangleToSeaName (show . pretty -> n) =
-  SeaName . Text.pack $ zEncodeString n
-
-mangleToSeaNameIx :: Pretty n => n -> Int -> SeaName
-mangleToSeaNameIx n ix = mangleToSeaName (pretty n <> text "/ix/" <> int ix)
-
-unmangleSeaName :: SeaName -> Text
-unmangleSeaName =
-  Text.pack . zDecodeString . Text.unpack . getSeaName
-
-inputIdAsSeaString :: InputId -> SeaString
-inputIdAsSeaString =
-  SeaString . renderInputId
 
 ------------------------------------------------------------------------
 

--- a/icicle-compiler/src/Icicle/Sea/IO.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO.hs
@@ -44,8 +44,8 @@ import           Icicle.Internal.Pretty
 
 import           Icicle.Data
 
+import           Icicle.Sea.Data
 import           Icicle.Sea.Error (SeaError(..))
-import           Icicle.Sea.FromAvalanche.State
 
 import           Icicle.Sea.IO.Offset
 import           Icicle.Sea.IO.Base
@@ -60,16 +60,16 @@ data IOFormat
   | FormatZebra ZebraConfig Mode PsvOutputConfig -- temporary
     deriving (Eq, Show)
 
-seaOfDriver :: IOFormat -> InputOpts -> [InputId] -> [SeaProgramAttribute] -> Either SeaError Doc
-seaOfDriver format opts inputs states
+seaOfDriver :: IOFormat -> InputOpts -> [InputId] -> [Cluster] -> Either SeaError Doc
+seaOfDriver format opts inputs clusters
   = case format of
       FormatPsv conf -> do
-        seaOfPsvDriver opts conf states
+        seaOfPsvDriver opts conf clusters
       FormatZebra _ mode outputConfig -> do
         -- FIXME generate code for psv as well when using zebra, because we
         -- are relying on some psv functions, they should be factored out or something
         let psvConfig =
               PsvConfig (PsvInputConfig mode PsvInputSparse) outputConfig
-        x <- seaOfPsvDriver opts psvConfig states
-        y <- seaOfZebraDriver inputs states
+        x <- seaOfPsvDriver opts psvConfig clusters
+        y <- seaOfZebraDriver inputs clusters
         return $ vsep [x, "", y]

--- a/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Offset.hs
@@ -1,9 +1,9 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Sea.IO.Offset where
 
-import P
+import           Icicle.Sea.Data
 
-import Icicle.Sea.FromAvalanche.State
+import           P
 
 
 -- typedef struct {
@@ -201,9 +201,9 @@ inputError = 2
 inputStart :: Int
 inputStart = 3
 
-inputFieldsCount :: SeaProgramAttribute -> Int
-inputFieldsCount state =
-  length (stateInputVars state) - 2
+inputFieldsCount :: Cluster -> Int
+inputFieldsCount cluster =
+  length (clusterInputVars cluster) - 2
 
 programInputFactTime :: Int
 programInputFactTime = programInput + inputFactTime

--- a/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
+++ b/icicle-compiler/src/Icicle/Sea/IO/Psv.hs
@@ -31,8 +31,8 @@ module Icicle.Sea.IO.Psv (
 
 import           Icicle.Internal.Pretty
 
+import           Icicle.Sea.Data
 import           Icicle.Sea.Error (SeaError(..))
-import           Icicle.Sea.FromAvalanche.State
 import           Icicle.Sea.IO.Base
 import           Icicle.Sea.IO.Psv.Input
 import           Icicle.Sea.IO.Psv.Output
@@ -75,8 +75,8 @@ defaultPsvMaxMapSize = 1024 * 1024
 
 ------------------------------------------------------------------------
 
-seaOfPsvDriver :: InputOpts -> PsvConfig -> [SeaProgramAttribute] -> Either SeaError Doc
-seaOfPsvDriver opts config states = do
+seaOfPsvDriver :: InputOpts -> PsvConfig -> [Cluster] -> Either SeaError Doc
+seaOfPsvDriver opts config clusters = do
   let inputConfig  = psvInputConfig config
   let outputConfig = psvOutputConfig config
   let outputList   = case inputPsvFormat inputConfig of
@@ -86,13 +86,13 @@ seaOfPsvDriver opts config states = do
                          -> Just [feed]
   let mode         = inputPsvMode inputConfig
 
-  let struct_sea  = seaOfFleetState      states
-      alloc_sea   = seaOfAllocFleet      states
-      collect_sea = seaOfCollectFleet    states
-      config_sea  = seaOfConfigureFleet  mode states
+  let struct_sea  = seaOfFleetState      clusters
+      alloc_sea   = seaOfAllocFleet      clusters
+      collect_sea = seaOfCollectFleet    clusters
+      config_sea  = seaOfConfigureFleet  mode clusters
 
-  read_sea  <- seaOfReadAnyFactPsv   opts inputConfig  states
-  write_sea <- seaOfWriteFleetOutput      outputConfig outputList states
+  read_sea  <- seaOfReadAnyFactPsv   opts inputConfig  clusters
+  write_sea <- seaOfWriteFleetOutput      outputConfig outputList clusters
 
   pure $ vsep
     [ struct_sea

--- a/icicle-compiler/src/Icicle/Sea/Name.hs
+++ b/icicle-compiler/src/Icicle/Sea/Name.hs
@@ -1,0 +1,68 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+module Icicle.Sea.Name (
+    SeaName
+  , renderSeaName
+  , prettySeaName
+  , parseSeaName
+
+  , mangle
+  , mangleIx
+  , unmangle
+  ) where
+
+import qualified Data.Text as Text
+
+import           Icicle.Internal.Pretty
+
+import           P
+
+import           Text.Encoding.Z (zEncodeString, zDecodeString)
+
+
+-- | A legal C identifier.
+--
+newtype SeaName =
+  SeaName {
+      unSeaName :: Text
+    } deriving (Eq, Ord, Show)
+
+renderSeaName :: SeaName -> Text
+renderSeaName =
+  unSeaName
+
+prettySeaName :: SeaName -> Doc
+prettySeaName =
+  prettyText . renderSeaName
+
+seaNameValidHead :: Char -> Bool
+seaNameValidHead c =
+     (c >= 'a' && c <= 'z')
+  || (c >= 'A' && c <= 'Z')
+  || (c == '_')
+
+seaNameValidTail :: Char -> Bool
+seaNameValidTail c =
+     seaNameValidHead c
+  || (c >= '0' && c <= '9')
+  || (c == '_')
+
+parseSeaName :: Text -> Maybe SeaName
+parseSeaName t =
+  case Text.unpack t of
+    x : xs | seaNameValidHead x && all seaNameValidTail xs ->
+      Just (SeaName t)
+    _ ->
+      Nothing
+
+mangle :: Pretty n => n -> SeaName
+mangle =
+  SeaName . Text.pack . zEncodeString . show . pretty
+
+mangleIx :: Pretty n => n -> Int -> SeaName
+mangleIx n ix =
+  mangle $
+    pretty n <> text "/ix/" <> int ix
+
+unmangle :: SeaName -> Text
+unmangle =
+  Text.pack . zDecodeString . Text.unpack . renderSeaName

--- a/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Zebra.hs
@@ -148,7 +148,7 @@ runTest pool zwt@(ZebraWellTyped wt facts entities) =
                   (\state -> do
                      fleet_ptr <- peekWordOff state zebraStateFleet
                      struct_count <- inputFieldsCount <$>
-                       hoistEither (stateOfPrograms 0 (wtInputId wt) (wtAvalancheFlat wt :| []))
+                       hoistEither (clusterOfPrograms 0 (wtInputId wt) (wtAvalancheFlat wt :| []))
                      fact_count <- hoistMaybe (SeaZebraError "test_impossible") . fmap length $
                        Map.lookup (Entity . Text.decodeUtf8 . Zebra.unEntityId . Zebra.entityId $ entity) facts
 

--- a/icicle-repl/test/cli/repl/t30-sea/expected
+++ b/icicle-repl/test/cli/repl/t30-sea/expected
@@ -1186,7 +1186,7 @@ read flat/87/simpflat/229 = flat/87/simpflat/215 [Double];
 output@{(Sum Error Double)} repl:output (flat/87/simpflat/228@{Error}, flat/87/simpflat/229@{Double});
 
 - C:
-#line 1 "state and input definition #0 - repl:input"
+#line 1 "cluster state #0 - repl:input"
 
 typedef struct {
     itime_t          convzs3;
@@ -1205,7 +1205,7 @@ typedef struct {
     /* inputs */
     input_replZCinput_t input;
 
-  /* compute for (0,0) */
+  /* kernel 0/0 */
     /* outputs */
     ierror_t         replZCoutputzsixzs0;
     idouble_t        replZCoutputzsixzs1;
@@ -1239,15 +1239,15 @@ typedef struct {
     ibool_t          has_flags_end_0_0;
 
 
-} iattribute_0_t;
+} icluster_0_t;
 
-iint_t size_of_state_iattribute_0 ()
+iint_t size_of_icluster_0 ()
 {
-    return sizeof (iattribute_0_t);
+    return sizeof (icluster_0_t);
 }
 
-#line 1 "compute function #0 - repl:input icompute_attribute_0_compute_0"
-void icompute_attribute_0_compute_0(iattribute_0_t *s)
+#line 1 "kernel function #0 - repl:input icluster_0_kernel_0"
+void icluster_0_kernel_0(icluster_0_t *s)
 {
     idouble_t        flatzs29zssimpflatzs130;
     ierror_t         flatzs91zssimpflatzs220;
@@ -2188,7 +2188,7 @@ read s/reify/2/conv/5/simpflat/24 = acc/s/reify/2/conv/5/simpflat/12 [Time];
 output@{(Sum Error Time)} repl:output (s/reify/2/conv/5/simpflat/23@{Error}, s/reify/2/conv/5/simpflat/24@{Time});
 
 - C:
-#line 1 "state and input definition #0 - repl:input"
+#line 1 "cluster state #0 - repl:input"
 
 typedef struct {
     itime_t          convzs3;
@@ -2206,7 +2206,7 @@ typedef struct {
     /* inputs */
     input_replZCinput_t input;
 
-  /* compute for (0,0) */
+  /* kernel 0/0 */
     /* outputs */
     ierror_t         replZCoutputzsixzs0;
     itime_t          replZCoutputzsixzs1;
@@ -2222,15 +2222,15 @@ typedef struct {
     ibool_t          has_flags_end_0_0;
 
 
-} iattribute_0_t;
+} icluster_0_t;
 
-iint_t size_of_state_iattribute_0 ()
+iint_t size_of_icluster_0 ()
 {
-    return sizeof (iattribute_0_t);
+    return sizeof (icluster_0_t);
 }
 
-#line 1 "compute function #0 - repl:input icompute_attribute_0_compute_0"
-void icompute_attribute_0_compute_0(iattribute_0_t *s)
+#line 1 "kernel function #0 - repl:input icluster_0_kernel_0"
+void icluster_0_kernel_0(icluster_0_t *s)
 {
     itime_t          flatzs4;
     itime_t          szsreifyzs2zsconvzs5zssimpflatzs24;

--- a/icicle-repl/test/cli/repl/t30.3-sum-not-error/expected
+++ b/icicle-repl/test/cli/repl/t30.3-sum-not-error/expected
@@ -21,7 +21,7 @@ ok, loaded test/cli/repl/data.psv, 13 rows
                                     \_____________)
 > ok, c is now on
 > > - C:
-#line 1 "state and input definition #0 - repl:input"
+#line 1 "cluster state #0 - repl:input"
 
 typedef struct {
     itime_t          convzs3;
@@ -39,7 +39,7 @@ typedef struct {
     /* inputs */
     input_replZCinput_t input;
 
-  /* compute for (0,0) */
+  /* kernel 0/0 */
     /* outputs */
     ibool_t          replZCoutputzsixzs0;
     iint_t           replZCoutputzsixzs1;
@@ -58,15 +58,15 @@ typedef struct {
     ibool_t          has_flags_end_0_0;
 
 
-} iattribute_0_t;
+} icluster_0_t;
 
-iint_t size_of_state_iattribute_0 ()
+iint_t size_of_icluster_0 ()
 {
-    return sizeof (iattribute_0_t);
+    return sizeof (icluster_0_t);
 }
 
-#line 1 "compute function #0 - repl:input icompute_attribute_0_compute_0"
-void icompute_attribute_0_compute_0(iattribute_0_t *s)
+#line 1 "kernel function #0 - repl:input icluster_0_kernel_0"
+void icluster_0_kernel_0(icluster_0_t *s)
 {
     idouble_t        perhapszsconvzs5zsavalzs0zssimpflatzs9;
     iint_t           perhapszsconvzs5zsavalzs0zssimpflatzs8;


### PR DESCRIPTION
Another quick cleanup, this renames `SeaProgramAttribute` -> `Cluster` and `SeaProgramCompute` -> `Kernel` and moves it to `Icicle.Sea.Data`. I also moved `SeaName` to `Icicle.Sea.Name` so it's up at the same level. Neither are really avalanche specific after all.

So the idea is that each input has a cluster of kernels which execute the relevant queries for that input.

! @tranma

/cc @amosr