### PR TITLE
Support for encoding / decoding C dictionary header

### DIFF
--- a/icicle-compiler/icicle.cabal
+++ b/icicle-compiler/icicle.cabal
@@ -124,6 +124,7 @@ library
 
                        Icicle.Compiler
 
+                       Icicle.Internal.Aeson
                        Icicle.Internal.Rename
 
                        Icicle.Runtime.Array
@@ -143,6 +144,7 @@ library
                        Icicle.Sea.FromAvalanche.Program
                        Icicle.Sea.FromAvalanche.State
                        Icicle.Sea.FromAvalanche.Type
+                       Icicle.Sea.Header
                        Icicle.Sea.IO
                        Icicle.Sea.IO.Base
                        Icicle.Sea.IO.Offset

--- a/icicle-compiler/src/Icicle/Internal/Aeson.hs
+++ b/icicle-compiler/src/Icicle/Internal/Aeson.hs
@@ -1,0 +1,238 @@
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Internal.Aeson (
+    AesonDecodeError(..)
+  , renderAesonDecodeError
+
+  , decodeJson
+  , encodePrettyJson
+  , encodeCompactJson
+
+  , prettyConfig
+  , compactConfig
+
+  , pText
+  , pRendered
+  , pInt
+  , pUnit
+  , pEnum
+  , pVector
+  , pNonEmpty
+  , pList
+  , pMap
+  , withKey
+  , expectKey
+
+  , ppText
+  , ppRendered
+  , ppInt
+  , ppUnit
+  , ppEnum
+  , ppVector
+  , ppNonEmpty
+  , ppList
+  , ppMap
+  ) where
+
+import           Data.Aeson ((.=), (.:))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Encode.Pretty as Aeson
+import           Data.Aeson.Internal ((<?>))
+import qualified Data.Aeson.Internal as Aeson
+import qualified Data.Aeson.Parser as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.ByteString.Lazy as Lazy
+import qualified Data.HashMap.Strict as HashMap
+import qualified Data.List as List
+import           Data.List.NonEmpty (NonEmpty(..))
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import           Data.String (String)
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Vector as Boxed
+
+import           P
+
+
+data AesonDecodeError =
+    AesonDecodeError !Aeson.JSONPath !Text
+    deriving (Eq, Show)
+
+renderAesonDecodeError :: AesonDecodeError -> Text
+renderAesonDecodeError = \case
+  AesonDecodeError path msg ->
+    Text.pack . Aeson.formatError path $ Text.unpack msg
+
+decodeJson :: (Aeson.Value -> Aeson.Parser a) -> Text -> Either AesonDecodeError a
+decodeJson p =
+  first (uncurry AesonDecodeError . second Text.pack) .
+    Aeson.eitherDecodeStrictWith Aeson.value' (Aeson.iparse p) .
+    Text.encodeUtf8
+
+encodePrettyJson :: [Text] -> Aeson.Value -> Text
+encodePrettyJson keyOrder =
+  Text.decodeUtf8 . Lazy.toStrict . (<> "\n") . Aeson.encodePretty' (prettyConfig keyOrder)
+
+encodeCompactJson :: [Text] -> Aeson.Value -> Text
+encodeCompactJson keyOrder =
+  Text.decodeUtf8 . Lazy.toStrict . Aeson.encodePretty' (compactConfig keyOrder)
+
+prettyConfig :: [Text] -> Aeson.Config
+prettyConfig keyOrder =
+  Aeson.defConfig {
+      Aeson.confIndent =
+        Aeson.Spaces 2
+    , Aeson.confCompare =
+        Aeson.keyOrder keyOrder
+    }
+
+compactConfig :: [Text] -> Aeson.Config
+compactConfig keyOrder =
+  (prettyConfig keyOrder) {
+      Aeson.confIndent =
+        Aeson.Spaces 0
+    }
+
+pText :: Aeson.Value -> Aeson.Parser Text
+pText =
+  Aeson.parseJSON
+
+ppText :: Text -> Aeson.Value
+ppText =
+  Aeson.toJSON
+
+pRendered :: String -> (Text -> Maybe a) -> Aeson.Value -> Aeson.Parser a
+pRendered expected parse x = do
+  txt <- pText x
+  case parse txt of
+    Nothing ->
+      fail $
+        "Not a valid " <> expected <> " <" <> Text.unpack txt <> ">"
+    Just name ->
+      pure name
+
+ppRendered :: (a -> Text) -> a -> Aeson.Value
+ppRendered render =
+  ppText . render
+
+pInt :: Aeson.Value -> Aeson.Parser Int
+pInt =
+  Aeson.parseJSON
+
+ppInt :: Int -> Aeson.Value
+ppInt =
+  Aeson.toJSON
+
+pUnit :: Aeson.Value -> Aeson.Parser ()
+pUnit =
+  Aeson.withObject "Unit (i.e. {})" $ \o ->
+    if HashMap.null o then
+      pure ()
+    else
+      fail $
+        "Expected an object containing unit (i.e. {})," <>
+        "\nbut found an object with one or more members"
+
+ppUnit :: Aeson.Value
+ppUnit =
+  Aeson.Object HashMap.empty
+
+pEnum :: String -> (Text -> Maybe (Aeson.Value -> Aeson.Parser a)) -> Aeson.Value -> Aeson.Parser a
+pEnum expected mkParser =
+  Aeson.withObject expected $ \o ->
+    case HashMap.toList o of
+      [(name, value)] -> do
+        case mkParser name of
+          Nothing ->
+            fail (expected <> ": unknown variant: " <> Text.unpack name) <?> Aeson.Key name
+          Just parser ->
+            parser value <?> Aeson.Key name
+      [] ->
+        fail $
+          "Expected " <> expected <> " but found an object with no members."
+      kvs ->
+        fail $
+          "Expected " <> expected <> " but found an object with more than one member." <>
+          "\n  " <> List.intercalate ", " (fmap (Text.unpack . fst) kvs)
+
+ppEnum :: Text -> Aeson.Value -> Aeson.Value
+ppEnum name value =
+  Aeson.object [
+      name .= value
+    ]
+
+pVector :: String -> (Aeson.Value -> Aeson.Parser a) -> Aeson.Value -> Aeson.Parser (Boxed.Vector a)
+pVector expected pValue =
+  Aeson.withArray expected $
+    traverse pValue
+
+ppVector :: (a -> Aeson.Value) -> Boxed.Vector a -> Aeson.Value
+ppVector ppValue xs =
+  Aeson.Array $
+    fmap ppValue xs
+
+pList :: String -> (Aeson.Value -> Aeson.Parser a) -> Aeson.Value -> Aeson.Parser [a]
+pList expected pValue =
+  fmap Boxed.toList . pVector expected pValue
+
+ppList :: (a -> Aeson.Value) -> [a] -> Aeson.Value
+ppList ppValue =
+  ppVector ppValue . Boxed.fromList
+
+pNonEmpty :: String -> (Aeson.Value -> Aeson.Parser a) -> Aeson.Value -> Aeson.Parser (NonEmpty a)
+pNonEmpty expected pValue v = do
+  xs0 <- pList expected pValue v
+  case xs0 of
+    [] ->
+      fail $
+        "Expected " <> expected <> " which must be non-empty, but found an empty array"
+    x : xs ->
+      pure $
+        x :| xs
+
+ppNonEmpty :: (a -> Aeson.Value) -> NonEmpty a -> Aeson.Value
+ppNonEmpty ppValue =
+  ppList ppValue . toList
+
+pMap :: Ord k => String -> (Text -> Maybe k) -> (Aeson.Value -> Aeson.Parser v) -> Aeson.Value -> Aeson.Parser (Map k v)
+pMap expected parseKey pValue =
+  let
+    parse (k0, v0) =
+      case parseKey k0 of
+        Nothing ->
+          fail ("failed to parse key of map: " <> Text.unpack k0) <?> Aeson.Key k0
+        Just k -> do
+          v <- pValue v0 <?> Aeson.Key k0
+          pure (k, v)
+  in
+    Aeson.withObject expected $
+      fmap Map.fromList . traverse parse . HashMap.toList
+
+ppMap :: (k -> Text) -> (v -> Aeson.Value) -> Map k v -> Aeson.Value
+ppMap renderKey ppValue =
+  let
+    keyed (k, v) =
+      renderKey k .=
+        ppValue v
+  in
+    Aeson.object . fmap keyed . Map.toList
+
+withKey :: Text -> Aeson.Object -> (Aeson.Value -> Aeson.Parser a) -> Aeson.Parser a
+withKey key o p = do
+  x <- o .: key
+  p x <?> Aeson.Key key
+
+expectKey :: (Eq a, Show a) => Text -> Text -> Aeson.Object -> (Aeson.Value -> Aeson.Parser a) -> a -> Aeson.Parser ()
+expectKey prefix key0 o p expected = do
+  x <- withKey key0 o p
+  unless (x == expected) . fail $
+    let
+      key =
+        if Text.null prefix then
+          key0
+        else
+          prefix <> "/" <> key0
+    in
+      "Expected " <> Text.unpack key <> " to be <" <> show expected <> "> but was <" <> show x <> ">"

--- a/icicle-compiler/src/Icicle/Sea/Data.hs
+++ b/icicle-compiler/src/Icicle/Sea/Data.hs
@@ -5,6 +5,7 @@
 module Icicle.Sea.Data (
     Cluster(..)
   , ClusterId(..)
+  , clusterOutputs
   , renderClusterId
   , prettyClusterId
 
@@ -20,7 +21,9 @@ module Icicle.Sea.Data (
   ) where
 
 import           Data.List.NonEmpty (NonEmpty)
+import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
 import qualified Data.Text as Text
 
 import           GHC.Generics (Generic)
@@ -43,7 +46,6 @@ data Cluster =
     , clusterInputVars :: ![(SeaName, ValType)]
     , clusterTimeVar :: !SeaName
     , clusterKernels :: !(NonEmpty Kernel)
-    , clusterOutputs :: !(Map OutputId MeltedType)
     } deriving (Eq, Ord, Show, Generic)
 
 data Kernel =
@@ -86,6 +88,10 @@ instance Show KernelIndex where
 instance Show KernelId where
   showsPrec =
     gshowsPrec
+
+clusterOutputs :: Cluster -> Map OutputId MeltedType
+clusterOutputs =
+  Map.fromList . concatMap kernelOutputs . NonEmpty.toList . clusterKernels
 
 renderClusterId :: ClusterId -> Text
 renderClusterId =

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/State.hs
@@ -90,9 +90,6 @@ clusterOfPrograms cid iid programs@(program :| _) =
 
         , clusterKernels =
             NonEmpty.zipWith (kernelOfProgram cid) (0 :| [1..]) programs
-
-        , clusterOutputs =
-            Map.fromList . concatMap outputsOfProgram $ NonEmpty.toList programs
         }
 
 kernelOfProgram ::

--- a/icicle-compiler/src/Icicle/Sea/Header.hs
+++ b/icicle-compiler/src/Icicle/Sea/Header.hs
@@ -1,0 +1,557 @@
+{-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Sea.Header (
+    Header(..)
+  , Fingerprint(..)
+  , renderHeader
+  , parseHeader
+
+  , HeaderDecodeError(..)
+  , renderHeaderDecodeError
+
+  , pFingerprint
+  , pStructType
+  , pValType
+  , pMeltedType
+  , pClusterId
+  , pKernelIndex
+  , pKernelId
+  , pSeaName
+  , pInputId
+  , pOutputId
+  , pMeltedOutput
+  , pNamedType
+  , pKernel
+  , pCluster
+  , pHeader
+
+  , ppFingerprint
+  , ppStructType
+  , ppValType
+  , ppMeltedType
+  , ppClusterId
+  , ppKernelIndex
+  , ppKernelId
+  , ppSeaName
+  , ppInputId
+  , ppOutputId
+  , ppMeltedOutput
+  , ppNamedType
+  , ppKernel
+  , ppCluster
+  , ppHeader
+  ) where
+
+import           Data.Aeson ((.=))
+import qualified Data.Aeson as Aeson
+import qualified Data.Aeson.Types as Aeson
+import qualified Data.List as List
+import qualified Data.Text as Text
+
+import           Icicle.Avalanche.Prim.Flat (meltType)
+import           Icicle.Common.Type
+import           Icicle.Data.Name
+import           Icicle.Internal.Aeson
+import           Icicle.Sea.Data
+import           Icicle.Sea.Name
+
+import           GHC.Generics (Generic)
+
+import           P
+
+import           X.Text.Show (gshowsPrec)
+
+data Header =
+  Header {
+      headerFingerprint :: !Fingerprint
+    , headerClusters :: ![Cluster]
+    } deriving (Eq, Ord, Show, Generic)
+
+newtype Fingerprint =
+  Fingerprint {
+      unFingerprint :: Text
+    } deriving (Eq, Ord, Generic)
+
+instance Show Fingerprint where
+  showsPrec =
+    gshowsPrec
+
+data HeaderDecodeError =
+    HeaderDecodeError !AesonDecodeError
+  | HeaderMalformedEnvelope
+    deriving (Eq, Show)
+
+renderHeaderDecodeError :: HeaderDecodeError -> Text
+renderHeaderDecodeError = \case
+  HeaderDecodeError err ->
+    renderAesonDecodeError err
+  HeaderMalformedEnvelope ->
+    "Failed reading header from C dictionary, envelope was malformed"
+
+pFingerprint :: Aeson.Value -> Aeson.Parser Fingerprint
+pFingerprint =
+  fmap Fingerprint . pText
+
+ppFingerprint :: Fingerprint -> Aeson.Value
+ppFingerprint =
+  ppText . unFingerprint
+
+pStructType :: Aeson.Value -> Aeson.Parser StructType
+pStructType =
+  fmap StructType . pMap "StructType" (pure . StructField) pValType
+
+ppStructType :: StructType -> Aeson.Value
+ppStructType =
+  ppMap nameOfStructField ppValType . getStructType
+
+pValType :: Aeson.Value -> Aeson.Parser ValType
+pValType =
+  pEnum "ValType" $ \case
+    "bool" ->
+      Just $
+        (BoolT <$) . pUnit
+
+    "time" ->
+      Just $
+        (TimeT <$) . pUnit
+
+    "double" ->
+      Just $
+        (DoubleT <$) . pUnit
+
+    "int" ->
+      Just $
+        (IntT <$) . pUnit
+
+    "string" ->
+      Just $
+        (StringT <$) . pUnit
+
+    "unit" ->
+      Just $
+        (UnitT <$) . pUnit
+
+    "error" ->
+      Just $
+        (ErrorT <$) . pUnit
+
+    "fact_identifier" ->
+      Just $
+        (FactIdentifierT <$) . pUnit
+
+    "array" ->
+      Just $
+        fmap ArrayT . pValType
+
+    "map" ->
+      Just . Aeson.withObject "MapT" $ \o ->
+        MapT
+          <$> withKey "key" o pValType
+          <*> withKey "value" o pValType
+
+    "option" ->
+      Just $
+        fmap OptionT . pValType
+
+    "pair" ->
+      Just . Aeson.withObject "PairT" $ \o ->
+        PairT
+          <$> withKey "first" o pValType
+          <*> withKey "second" o pValType
+
+    "sum" ->
+      Just . Aeson.withObject "SumT" $ \o ->
+        SumT
+          <$> withKey "left" o pValType
+          <*> withKey "right" o pValType
+
+    "struct" ->
+      Just $
+        fmap StructT . pStructType
+
+    "buf" ->
+      Just . Aeson.withObject "BufT" $ \o ->
+        BufT
+          <$> withKey "size" o pInt
+          <*> withKey "element" o pValType
+
+    x ->
+      fail $ "Unknown type: " <> Text.unpack x
+
+ppValType :: ValType -> Aeson.Value
+ppValType = \case
+ BoolT ->
+   ppEnum "bool" ppUnit
+
+ TimeT ->
+   ppEnum "time" ppUnit
+
+ DoubleT ->
+   ppEnum "double" ppUnit
+
+ IntT ->
+   ppEnum "int" ppUnit
+
+ StringT ->
+   ppEnum "string" ppUnit
+
+ UnitT ->
+   ppEnum "unit" ppUnit
+
+ ErrorT ->
+   ppEnum "error" ppUnit
+
+ FactIdentifierT ->
+   ppEnum "fact_identifier" ppUnit
+
+ ArrayT x ->
+   ppEnum "array" $
+     ppValType x
+
+ MapT k v ->
+   ppEnum "map" $
+     Aeson.object [
+         "key" .=
+           ppValType k
+       , "value" .=
+           ppValType v
+       ]
+
+ OptionT x ->
+   ppEnum "option" $
+     ppValType x
+
+ PairT x y ->
+   ppEnum "pair" $
+     Aeson.object [
+         "first" .=
+           ppValType x
+       , "second" .=
+           ppValType y
+       ]
+
+ SumT x y ->
+   ppEnum "sum" $
+     Aeson.object [
+         "left" .=
+           ppValType x
+       , "right" .=
+           ppValType y
+       ]
+
+ StructT x ->
+   ppEnum "struct" $
+     ppStructType x
+
+ BufT n x ->
+   ppEnum "buf" $
+     Aeson.object [
+         "size" .=
+           ppInt n
+       , "element" .=
+           ppValType x
+       ]
+
+pMeltedType :: Aeson.Value -> Aeson.Parser MeltedType
+pMeltedType =
+  Aeson.withObject "MeltedType" $ \o -> do
+    logical <- withKey "logical" o pValType
+    melted0 <- withKey "melted" o $ pList "Array ValType" pValType
+
+    let
+      melted =
+        meltType logical
+
+    when (melted0 /= melted) $
+      fail $
+        "serialised melted type did not match calculated melted type:" <>
+        "\n" <>
+        "\n  logical type =" <>
+        "\n    " <> show logical <>
+        "\n" <>
+        "\n  serialised melted type =" <>
+        "\n    " <> show melted0 <>
+        "\n" <>
+        "\n  calculated melted type =" <>
+        "\n    " <> show melted
+
+    pure $
+      MeltedType logical melted
+
+ppMeltedType :: MeltedType -> Aeson.Value
+ppMeltedType x =
+  Aeson.object [
+      "logical" .=
+        ppValType (typeLogical x)
+    , "melted" .=
+        ppList ppValType (typeMelted x)
+    ]
+
+pClusterId :: Aeson.Value -> Aeson.Parser ClusterId
+pClusterId =
+  fmap ClusterId . pInt
+
+ppClusterId :: ClusterId -> Aeson.Value
+ppClusterId =
+  ppInt . unClusterId
+
+pKernelIndex :: Aeson.Value -> Aeson.Parser KernelIndex
+pKernelIndex =
+  fmap KernelIndex . pInt
+
+ppKernelIndex :: KernelIndex -> Aeson.Value
+ppKernelIndex =
+  ppInt . unKernelIndex
+
+pKernelId :: Aeson.Value -> Aeson.Parser KernelId
+pKernelId =
+  Aeson.withObject "KernelId" $ \o ->
+    KernelId
+      <$> withKey "cluster" o pClusterId
+      <*> withKey "kernel" o pKernelIndex
+
+ppKernelId :: KernelId -> Aeson.Value
+ppKernelId x =
+  Aeson.object [
+      "cluster" .=
+        ppClusterId (kernelCluster x)
+    , "kernel" .=
+        ppKernelIndex (kernelIndex x)
+    ]
+
+pSeaName :: Aeson.Value -> Aeson.Parser SeaName
+pSeaName =
+  pRendered "SeaName" parseSeaName
+
+ppSeaName :: SeaName -> Aeson.Value
+ppSeaName =
+  ppRendered renderSeaName
+
+pInputId :: Aeson.Value -> Aeson.Parser InputId
+pInputId =
+  pRendered "InputId" parseInputId
+
+ppInputId :: InputId -> Aeson.Value
+ppInputId =
+  ppRendered renderInputId
+
+pOutputId :: Aeson.Value -> Aeson.Parser OutputId
+pOutputId =
+  pRendered "OutputId" parseOutputId
+
+ppOutputId :: OutputId -> Aeson.Value
+ppOutputId =
+  ppRendered renderOutputId
+
+pMeltedOutput :: Aeson.Value -> Aeson.Parser (OutputId, MeltedType)
+pMeltedOutput =
+  Aeson.withObject "(OutputId, MeltedType)" $ \o ->
+    (,)
+      <$> withKey "output_id" o pOutputId
+      <*> withKey "type" o pMeltedType
+
+ppMeltedOutput :: (OutputId, MeltedType) -> Aeson.Value
+ppMeltedOutput (oid, mtype) =
+  Aeson.object [
+      "output_id" .=
+        ppOutputId oid
+    , "type" .=
+        ppMeltedType mtype
+    ]
+
+pNamedType :: Aeson.Value -> Aeson.Parser (SeaName, ValType)
+pNamedType =
+  Aeson.withObject "(SeaName, ValType)" $ \o ->
+    (,)
+      <$> withKey "name" o pSeaName
+      <*> withKey "type" o pValType
+
+ppNamedType :: (SeaName, ValType) -> Aeson.Value
+ppNamedType (name, vtype) =
+  Aeson.object [
+      "name" .=
+        ppSeaName name
+    , "type" .=
+        ppValType vtype
+    ]
+
+pKernel :: Aeson.Value -> Aeson.Parser Kernel
+pKernel =
+  Aeson.withObject "Kernel" $ \o ->
+    Kernel
+      <$> withKey "kernel_id" o pKernelId
+      <*> withKey "resumables" o (pList "Array (SeaName, ValType)" pNamedType)
+      <*> withKey "outputs" o (pList "Array (OutputId, MeltedType)" pMeltedOutput)
+
+ppKernel :: Kernel -> Aeson.Value
+ppKernel x =
+  Aeson.object [
+      "kernel_id" .=
+        ppKernelId (kernelId x)
+    , "resumables" .=
+        ppList ppNamedType (kernelResumables x)
+    , "outputs" .=
+        ppList ppMeltedOutput (kernelOutputs x)
+    ]
+
+pCluster :: Aeson.Value -> Aeson.Parser Cluster
+pCluster =
+  Aeson.withObject "Cluster" $ \o ->
+    Cluster
+      <$> withKey "cluster_id" o pClusterId
+      <*> withKey "input_id" o pInputId
+      <*> withKey "input_type" o pValType
+      <*> withKey "input_vars" o (pList "Array (SeaName, ValType)" pNamedType)
+      <*> withKey "time_var" o pSeaName
+      <*> withKey "kernels" o (pNonEmpty "NonEmpty Kernel" pKernel)
+
+ppCluster :: Cluster -> Aeson.Value
+ppCluster x =
+  Aeson.object [
+      "cluster_id" .=
+        ppClusterId (clusterId x)
+    , "input_id" .=
+        ppInputId (clusterInputId x)
+    , "input_type" .=
+        ppValType (clusterInputType x)
+    , "input_vars" .=
+        ppList ppNamedType (clusterInputVars x)
+    , "time_var" .=
+        ppSeaName (clusterTimeVar x)
+    , "kernels" .=
+        ppNonEmpty ppKernel (clusterKernels x)
+    ]
+
+pHeader :: Aeson.Value -> Aeson.Parser Header
+pHeader =
+  Aeson.withObject "Header" $ \o -> do
+    expectKey "header" "version" o pText "v0"
+    Header
+      <$> withKey "fingerprint" o pFingerprint
+      <*> withKey "clusters" o (pList "Map InputId Cluster" pCluster)
+
+ppHeader :: Header -> Aeson.Value
+ppHeader x =
+  Aeson.object [
+      "version" .=
+        ppText "v0"
+    , "fingerprint" .=
+        ppFingerprint (headerFingerprint x)
+    , "clusters" .=
+        ppList ppCluster (headerClusters x)
+    ]
+
+headerKeyOrder :: [Text]
+headerKeyOrder = [
+  -- Header
+    "version"
+  , "fingerprint"
+  , "clusters"
+
+  -- Cluster
+  , "cluster_id"
+  , "input_id"
+  , "input_type"
+  , "input_vars"
+  , "time_var"
+  , "kernels"
+
+  -- Kernel
+  , "kernel_id"
+  , "resumables"
+  , "outputs"
+
+  -- (Name, MeltedType)
+  -- (OutputId, MeltedType)
+  , "name"
+  , "output_id"
+  , "type"
+
+  -- KernelId
+  , "cluster"
+  , "kernel"
+
+  -- MeltedType
+  , "logical"
+  , "melted"
+
+  -- ValType
+  , "key"
+  , "value"
+  , "first"
+  , "second"
+  , "left"
+  , "right"
+  , "size"
+  , "element"
+  ]
+
+divider :: [Text]
+divider = [
+    "//---------------------"
+  , "// ICICLE C DICTIONARY"
+  , "//---------------------"
+  , "//"
+  ]
+
+startHeader :: Text
+startHeader =
+  Text.unlines divider
+
+endHeader :: Text
+endHeader =
+  Text.unlines $
+    List.reverse divider
+
+comment :: Text -> Text
+comment =
+  Text.unlines . fmap ("// " <>) . Text.lines
+
+dropPrefix :: Text -> Text -> Maybe Text
+dropPrefix prefix x =
+  let
+    !n =
+      Text.length prefix
+
+    (x0, x1) =
+      Text.splitAt n x
+  in
+    if x0 /= prefix then
+      Nothing
+    else
+      Just x1
+
+uncommentLine :: Text -> Maybe Text
+uncommentLine =
+  dropPrefix "// "
+
+uncomment :: Text -> Maybe Text
+uncomment =
+  fmap Text.unlines . traverse uncommentLine . Text.lines
+
+renderEnvelope :: Text -> Text
+renderEnvelope x =
+  startHeader <> comment x <> endHeader
+
+parseEnvelope :: Text -> Either HeaderDecodeError (Text, Text)
+parseEnvelope file =
+  let
+    (header, code) =
+      Text.breakOn endHeader file
+  in
+    (,)
+      <$> maybeToRight HeaderMalformedEnvelope (uncomment =<< dropPrefix startHeader header)
+      <*> maybeToRight HeaderMalformedEnvelope (dropPrefix endHeader code)
+
+renderHeader :: Header -> Text
+renderHeader =
+  renderEnvelope . encodePrettyJson headerKeyOrder . ppHeader
+
+parseHeader :: Text -> Either HeaderDecodeError (Header, Text)
+parseHeader file = do
+  (header0, code) <- parseEnvelope file
+  header <- first HeaderDecodeError $ decodeJson pHeader header0
+  pure (header, code)

--- a/icicle-compiler/test/Icicle/Test/Sea/Header.hs
+++ b/icicle-compiler/test/Icicle/Test/Sea/Header.hs
@@ -1,0 +1,155 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Icicle.Test.Sea.Header where
+
+import           Disorder.Corpus
+import           Disorder.Jack
+
+import qualified Data.List.NonEmpty as NonEmpty
+import qualified Data.Map.Strict as Map
+import qualified Data.Text as Text
+
+import           Icicle.Avalanche.Prim.Flat
+import           Icicle.Common.Type
+import           Icicle.Data.Name
+import           Icicle.Sea.Data
+import           Icicle.Sea.Header
+import           Icicle.Sea.Name
+
+import           P
+
+import qualified Prelude as Savage
+
+import           System.IO (IO)
+
+
+genFingerprint :: Jack Fingerprint
+genFingerprint =
+  Fingerprint
+    <$> elements muppets
+
+genInputId :: Jack InputId
+genInputId =
+  justOf . fmap parseInputId $
+    (\ns n -> ns <> ":" <> n)
+      <$> elements colours
+      <*> elements simpsons
+
+genOutputId :: Jack OutputId
+genOutputId =
+  justOf . fmap parseOutputId $
+    (\ns n -> ns <> ":" <> n)
+      <$> elements weather
+      <*> elements cooking
+
+genStructField :: Jack StructField
+genStructField =
+  StructField
+    <$> elements viruses
+
+genValType :: Jack ValType
+genValType =
+  oneOfRec [
+      pure BoolT
+    , pure TimeT
+    , pure DoubleT
+    , pure IntT
+    , pure StringT
+    , pure UnitT
+    , pure ErrorT
+    , pure FactIdentifierT
+    ] [
+      ArrayT <$> genValType
+    , MapT <$> genValType <*> genValType
+    , OptionT <$> genValType
+    , PairT <$> genValType <*> genValType
+    , SumT <$> genValType <*> genValType
+    , StructT . StructType . Map.fromList
+        <$> listOfN 0 10 ((,) <$> genStructField <*> genValType)
+    , BufT <$> choose (1, 100) <*> genValType
+    ]
+
+genMeltedType :: Jack MeltedType
+genMeltedType = do
+  vtype <- genValType
+  pure $
+    MeltedType vtype (meltType vtype)
+
+genClusterId :: Jack ClusterId
+genClusterId =
+  ClusterId
+    <$> choose (0, 10000)
+
+genKernelIndex :: Jack KernelIndex
+genKernelIndex =
+  KernelIndex
+    <$> choose (0, 10000)
+
+genKernelId :: Jack KernelId
+genKernelId =
+  KernelId
+    <$> genClusterId
+    <*> genKernelIndex
+
+genSeaName :: Jack SeaName
+genSeaName =
+  fmap mangle $
+    elements (southpark :: [Text])
+
+genKernel :: Jack Kernel
+genKernel =
+  Kernel
+    <$> genKernelId
+    <*> listOfN 0 5 ((,) <$> genSeaName <*> genValType)
+    <*> listOfN 0 5 ((,) <$> genOutputId <*> genMeltedType)
+
+genCluster :: Jack Cluster
+genCluster =
+  Cluster
+    <$> genClusterId
+    <*> genInputId
+    <*> genValType
+    <*> listOfN 0 5 ((,) <$> genSeaName <*> genValType)
+    <*> genSeaName
+    <*> (NonEmpty.fromList <$> listOfN 1 10 genKernel)
+
+genHeader :: Jack Header
+genHeader =
+  Header
+    <$> genFingerprint
+    <*> listOfN 0 5 genCluster
+
+snippet :: Text
+snippet =
+  Text.unlines [
+      "int main (int argc, char **argv) {"
+    , "    return 0;"
+    , "}"
+    ]
+
+renderHeaderX :: Header -> Text
+renderHeaderX x =
+  renderHeader x <> snippet
+
+parseHeaderX :: Text -> Either HeaderDecodeError Header
+parseHeaderX x = do
+  (header, code) <- parseHeader x
+  if code /= snippet then
+    Savage.error $
+      show code <>
+      "\n=/=\n" <>
+      show snippet
+  else
+    pure header
+
+prop_header_roundtrip :: Property
+prop_header_roundtrip =
+  gamble genHeader $
+    tripping renderHeaderX parseHeaderX
+
+return []
+tests :: IO Bool
+tests =
+  $quickCheckAll


### PR DESCRIPTION
This adds support for encoding / decoding a header which we will attach to the start of C dictionaries.

The header looks a bit like:

```c
//---------------------
// ICICLE C DICTIONARY
//---------------------
//
// {
//   "version": "1",
//   ..
// }
//
//---------------------
// ICICLE C DICTIONARY
//---------------------
// .. start of C code 
```
! @tranma 