### PR TITLE
FoldBool: change arguments to be lambdas rather than values.

### DIFF
--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Flatten/Exp.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Flatten/Exp.hs
@@ -329,8 +329,9 @@ flatX a_fresh xx stm
          acc <- fresh
          -- Compute the rest of the computation, assuming we've stored result in variable named acc
          stm' <- stm (xVar acc)
-         sthen <- flatX' then_ $ (return . Write acc)
-         selse <- flatX' else_ $ (return . Write acc)
+         let vunit = xValue UnitT VUnit
+         sthen <- flatX' (then_ `xApp` vunit) $ (return . Write acc)
+         selse <- flatX' (else_ `xApp` vunit) $ (return . Write acc)
          -- Perform if and write result
          let if_ =  If pred' sthen selse
          -- After if, read back result from accumulator and then go do the rest of the statements

--- a/icicle-core/src/Icicle/Core/Eval/Exp.hs
+++ b/icicle-core/src/Icicle/Core/Eval/Exp.hs
@@ -29,9 +29,9 @@ evalPrim p vs
      -- Folds and destructions
      PrimFold PrimFoldBool _
       | [t, _, VBase (VBool True)] <- vs
-      -> return t
+      -> applies' t [VBase VUnit]
       | [_, f, VBase (VBool False)] <- vs
-      -> return f
+      -> applies' f [VBase VUnit]
       | otherwise
       -> primError
 

--- a/icicle-core/src/Icicle/Core/Exp/Prim.hs
+++ b/icicle-core/src/Icicle/Core/Exp/Prim.hs
@@ -83,7 +83,7 @@ typeOfPrim p
 
     -- Folds
     PrimFold PrimFoldBool ret
-     -> FunT [funOfVal ret, funOfVal ret, funOfVal BoolT] ret
+     -> FunT [FunT [funOfVal UnitT] ret, FunT [funOfVal UnitT] ret, funOfVal BoolT] ret
     PrimFold (PrimFoldArray a) ret
      -> FunT [FunT [funOfVal ret, funOfVal a] ret, funOfVal ret, funOfVal (ArrayT a)] ret
     PrimFold (PrimFoldOption a) ret

--- a/icicle-repl/test/cli/repl/t10-avalanche/expected
+++ b/icicle-repl/test/cli/repl/t10-avalanche/expected
@@ -58,24 +58,26 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl:output (conv/31@{(Sum Err
 > - Avalanche (simplified):
 conv/3 = TIME
 conv/4 = MAX_MAP_SIZE
-init acc/conv/35@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} = Right Map []@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))};
-load_resumable@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} acc/conv/35;
+init acc/conv/37@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} = Right Map []@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))};
+load_resumable@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} acc/conv/37;
 
 for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0@{((Sum Error Int), Time)}) in new
 {
-  read conv/35/aval/0 = acc/conv/35 [(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))];
-  write acc/conv/35 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} 
+  read conv/37/aval/0 = acc/conv/37 [(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))];
+  write acc/conv/37 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} 
     (\conv/30@{Error} left#@{Error, Map Time (Buf 2 ((Sum Error Int), Time))} conv/30) 
     (\conv/27@{Map Time (Buf 2 ((Sum Error Int), Time))} 
       let conv/26 = snd#@{(Sum Error Int), Time} conv/0
       let conv/32 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
         (\conv/31@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv/31 conv/1 conv/0) (Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv/1 conv/0) conv/26 conv/27
-       in if#@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} (right#@{Error, Map Time (Buf 2 ((Sum Error Int), Time))} conv/32) (Left ExceptCannotCompute@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time (Buf 2 ((Sum Error Int), Time))} conv/32)) conv/4)) conv/35/aval/0;
+       in if#@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} 
+        (\conv/33@{Unit} right#@{Error, Map Time (Buf 2 ((Sum Error Int), Time))} conv/32) 
+        (\conv/33@{Unit} Left ExceptCannotCompute@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time (Buf 2 ((Sum Error Int), Time))} conv/32)) conv/4)) conv/37/aval/0;
 }
-save_resumable@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} acc/conv/35;
+save_resumable@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} acc/conv/37;
 
-read conv/35 = acc/conv/35 [(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))];
-let conv/36 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time Int))} 
+read conv/37 = acc/conv/37 [(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))];
+let conv/38 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time Int))} 
   (\conv/30@{Error} left#@{Error, Map Time Int} conv/30) 
   (\conv/27@{Map Time (Buf 2 ((Sum Error Int), Time))} Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
     (\conv/24@{(Sum Error (Map Time Int))} \conv/26@{Time} \conv/28@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
@@ -83,9 +85,11 @@ let conv/36 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum
       (\conv/25@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
         (\conv/30@{Error} left#@{Error, Map Time Int} conv/30) 
         (\conv/29@{Int} 
-          let conv/34 = Map_insertOrUpdate#@{(Time,Int)} 
-            (\conv/33@{Int} conv/29) conv/29 conv/26 conv/25
-           in if#@{(Sum Error (Map Time Int))} (right#@{Error, Map Time Int} conv/34) (Left ExceptCannotCompute@{(Sum Error (Map Time Int))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time Int} conv/34)) conv/4)) (
+          let conv/35 = Map_insertOrUpdate#@{(Time,Int)} 
+            (\conv/34@{Int} conv/29) conv/29 conv/26 conv/25
+           in if#@{(Sum Error (Map Time Int))} 
+            (\conv/36@{Unit} right#@{Error, Map Time Int} conv/35) 
+            (\conv/36@{Unit} Left ExceptCannotCompute@{(Sum Error (Map Time Int))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time Int} conv/35)) conv/4)) (
         let conv/10 = 
           let conv/5 = Latest_read#@{Array ((Sum Error Int), Time)} conv/28
            in Array_fold#@{((Sum Error Int), Time)}@{(Sum Error Int)} 
@@ -96,8 +100,8 @@ let conv/36 = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum
                   (\reify/2/conv/14@{Error} left#@{Error, Int} reify/2/conv/14) 
                   (\reify/3/conv/15@{Int} right#@{Error, Int} (add#@{Int} reify/1/conv/13 reify/3/conv/15)) conv/9) (fst#@{(Sum Error Int), Time} conv/8)
                in s/conv/19) (Right 0@{(Sum Error Int)}) conv/5
-         in conv/10)) conv/24) (Right Map []@{(Sum Error (Map Time Int))}) conv/27) conv/35;
-output@{(Sum Error (Map Time Int))} repl:output (conv/36@{(Sum Error (Map Time Int))});
+         in conv/10)) conv/24) (Right Map []@{(Sum Error (Map Time Int))}) conv/27) conv/37;
+output@{(Sum Error (Map Time Int))} repl:output (conv/38@{(Sum Error (Map Time Int))});
 
 - Core evaluation:
 [homer, [(1989-12-17,100)

--- a/icicle-repl/test/cli/repl/t10.2-core/expected
+++ b/icicle-repl/test/cli/repl/t10.2-core/expected
@@ -77,7 +77,7 @@ Precomputations:
 
 
 Streams:
-  STREAM_FOLD (conv/35 : (Sum Error (Map Time (Buf 2 ((Sum Error Int), Time)))))
+  STREAM_FOLD (conv/37 : (Sum Error (Map Time (Buf 2 ((Sum Error Int), Time)))))
     INIT:
       Right Map []@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))}
     KONS:
@@ -87,11 +87,13 @@ Streams:
           let conv/26 = snd#@{(Sum Error Int), Time} conv/0
           let conv/32 = Map_insertOrUpdate#@{(Time,Buf 2 ((Sum Error Int), Time))} 
             (\conv/31@{Buf 2 ((Sum Error Int), Time)} Latest_push#@{Buf 2 ((Sum Error Int), Time)} conv/31 conv/1 conv/0) (Latest_push#@{Buf 2 ((Sum Error Int), Time)} (Buf []@{Buf 2 ((Sum Error Int), Time)}) conv/1 conv/0) conv/26 conv/27
-           in if#@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} (right#@{Error, Map Time (Buf 2 ((Sum Error Int), Time))} conv/32) (Left ExceptCannotCompute@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time (Buf 2 ((Sum Error Int), Time))} conv/32)) conv/4)) conv/35
+           in if#@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))} 
+            (\conv/33@{Unit} right#@{Error, Map Time (Buf 2 ((Sum Error Int), Time))} conv/32) 
+            (\conv/33@{Unit} Left ExceptCannotCompute@{(Sum Error (Map Time (Buf 2 ((Sum Error Int), Time))))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time (Buf 2 ((Sum Error Int), Time))} conv/32)) conv/4)) conv/37
   
 
 Postcomputations:
-  conv/36              = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time Int))} 
+  conv/38              = Sum_fold#@{(Error,Map Time (Buf 2 ((Sum Error Int), Time)))}@{(Sum Error (Map Time Int))} 
                            (\conv/30@{Error} left#@{Error, Map Time Int} conv/30) 
                            (\conv/27@{Map Time (Buf 2 ((Sum Error Int), Time))} Map_fold#@{(Time,Buf 2 ((Sum Error Int), Time))}@{(Sum Error (Map Time Int))} 
                              (\conv/24@{(Sum Error (Map Time Int))} \conv/26@{Time} \conv/28@{Buf 2 ((Sum Error Int), Time)} Sum_fold#@{(Error,Map Time Int)}@{(Sum Error (Map Time Int))} 
@@ -99,9 +101,11 @@ Postcomputations:
                                (\conv/25@{Map Time Int} Sum_fold#@{(Error,Int)}@{(Sum Error (Map Time Int))} 
                                  (\conv/30@{Error} left#@{Error, Map Time Int} conv/30) 
                                  (\conv/29@{Int} 
-                                   let conv/34 = Map_insertOrUpdate#@{(Time,Int)} 
-                                     (\conv/33@{Int} conv/29) conv/29 conv/26 conv/25
-                                    in if#@{(Sum Error (Map Time Int))} (right#@{Error, Map Time Int} conv/34) (Left ExceptCannotCompute@{(Sum Error (Map Time Int))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time Int} conv/34)) conv/4)) (
+                                   let conv/35 = Map_insertOrUpdate#@{(Time,Int)} 
+                                     (\conv/34@{Int} conv/29) conv/29 conv/26 conv/25
+                                    in if#@{(Sum Error (Map Time Int))} 
+                                     (\conv/36@{Unit} right#@{Error, Map Time Int} conv/35) 
+                                     (\conv/36@{Unit} Left ExceptCannotCompute@{(Sum Error (Map Time Int))}) (lt#@{Int} (length#@{Array Time} (keys#@{Map Time Int} conv/35)) conv/4)) (
                                  let conv/10 = 
                                    let conv/5 = Latest_read#@{Array ((Sum Error Int), Time)} conv/28
                                     in Array_fold#@{((Sum Error Int), Time)}@{(Sum Error Int)} 
@@ -112,10 +116,10 @@ Postcomputations:
                                            (\reify/2/conv/14@{Error} left#@{Error, Int} reify/2/conv/14) 
                                            (\reify/3/conv/15@{Int} right#@{Error, Int} (add#@{Int} reify/1/conv/13 reify/3/conv/15)) conv/9) (fst#@{(Sum Error Int), Time} conv/8)
                                         in s/conv/19) (Right 0@{(Sum Error Int)}) conv/5
-                                  in conv/10)) conv/24) (Right Map []@{(Sum Error (Map Time Int))}) conv/27) conv/35
+                                  in conv/10)) conv/24) (Right Map []@{(Sum Error (Map Time Int))}) conv/27) conv/37
 
 Returning:
-  repl:output          = conv/36
+  repl:output          = conv/38
 
 
 - Core type:

--- a/icicle-repl/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-repl/test/cli/repl/t10.3-flatten/expected
@@ -299,34 +299,34 @@ output@{(Sum Error (Int, Array (Sum Error Int)))} repl:output (flat/22/simpflat/
 > - Flattened (simplified), not typechecked:
 conv/3 = TIME
 conv/4 = MAX_MAP_SIZE
-init acc/conv/35/simpflat/47@{Error} = ExceptNotAnError@{Error};
-init acc/conv/35/simpflat/48@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
-init acc/conv/35/simpflat/49@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
-init acc/conv/35/simpflat/50@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
-init acc/conv/35/simpflat/51@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-load_resumable@{Error} acc/conv/35/simpflat/47;
-load_resumable@{Array Time} acc/conv/35/simpflat/48;
-load_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/35/simpflat/49;
-load_resumable@{Array (Buf 2 Error)} acc/conv/35/simpflat/50;
-load_resumable@{Array (Buf 2 Int)} acc/conv/35/simpflat/51;
+init acc/conv/37/simpflat/47@{Error} = ExceptNotAnError@{Error};
+init acc/conv/37/simpflat/48@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init acc/conv/37/simpflat/49@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
+init acc/conv/37/simpflat/50@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
+init acc/conv/37/simpflat/51@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
+load_resumable@{Error} acc/conv/37/simpflat/47;
+load_resumable@{Array Time} acc/conv/37/simpflat/48;
+load_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/37/simpflat/49;
+load_resumable@{Array (Buf 2 Error)} acc/conv/37/simpflat/50;
+load_resumable@{Array (Buf 2 Int)} acc/conv/37/simpflat/51;
 for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, conv/0/simpflat/171@{Int}, conv/0/simpflat/172@{Time}) in new
 {
-  read conv/35/aval/0/simpflat/53 = acc/conv/35/simpflat/47 [Error];
-  read conv/35/aval/0/simpflat/54 = acc/conv/35/simpflat/48 [Array Time];
-  read conv/35/aval/0/simpflat/55 = acc/conv/35/simpflat/49 [Array (Buf 2 FactIdentifier)];
-  read conv/35/aval/0/simpflat/56 = acc/conv/35/simpflat/50 [Array (Buf 2 Error)];
-  read conv/35/aval/0/simpflat/57 = acc/conv/35/simpflat/51 [Array (Buf 2 Int)];
+  read conv/37/aval/0/simpflat/53 = acc/conv/37/simpflat/47 [Error];
+  read conv/37/aval/0/simpflat/54 = acc/conv/37/simpflat/48 [Array Time];
+  read conv/37/aval/0/simpflat/55 = acc/conv/37/simpflat/49 [Array (Buf 2 FactIdentifier)];
+  read conv/37/aval/0/simpflat/56 = acc/conv/37/simpflat/50 [Array (Buf 2 Error)];
+  read conv/37/aval/0/simpflat/57 = acc/conv/37/simpflat/51 [Array (Buf 2 Int)];
   init flat/0/simpflat/59@{Error} = ExceptNotAnError@{Error};
   init flat/0/simpflat/60@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat/0/simpflat/61@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
   init flat/0/simpflat/62@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
   init flat/0/simpflat/63@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-  if (eq#@{Error} conv/35/aval/0/simpflat/53 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} conv/37/aval/0/simpflat/53 (ExceptNotAnError@{Error}))
   {
-    init map_insert_acc_keys/flat/3@{Array Time} = conv/35/aval/0/simpflat/54;
-    init map_insert_acc_vals/flat/4/simpflat/65@{Array (Buf 2 FactIdentifier)} = conv/35/aval/0/simpflat/55;
-    init map_insert_acc_vals/flat/4/simpflat/66@{Array (Buf 2 Error)} = conv/35/aval/0/simpflat/56;
-    init map_insert_acc_vals/flat/4/simpflat/67@{Array (Buf 2 Int)} = conv/35/aval/0/simpflat/57;
+    init map_insert_acc_keys/flat/3@{Array Time} = conv/37/aval/0/simpflat/54;
+    init map_insert_acc_vals/flat/4/simpflat/65@{Array (Buf 2 FactIdentifier)} = conv/37/aval/0/simpflat/55;
+    init map_insert_acc_vals/flat/4/simpflat/66@{Array (Buf 2 Error)} = conv/37/aval/0/simpflat/56;
+    init map_insert_acc_vals/flat/4/simpflat/67@{Array (Buf 2 Int)} = conv/37/aval/0/simpflat/57;
     init map_insert_acc_bs_found/flat/6@{Bool} = False@{Bool};
     init map_insert_acc_bs_index/flat/5@{Int} = -1@{Int};
     read map_insert_loc_keys/flat/7 = map_insert_acc_keys/flat/3 [Array Time];
@@ -524,7 +524,7 @@ for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, 
   }
   else
   {
-    write flat/0/simpflat/59 = conv/35/aval/0/simpflat/53;
+    write flat/0/simpflat/59 = conv/37/aval/0/simpflat/53;
     write flat/0/simpflat/60 = unsafe_Array_create#@{Time} (0@{Int});
     write flat/0/simpflat/61 = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
     write flat/0/simpflat/62 = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
@@ -535,19 +535,19 @@ for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, 
   read flat/0/simpflat/107 = flat/0/simpflat/61 [Array (Buf 2 FactIdentifier)];
   read flat/0/simpflat/108 = flat/0/simpflat/62 [Array (Buf 2 Error)];
   read flat/0/simpflat/109 = flat/0/simpflat/63 [Array (Buf 2 Int)];
-  write acc/conv/35/simpflat/47 = flat/0/simpflat/105;
-  write acc/conv/35/simpflat/48 = flat/0/simpflat/106;
-  write acc/conv/35/simpflat/49 = flat/0/simpflat/107;
-  write acc/conv/35/simpflat/50 = flat/0/simpflat/108;
-  write acc/conv/35/simpflat/51 = flat/0/simpflat/109;
+  write acc/conv/37/simpflat/47 = flat/0/simpflat/105;
+  write acc/conv/37/simpflat/48 = flat/0/simpflat/106;
+  write acc/conv/37/simpflat/49 = flat/0/simpflat/107;
+  write acc/conv/37/simpflat/50 = flat/0/simpflat/108;
+  write acc/conv/37/simpflat/51 = flat/0/simpflat/109;
 }
-read acc/conv/35/flat/40/simpflat/111 = acc/conv/35/simpflat/47 [Error];
-read acc/conv/35/flat/40/simpflat/113 = acc/conv/35/simpflat/49 [Array (Buf 2 FactIdentifier)];
-if (eq#@{Error} acc/conv/35/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
+read acc/conv/37/flat/40/simpflat/111 = acc/conv/37/simpflat/47 [Error];
+read acc/conv/37/flat/40/simpflat/113 = acc/conv/37/simpflat/49 [Array (Buf 2 FactIdentifier)];
+if (eq#@{Error} acc/conv/37/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
 {
-  foreach (flat/42 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc/conv/35/flat/40/simpflat/113)
+  foreach (flat/42 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc/conv/37/flat/40/simpflat/113)
   {
-    let simpflat/512 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc/conv/35/flat/40/simpflat/113 flat/42;
+    let simpflat/512 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc/conv/37/flat/40/simpflat/113 flat/42;
     let flat/43 = Buf_read#@{Array FactIdentifier} simpflat/512;
     foreach (flat/44 in 0@{Int} .. Array_length#@{FactIdentifier} flat/43)
     {
@@ -555,31 +555,31 @@ if (eq#@{Error} acc/conv/35/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
     }
   }
 }
-save_resumable@{Error} acc/conv/35/simpflat/47;
-save_resumable@{Array Time} acc/conv/35/simpflat/48;
-save_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/35/simpflat/49;
-save_resumable@{Array (Buf 2 Error)} acc/conv/35/simpflat/50;
-save_resumable@{Array (Buf 2 Int)} acc/conv/35/simpflat/51;
-read conv/35/simpflat/117 = acc/conv/35/simpflat/47 [Error];
-read conv/35/simpflat/118 = acc/conv/35/simpflat/48 [Array Time];
-read conv/35/simpflat/120 = acc/conv/35/simpflat/50 [Array (Buf 2 Error)];
-read conv/35/simpflat/121 = acc/conv/35/simpflat/51 [Array (Buf 2 Int)];
+save_resumable@{Error} acc/conv/37/simpflat/47;
+save_resumable@{Array Time} acc/conv/37/simpflat/48;
+save_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/37/simpflat/49;
+save_resumable@{Array (Buf 2 Error)} acc/conv/37/simpflat/50;
+save_resumable@{Array (Buf 2 Int)} acc/conv/37/simpflat/51;
+read conv/37/simpflat/117 = acc/conv/37/simpflat/47 [Error];
+read conv/37/simpflat/118 = acc/conv/37/simpflat/48 [Array Time];
+read conv/37/simpflat/120 = acc/conv/37/simpflat/50 [Array (Buf 2 Error)];
+read conv/37/simpflat/121 = acc/conv/37/simpflat/51 [Array (Buf 2 Int)];
 init flat/47/simpflat/123@{Error} = ExceptNotAnError@{Error};
 init flat/47/simpflat/124@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
 init flat/47/simpflat/125@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-if (eq#@{Error} conv/35/simpflat/117 (ExceptNotAnError@{Error}))
+if (eq#@{Error} conv/37/simpflat/117 (ExceptNotAnError@{Error}))
 {
   init flat/55/simpflat/126@{Error} = ExceptNotAnError@{Error};
   init flat/55/simpflat/127@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat/55/simpflat/128@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-  foreach (for_counter/flat/56 in 0@{Int} .. Array_length#@{Time} conv/35/simpflat/118)
+  foreach (for_counter/flat/56 in 0@{Int} .. Array_length#@{Time} conv/37/simpflat/118)
   {
     read flat/55/simpflat/129 = flat/55/simpflat/126 [Error];
     read flat/55/simpflat/130 = flat/55/simpflat/127 [Array Time];
     read flat/55/simpflat/131 = flat/55/simpflat/128 [Array Int];
-    let simpflat/534 = unsafe_Array_index#@{Time} conv/35/simpflat/118 for_counter/flat/56;
-    let simpflat/538 = unsafe_Array_index#@{Buf 2 Error} conv/35/simpflat/120 for_counter/flat/56;
-    let simpflat/540 = unsafe_Array_index#@{Buf 2 Int} conv/35/simpflat/121 for_counter/flat/56;
+    let simpflat/534 = unsafe_Array_index#@{Time} conv/37/simpflat/118 for_counter/flat/56;
+    let simpflat/538 = unsafe_Array_index#@{Buf 2 Error} conv/37/simpflat/120 for_counter/flat/56;
+    let simpflat/540 = unsafe_Array_index#@{Buf 2 Int} conv/37/simpflat/121 for_counter/flat/56;
     init flat/58/simpflat/132@{Error} = ExceptNotAnError@{Error};
     init flat/58/simpflat/133@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
     init flat/58/simpflat/134@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
@@ -805,7 +805,7 @@ if (eq#@{Error} conv/35/simpflat/117 (ExceptNotAnError@{Error}))
 }
 else
 {
-  write flat/47/simpflat/123 = conv/35/simpflat/117;
+  write flat/47/simpflat/123 = conv/37/simpflat/117;
   write flat/47/simpflat/124 = unsafe_Array_create#@{Time} (0@{Int});
   write flat/47/simpflat/125 = unsafe_Array_create#@{Int} (0@{Int});
 }
@@ -817,34 +817,34 @@ output@{(Sum Error (Map Time Int))} repl:output (flat/47/simpflat/167@{Error}, f
 - Flattened Avalanche (simplified), typechecked:
 conv/3 = TIME
 conv/4 = MAX_MAP_SIZE
-init acc/conv/35/simpflat/47@{Error} = ExceptNotAnError@{Error};
-init acc/conv/35/simpflat/48@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
-init acc/conv/35/simpflat/49@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
-init acc/conv/35/simpflat/50@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
-init acc/conv/35/simpflat/51@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-load_resumable@{Error} acc/conv/35/simpflat/47;
-load_resumable@{Array Time} acc/conv/35/simpflat/48;
-load_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/35/simpflat/49;
-load_resumable@{Array (Buf 2 Error)} acc/conv/35/simpflat/50;
-load_resumable@{Array (Buf 2 Int)} acc/conv/35/simpflat/51;
+init acc/conv/37/simpflat/47@{Error} = ExceptNotAnError@{Error};
+init acc/conv/37/simpflat/48@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
+init acc/conv/37/simpflat/49@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
+init acc/conv/37/simpflat/50@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
+init acc/conv/37/simpflat/51@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
+load_resumable@{Error} acc/conv/37/simpflat/47;
+load_resumable@{Array Time} acc/conv/37/simpflat/48;
+load_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/37/simpflat/49;
+load_resumable@{Array (Buf 2 Error)} acc/conv/37/simpflat/50;
+load_resumable@{Array (Buf 2 Int)} acc/conv/37/simpflat/51;
 for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, conv/0/simpflat/171@{Int}, conv/0/simpflat/172@{Time}) in new
 {
-  read conv/35/aval/0/simpflat/53 = acc/conv/35/simpflat/47 [Error];
-  read conv/35/aval/0/simpflat/54 = acc/conv/35/simpflat/48 [Array Time];
-  read conv/35/aval/0/simpflat/55 = acc/conv/35/simpflat/49 [Array (Buf 2 FactIdentifier)];
-  read conv/35/aval/0/simpflat/56 = acc/conv/35/simpflat/50 [Array (Buf 2 Error)];
-  read conv/35/aval/0/simpflat/57 = acc/conv/35/simpflat/51 [Array (Buf 2 Int)];
+  read conv/37/aval/0/simpflat/53 = acc/conv/37/simpflat/47 [Error];
+  read conv/37/aval/0/simpflat/54 = acc/conv/37/simpflat/48 [Array Time];
+  read conv/37/aval/0/simpflat/55 = acc/conv/37/simpflat/49 [Array (Buf 2 FactIdentifier)];
+  read conv/37/aval/0/simpflat/56 = acc/conv/37/simpflat/50 [Array (Buf 2 Error)];
+  read conv/37/aval/0/simpflat/57 = acc/conv/37/simpflat/51 [Array (Buf 2 Int)];
   init flat/0/simpflat/59@{Error} = ExceptNotAnError@{Error};
   init flat/0/simpflat/60@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat/0/simpflat/61@{Array (Buf 2 FactIdentifier)} = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
   init flat/0/simpflat/62@{Array (Buf 2 Error)} = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
   init flat/0/simpflat/63@{Array (Buf 2 Int)} = unsafe_Array_create#@{Buf 2 Int} (0@{Int});
-  if (eq#@{Error} conv/35/aval/0/simpflat/53 (ExceptNotAnError@{Error}))
+  if (eq#@{Error} conv/37/aval/0/simpflat/53 (ExceptNotAnError@{Error}))
   {
-    init map_insert_acc_keys/flat/3@{Array Time} = conv/35/aval/0/simpflat/54;
-    init map_insert_acc_vals/flat/4/simpflat/65@{Array (Buf 2 FactIdentifier)} = conv/35/aval/0/simpflat/55;
-    init map_insert_acc_vals/flat/4/simpflat/66@{Array (Buf 2 Error)} = conv/35/aval/0/simpflat/56;
-    init map_insert_acc_vals/flat/4/simpflat/67@{Array (Buf 2 Int)} = conv/35/aval/0/simpflat/57;
+    init map_insert_acc_keys/flat/3@{Array Time} = conv/37/aval/0/simpflat/54;
+    init map_insert_acc_vals/flat/4/simpflat/65@{Array (Buf 2 FactIdentifier)} = conv/37/aval/0/simpflat/55;
+    init map_insert_acc_vals/flat/4/simpflat/66@{Array (Buf 2 Error)} = conv/37/aval/0/simpflat/56;
+    init map_insert_acc_vals/flat/4/simpflat/67@{Array (Buf 2 Int)} = conv/37/aval/0/simpflat/57;
     init map_insert_acc_bs_found/flat/6@{Bool} = False@{Bool};
     init map_insert_acc_bs_index/flat/5@{Int} = -1@{Int};
     read map_insert_loc_keys/flat/7 = map_insert_acc_keys/flat/3 [Array Time];
@@ -1042,7 +1042,7 @@ for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, 
   }
   else
   {
-    write flat/0/simpflat/59 = conv/35/aval/0/simpflat/53;
+    write flat/0/simpflat/59 = conv/37/aval/0/simpflat/53;
     write flat/0/simpflat/60 = unsafe_Array_create#@{Time} (0@{Int});
     write flat/0/simpflat/61 = unsafe_Array_create#@{Buf 2 FactIdentifier} (0@{Int});
     write flat/0/simpflat/62 = unsafe_Array_create#@{Buf 2 Error} (0@{Int});
@@ -1053,19 +1053,19 @@ for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/170@{Error}, 
   read flat/0/simpflat/107 = flat/0/simpflat/61 [Array (Buf 2 FactIdentifier)];
   read flat/0/simpflat/108 = flat/0/simpflat/62 [Array (Buf 2 Error)];
   read flat/0/simpflat/109 = flat/0/simpflat/63 [Array (Buf 2 Int)];
-  write acc/conv/35/simpflat/47 = flat/0/simpflat/105;
-  write acc/conv/35/simpflat/48 = flat/0/simpflat/106;
-  write acc/conv/35/simpflat/49 = flat/0/simpflat/107;
-  write acc/conv/35/simpflat/50 = flat/0/simpflat/108;
-  write acc/conv/35/simpflat/51 = flat/0/simpflat/109;
+  write acc/conv/37/simpflat/47 = flat/0/simpflat/105;
+  write acc/conv/37/simpflat/48 = flat/0/simpflat/106;
+  write acc/conv/37/simpflat/49 = flat/0/simpflat/107;
+  write acc/conv/37/simpflat/50 = flat/0/simpflat/108;
+  write acc/conv/37/simpflat/51 = flat/0/simpflat/109;
 }
-read acc/conv/35/flat/40/simpflat/111 = acc/conv/35/simpflat/47 [Error];
-read acc/conv/35/flat/40/simpflat/113 = acc/conv/35/simpflat/49 [Array (Buf 2 FactIdentifier)];
-if (eq#@{Error} acc/conv/35/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
+read acc/conv/37/flat/40/simpflat/111 = acc/conv/37/simpflat/47 [Error];
+read acc/conv/37/flat/40/simpflat/113 = acc/conv/37/simpflat/49 [Array (Buf 2 FactIdentifier)];
+if (eq#@{Error} acc/conv/37/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
 {
-  foreach (flat/42 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc/conv/35/flat/40/simpflat/113)
+  foreach (flat/42 in 0@{Int} .. Array_length#@{Buf 2 FactIdentifier} acc/conv/37/flat/40/simpflat/113)
   {
-    let simpflat/512 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc/conv/35/flat/40/simpflat/113 flat/42;
+    let simpflat/512 = unsafe_Array_index#@{Buf 2 FactIdentifier} acc/conv/37/flat/40/simpflat/113 flat/42;
     let flat/43 = Buf_read#@{Array FactIdentifier} simpflat/512;
     foreach (flat/44 in 0@{Int} .. Array_length#@{FactIdentifier} flat/43)
     {
@@ -1073,31 +1073,31 @@ if (eq#@{Error} acc/conv/35/flat/40/simpflat/111 (ExceptNotAnError@{Error}))
     }
   }
 }
-save_resumable@{Error} acc/conv/35/simpflat/47;
-save_resumable@{Array Time} acc/conv/35/simpflat/48;
-save_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/35/simpflat/49;
-save_resumable@{Array (Buf 2 Error)} acc/conv/35/simpflat/50;
-save_resumable@{Array (Buf 2 Int)} acc/conv/35/simpflat/51;
-read conv/35/simpflat/117 = acc/conv/35/simpflat/47 [Error];
-read conv/35/simpflat/118 = acc/conv/35/simpflat/48 [Array Time];
-read conv/35/simpflat/120 = acc/conv/35/simpflat/50 [Array (Buf 2 Error)];
-read conv/35/simpflat/121 = acc/conv/35/simpflat/51 [Array (Buf 2 Int)];
+save_resumable@{Error} acc/conv/37/simpflat/47;
+save_resumable@{Array Time} acc/conv/37/simpflat/48;
+save_resumable@{Array (Buf 2 FactIdentifier)} acc/conv/37/simpflat/49;
+save_resumable@{Array (Buf 2 Error)} acc/conv/37/simpflat/50;
+save_resumable@{Array (Buf 2 Int)} acc/conv/37/simpflat/51;
+read conv/37/simpflat/117 = acc/conv/37/simpflat/47 [Error];
+read conv/37/simpflat/118 = acc/conv/37/simpflat/48 [Array Time];
+read conv/37/simpflat/120 = acc/conv/37/simpflat/50 [Array (Buf 2 Error)];
+read conv/37/simpflat/121 = acc/conv/37/simpflat/51 [Array (Buf 2 Int)];
 init flat/47/simpflat/123@{Error} = ExceptNotAnError@{Error};
 init flat/47/simpflat/124@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
 init flat/47/simpflat/125@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-if (eq#@{Error} conv/35/simpflat/117 (ExceptNotAnError@{Error}))
+if (eq#@{Error} conv/37/simpflat/117 (ExceptNotAnError@{Error}))
 {
   init flat/55/simpflat/126@{Error} = ExceptNotAnError@{Error};
   init flat/55/simpflat/127@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
   init flat/55/simpflat/128@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
-  foreach (for_counter/flat/56 in 0@{Int} .. Array_length#@{Time} conv/35/simpflat/118)
+  foreach (for_counter/flat/56 in 0@{Int} .. Array_length#@{Time} conv/37/simpflat/118)
   {
     read flat/55/simpflat/129 = flat/55/simpflat/126 [Error];
     read flat/55/simpflat/130 = flat/55/simpflat/127 [Array Time];
     read flat/55/simpflat/131 = flat/55/simpflat/128 [Array Int];
-    let simpflat/534 = unsafe_Array_index#@{Time} conv/35/simpflat/118 for_counter/flat/56;
-    let simpflat/538 = unsafe_Array_index#@{Buf 2 Error} conv/35/simpflat/120 for_counter/flat/56;
-    let simpflat/540 = unsafe_Array_index#@{Buf 2 Int} conv/35/simpflat/121 for_counter/flat/56;
+    let simpflat/534 = unsafe_Array_index#@{Time} conv/37/simpflat/118 for_counter/flat/56;
+    let simpflat/538 = unsafe_Array_index#@{Buf 2 Error} conv/37/simpflat/120 for_counter/flat/56;
+    let simpflat/540 = unsafe_Array_index#@{Buf 2 Int} conv/37/simpflat/121 for_counter/flat/56;
     init flat/58/simpflat/132@{Error} = ExceptNotAnError@{Error};
     init flat/58/simpflat/133@{Array Time} = unsafe_Array_create#@{Time} (0@{Int});
     init flat/58/simpflat/134@{Array Int} = unsafe_Array_create#@{Int} (0@{Int});
@@ -1323,7 +1323,7 @@ if (eq#@{Error} conv/35/simpflat/117 (ExceptNotAnError@{Error}))
 }
 else
 {
-  write flat/47/simpflat/123 = conv/35/simpflat/117;
+  write flat/47/simpflat/123 = conv/37/simpflat/117;
   write flat/47/simpflat/124 = unsafe_Array_create#@{Time} (0@{Int});
   write flat/47/simpflat/125 = unsafe_Array_create#@{Int} (0@{Int});
 }

--- a/icicle-source/src/Icicle/Source/ToCore/Exp.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Exp.hs
@@ -156,7 +156,8 @@ convertCase x scrut pats scrutT resT
           | Just ([],tru) <- Map.lookup ConTrue     m
           , Just ([],fal) <- Map.lookup ConFalse    m
           -> return ((CE.xPrim $ C.PrimFold C.PrimFoldBool resT)
-                     CE.@~ tru CE.@~ fal
+                     CE.@~ CE.xLam sn T.UnitT tru
+                     CE.@~ CE.xLam sn T.UnitT fal
                      CE.@~ scrut)
 
          T.PairT ta tb

--- a/icicle-source/src/Icicle/Source/ToCore/Fold.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Fold.hs
@@ -220,11 +220,12 @@ convertFold q
      -> do  res <- convertFold q'
             e'         <- convertExp  e
             prev       <- lift fresh
+            n'unit     <- lift fresh
             let tt'    = typeFold res
             let prev'  = CE.xVar prev
             let k' = CE.xLam prev tt'
                    ( CE.xPrim (C.PrimFold C.PrimFoldBool tt')
-                     CE.@~ (foldKons res CE.@~ prev') CE.@~ prev' CE.@~ e' )
+                     CE.@~ CE.xLam n'unit T.UnitT (foldKons res CE.@~ prev') CE.@~ CE.xLam n'unit T.UnitT prev' CE.@~ e' )
             return (res { foldKons = k' })
 
     (Latest _ i : _)

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -394,6 +394,7 @@ primInsertOrUpdate tk tv xm xk xvz xvu = do
 
   n  <- lift F.fresh
   n' <- lift F.fresh
+  n''<- lift F.fresh
   let tm     = T.MapT tk tv
   let tsum   = T.SumT T.ErrorT tm
 
@@ -414,7 +415,7 @@ primInsertOrUpdate tk tv xm xk xvz xvu = do
 
   return     $ CE.makeLets () [ (n', insert) ]
              $ apps (C.PrimFold C.PrimFoldBool $ tsum)
-             [ vright, verr, lenchk ]
+             [ CE.xLam n'' T.UnitT vright, CE.xLam n'' T.UnitT verr, lenchk ]
  where
   apps f xs = CE.makeApps () (CE.XPrim () f) xs
   bf = C.PrimMinimal . Min.PrimBuiltinFun

--- a/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
@@ -448,6 +448,7 @@ convertKey env (InputKey (Just k)) (core, ret) = do
         n'acc'new <- lift fresh
         n'key'old <- lift fresh
         n'key'new <- lift fresh
+        n'unit    <- lift fresh
 
         xx' <- lift $ CE.subst1 () n'input (CE.xVar n'acc'old) xx
         let a  = CE.makeApps () (sndX  t'key t'acc) [CE.xVar n'input]
@@ -457,8 +458,8 @@ convertKey env (InputKey (Just k)) (core, ret) = do
                $ CE.xLet n'acc'new xx'
                $ CE.makeApps ()
                    ( CE.xPrim (C.PrimFold C.PrimFoldBool (T.PairT t'key t'acc)) )
-                   [ CE.xVar n'input
-                   , CE.makeApps () (pairX t'key t'acc) [ CE.xVar n'key'new, CE.xVar n'acc'new ]
+                   [ CE.xLam n'unit T.UnitT $ CE.xVar n'input
+                   , CE.xLam n'unit T.UnitT $ CE.makeApps () (pairX t'key t'acc) [ CE.xVar n'key'new, CE.xVar n'acc'new ]
                    , CE.makeApps () (eqX   t'key      ) [ CE.xVar n'key'old, CE.xVar n'key'new ] ]
 
         pure ( x', Map.singleton n'input a )


### PR DESCRIPTION
```
- if :: a -> a -> Bool -> a
+ if :: (() -> a) -> (() -> a) -> Bool -> a
```
if was sometimes strict in both its arguments because it would anormalise and pull out any let-bindings inside the branch.

! @jystic @tranma 