### PR TITLE
Case with pure scrutinee and aggregate return is broken #597

### DIFF
--- a/data/sea/20-simple.h
+++ b/data/sea/20-simple.h
@@ -54,6 +54,7 @@ static idouble_t INLINE idouble_log   (idouble_t x)              { return log(x)
 static idouble_t INLINE idouble_exp   (idouble_t x)              { return exp(x); }
 static idouble_t INLINE idouble_sqrt  (idouble_t x)              { return sqrt(x); }
 static idouble_t INLINE idouble_abs   (idouble_t x)              { return fabs(x); }
+static idouble_t INLINE idouble_is_valid(idouble_t x)            { return isfinite(x); }
 
 MK_SIMPLE_CMPS(idouble_t, idouble_)
 MK_SIMPLE_COPY(idouble_t, idouble_)

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
@@ -126,6 +126,7 @@ seaOfPrimBuiltinMath p = case p of
   M.PrimBuiltinRound           -> "idouble_round"
   M.PrimBuiltinTruncate        -> "idouble_trunc"
   M.PrimBuiltinToDoubleFromInt -> "iint_extend"
+  M.PrimBuiltinDoubleIsValid   -> "idouble_is_valid"
 
 seaOfPrimRelation :: M.PrimRelation -> Doc
 seaOfPrimRelation p

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Core.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Core.hs
@@ -175,7 +175,8 @@ instance Arbitrary PM.PrimBuiltinMath where
     , PM.PrimBuiltinFloor
     , PM.PrimBuiltinTruncate
     , PM.PrimBuiltinRound
-    , PM.PrimBuiltinToDoubleFromInt ]
+    , PM.PrimBuiltinToDoubleFromInt
+    , PM.PrimBuiltinDoubleIsValid ]
 
 --------------------------------------------------------------------------------
 

--- a/icicle-compiler/test/cli/repl/t13-cases-either/expected
+++ b/icicle-compiler/test/cli/repl/t13-cases-either/expected
@@ -3,13 +3,13 @@ ok, loaded 38 functions from data/libs/prelude.icicle
 ok, loaded test/cli/repl/data.psv, 13 rows
 > ok, type is now on
 > - Type:
-Aggregate Definitely (Sum Int Double)
+Aggregate Possibly (Sum Int Double)
 
 - Core evaluation:
 [homer, 5.0,marge, 3.0]
 
 > - Type:
-Aggregate Definitely (Sum Int Double)
+Aggregate Possibly (Sum Int Double)
 
 - Core evaluation:
 [homer, 5.0,marge, 3.0]

--- a/icicle-compiler/test/cli/repl/t16-prelude/expected
+++ b/icicle-compiler/test/cli/repl/t16-prelude/expected
@@ -66,20 +66,20 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 > > -- Gradient example
 > - C evaluation:
 [homer, 17.53336340594424
-,marge, NaN]
+,marge, tombstone]
 
 - Core evaluation:
 [homer, 17.53336340594424
-,marge, NaN]
+,marge, tombstone]
 
 > > -- Pearsons correlation example
 > - C evaluation:
 [homer, 0.9279829441311143
-,marge, NaN]
+,marge, tombstone]
 
 - Core evaluation:
 [homer, 0.9279829441311143
-,marge, NaN]
+,marge, tombstone]
 
 > > -- Newest example
 > - C evaluation:

--- a/icicle-compiler/test/cli/repl/t20-lexer/expected
+++ b/icicle-compiler/test/cli/repl/t20-lexer/expected
@@ -28,7 +28,7 @@ Check error:
     Suggested bindings are:
       max                  : Element a -> Aggregate Possibly a
       mean                 : (Num a) => Element a -> Aggregate Possibly Double
-      exp                  : Double -> Double
+      exp                  : Double -> Possibly Double
       day                  : Time -> Int
       year                 : Time -> Int
 

--- a/icicle-compiler/test/cli/repl/t30-sea/expected
+++ b/icicle-compiler/test/cli/repl/t30-sea/expected
@@ -26,1164 +26,1792 @@ ok, c is now on
 > - Flattened (simplified), not typechecked:
 conv/3 = TIME
 conv/4 = MAX_MAP_SIZE
-init acc/conv/11/simpflat/33@{Error} = ExceptNotAnError@{Error};
-init acc/conv/11/simpflat/34@{Double} = 0.0@{Double};
-init acc/s/reify/6/conv/12/simpflat/39@{Error} = ExceptFold1NoValue@{Error};
-init acc/s/reify/6/conv/12/simpflat/40@{Double} = 0.0@{Double};
-init acc/s/reify/6/conv/12/simpflat/41@{Double} = 0.0@{Double};
-init acc/conv/60/simpflat/42@{Error} = ExceptNotAnError@{Error};
-init acc/conv/60/simpflat/43@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/48@{Error} = ExceptNotAnError@{Error};
-init acc/a/conv/61/simpflat/49@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/50@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/51@{Double} = 0.0@{Double};
-load_resumable@{Error} acc/a/conv/61/simpflat/48;
-load_resumable@{Double} acc/a/conv/61/simpflat/49;
-load_resumable@{Double} acc/a/conv/61/simpflat/50;
-load_resumable@{Double} acc/a/conv/61/simpflat/51;
-load_resumable@{Error} acc/conv/60/simpflat/42;
-load_resumable@{Double} acc/conv/60/simpflat/43;
-load_resumable@{Error} acc/s/reify/6/conv/12/simpflat/39;
-load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/40;
-load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/41;
-load_resumable@{Error} acc/conv/11/simpflat/33;
-load_resumable@{Double} acc/conv/11/simpflat/34;
-for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/230@{Error}, conv/0/simpflat/231@{String}, conv/0/simpflat/232@{Int}, conv/0/simpflat/233@{Time}) in new
+init acc/conv/11/simpflat/22@{Error} = ExceptNotAnError@{Error};
+init acc/conv/11/simpflat/23@{Double} = 0.0@{Double};
+init acc/s/reify/6/conv/12/simpflat/28@{Error} = ExceptFold1NoValue@{Error};
+init acc/s/reify/6/conv/12/simpflat/29@{Double} = 0.0@{Double};
+init acc/s/reify/6/conv/12/simpflat/30@{Double} = 0.0@{Double};
+init acc/conv/76/simpflat/31@{Error} = ExceptNotAnError@{Error};
+init acc/conv/76/simpflat/32@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/37@{Error} = ExceptNotAnError@{Error};
+init acc/a/conv/77/simpflat/38@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/39@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/40@{Double} = 0.0@{Double};
+load_resumable@{Error} acc/a/conv/77/simpflat/37;
+load_resumable@{Double} acc/a/conv/77/simpflat/38;
+load_resumable@{Double} acc/a/conv/77/simpflat/39;
+load_resumable@{Double} acc/a/conv/77/simpflat/40;
+load_resumable@{Error} acc/conv/76/simpflat/31;
+load_resumable@{Double} acc/conv/76/simpflat/32;
+load_resumable@{Error} acc/s/reify/6/conv/12/simpflat/28;
+load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/29;
+load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/30;
+load_resumable@{Error} acc/conv/11/simpflat/22;
+load_resumable@{Double} acc/conv/11/simpflat/23;
+for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/307@{Error}, conv/0/simpflat/308@{String}, conv/0/simpflat/309@{Int}, conv/0/simpflat/310@{Time}) in new
 {
-  init flat/0/simpflat/52@{Error} = ExceptNotAnError@{Error};
-  init flat/0/simpflat/53@{Int} = 0@{Int};
-  if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+  init flat/0/simpflat/41@{Error} = ExceptNotAnError@{Error};
+  init flat/0/simpflat/42@{Int} = 0@{Int};
+  if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
   {
-    write flat/0/simpflat/52 = ExceptNotAnError@{Error};
-    write flat/0/simpflat/53 = conv/0/simpflat/232;
+    write flat/0/simpflat/41 = ExceptNotAnError@{Error};
+    write flat/0/simpflat/42 = conv/0/simpflat/309;
   }
   else
   {
-    write flat/0/simpflat/52 = conv/0/simpflat/230;
-    write flat/0/simpflat/53 = 0@{Int};
+    write flat/0/simpflat/41 = conv/0/simpflat/307;
+    write flat/0/simpflat/42 = 0@{Int};
   }
-  read flat/0/simpflat/54 = flat/0/simpflat/52 [Error];
-  read flat/0/simpflat/55 = flat/0/simpflat/53 [Int];
-  init flat/1/simpflat/56@{Error} = ExceptNotAnError@{Error};
-  init flat/1/simpflat/57@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/0/simpflat/54 (ExceptNotAnError@{Error}))
+  read flat/0/simpflat/43 = flat/0/simpflat/41 [Error];
+  read flat/0/simpflat/44 = flat/0/simpflat/42 [Int];
+  init flat/1/simpflat/45@{Error} = ExceptNotAnError@{Error};
+  init flat/1/simpflat/46@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/0/simpflat/43 (ExceptNotAnError@{Error}))
   {
-    write flat/1/simpflat/56 = ExceptNotAnError@{Error};
-    write flat/1/simpflat/57 = doubleOfInt# flat/0/simpflat/55;
-  }
-  else
-  {
-    write flat/1/simpflat/56 = flat/0/simpflat/54;
-    write flat/1/simpflat/57 = 0.0@{Double};
-  }
-  read flat/1/simpflat/58 = flat/1/simpflat/56 [Error];
-  read flat/1/simpflat/59 = flat/1/simpflat/57 [Double];
-  init flat/2/simpflat/60@{Error} = ExceptNotAnError@{Error};
-  init flat/2/simpflat/61@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/1/simpflat/58 (ExceptNotAnError@{Error}))
-  {
-    write flat/2/simpflat/60 = ExceptNotAnError@{Error};
-    write flat/2/simpflat/61 = flat/1/simpflat/59;
+    write flat/1/simpflat/45 = ExceptNotAnError@{Error};
+    write flat/1/simpflat/46 = doubleOfInt# flat/0/simpflat/44;
   }
   else
   {
-    write flat/2/simpflat/60 = flat/1/simpflat/58;
-    write flat/2/simpflat/61 = 0.0@{Double};
+    write flat/1/simpflat/45 = flat/0/simpflat/43;
+    write flat/1/simpflat/46 = 0.0@{Double};
   }
-  read flat/2/simpflat/62 = flat/2/simpflat/60 [Error];
-  read flat/2/simpflat/63 = flat/2/simpflat/61 [Double];
-  write acc/conv/11/simpflat/33 = flat/2/simpflat/62;
-  write acc/conv/11/simpflat/34 = flat/2/simpflat/63;
-  read conv/11/aval/1/simpflat/64 = acc/conv/11/simpflat/33 [Error];
-  read conv/11/aval/1/simpflat/65 = acc/conv/11/simpflat/34 [Double];
-  read s/reify/6/conv/12/aval/0/simpflat/70 = acc/s/reify/6/conv/12/simpflat/39 [Error];
-  read s/reify/6/conv/12/aval/0/simpflat/71 = acc/s/reify/6/conv/12/simpflat/40 [Double];
-  read s/reify/6/conv/12/aval/0/simpflat/72 = acc/s/reify/6/conv/12/simpflat/41 [Double];
-  init flat/3/simpflat/73@{Error} = ExceptNotAnError@{Error};
-  init flat/3/simpflat/74@{Double} = 0.0@{Double};
-  init flat/3/simpflat/75@{Double} = 0.0@{Double};
-  if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/70 (ExceptNotAnError@{Error}))
+  read flat/1/simpflat/47 = flat/1/simpflat/45 [Error];
+  read flat/1/simpflat/48 = flat/1/simpflat/46 [Double];
+  init flat/2/simpflat/49@{Error} = ExceptNotAnError@{Error};
+  init flat/2/simpflat/50@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/1/simpflat/47 (ExceptNotAnError@{Error}))
   {
-    init flat/10/simpflat/76@{Error} = ExceptNotAnError@{Error};
-    init flat/10/simpflat/77@{Double} = 0.0@{Double};
-    init flat/10/simpflat/78@{Double} = 0.0@{Double};
-    if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/70 (ExceptNotAnError@{Error}))
-    {
-      init flat/13/simpflat/79@{Error} = ExceptNotAnError@{Error};
-      init flat/13/simpflat/80@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/11/aval/1/simpflat/64 (ExceptNotAnError@{Error}))
-      {
-        write flat/13/simpflat/79 = ExceptNotAnError@{Error};
-        write flat/13/simpflat/80 = sub#@{Double} conv/11/aval/1/simpflat/65 s/reify/6/conv/12/aval/0/simpflat/71;
-      }
-      else
-      {
-        write flat/13/simpflat/79 = conv/11/aval/1/simpflat/64;
-        write flat/13/simpflat/80 = 0.0@{Double};
-      }
-      read flat/13/simpflat/81 = flat/13/simpflat/79 [Error];
-      read flat/13/simpflat/82 = flat/13/simpflat/80 [Double];
-      init flat/14/simpflat/83@{Error} = ExceptNotAnError@{Error};
-      init flat/14/simpflat/84@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/13/simpflat/81 (ExceptNotAnError@{Error}))
-      {
-        write flat/14/simpflat/83 = ExceptNotAnError@{Error};
-        let simpflat/285 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/72 (1.0@{Double});
-        write flat/14/simpflat/84 = div# flat/13/simpflat/82 simpflat/285;
-      }
-      else
-      {
-        write flat/14/simpflat/83 = flat/13/simpflat/81;
-        write flat/14/simpflat/84 = 0.0@{Double};
-      }
-      read flat/14/simpflat/85 = flat/14/simpflat/83 [Error];
-      read flat/14/simpflat/86 = flat/14/simpflat/84 [Double];
-      init flat/15/simpflat/87@{Error} = ExceptNotAnError@{Error};
-      init flat/15/simpflat/88@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/14/simpflat/85 (ExceptNotAnError@{Error}))
-      {
-        write flat/15/simpflat/87 = ExceptNotAnError@{Error};
-        write flat/15/simpflat/88 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/71 flat/14/simpflat/86;
-      }
-      else
-      {
-        write flat/15/simpflat/87 = flat/14/simpflat/85;
-        write flat/15/simpflat/88 = 0.0@{Double};
-      }
-      read flat/15/simpflat/89 = flat/15/simpflat/87 [Error];
-      read flat/15/simpflat/90 = flat/15/simpflat/88 [Double];
-      init flat/16/simpflat/91@{Error} = ExceptNotAnError@{Error};
-      init flat/16/simpflat/92@{Double} = 0.0@{Double};
-      init flat/16/simpflat/93@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/15/simpflat/89 (ExceptNotAnError@{Error}))
-      {
-        write flat/16/simpflat/91 = ExceptNotAnError@{Error};
-        write flat/16/simpflat/92 = flat/15/simpflat/90;
-        write flat/16/simpflat/93 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/72 (1.0@{Double});
-      }
-      else
-      {
-        write flat/16/simpflat/91 = flat/15/simpflat/89;
-        write flat/16/simpflat/92 = 0.0@{Double};
-        write flat/16/simpflat/93 = 0.0@{Double};
-      }
-      read flat/16/simpflat/94 = flat/16/simpflat/91 [Error];
-      read flat/16/simpflat/95 = flat/16/simpflat/92 [Double];
-      read flat/16/simpflat/96 = flat/16/simpflat/93 [Double];
-      write flat/10/simpflat/76 = flat/16/simpflat/94;
-      write flat/10/simpflat/77 = flat/16/simpflat/95;
-      write flat/10/simpflat/78 = flat/16/simpflat/96;
-    }
-    else
-    {
-      write flat/10/simpflat/76 = s/reify/6/conv/12/aval/0/simpflat/70;
-      write flat/10/simpflat/77 = 0.0@{Double};
-      write flat/10/simpflat/78 = 0.0@{Double};
-    }
-    read flat/10/simpflat/97 = flat/10/simpflat/76 [Error];
-    read flat/10/simpflat/98 = flat/10/simpflat/77 [Double];
-    read flat/10/simpflat/99 = flat/10/simpflat/78 [Double];
-    write flat/3/simpflat/73 = flat/10/simpflat/97;
-    write flat/3/simpflat/74 = flat/10/simpflat/98;
-    write flat/3/simpflat/75 = flat/10/simpflat/99;
+    write flat/2/simpflat/49 = ExceptNotAnError@{Error};
+    write flat/2/simpflat/50 = flat/1/simpflat/48;
   }
   else
   {
-    init flat/6/simpflat/100@{Error} = ExceptNotAnError@{Error};
-    init flat/6/simpflat/101@{Double} = 0.0@{Double};
-    init flat/6/simpflat/102@{Double} = 0.0@{Double};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s/reify/6/conv/12/aval/0/simpflat/70)
-    {
-      init flat/7/simpflat/103@{Error} = ExceptNotAnError@{Error};
-      init flat/7/simpflat/104@{Double} = 0.0@{Double};
-      init flat/7/simpflat/105@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/11/aval/1/simpflat/64 (ExceptNotAnError@{Error}))
-      {
-        write flat/7/simpflat/103 = ExceptNotAnError@{Error};
-        write flat/7/simpflat/104 = conv/11/aval/1/simpflat/65;
-        write flat/7/simpflat/105 = 1.0@{Double};
-      }
-      else
-      {
-        write flat/7/simpflat/103 = conv/11/aval/1/simpflat/64;
-        write flat/7/simpflat/104 = 0.0@{Double};
-        write flat/7/simpflat/105 = 0.0@{Double};
-      }
-      read flat/7/simpflat/106 = flat/7/simpflat/103 [Error];
-      read flat/7/simpflat/107 = flat/7/simpflat/104 [Double];
-      read flat/7/simpflat/108 = flat/7/simpflat/105 [Double];
-      write flat/6/simpflat/100 = flat/7/simpflat/106;
-      write flat/6/simpflat/101 = flat/7/simpflat/107;
-      write flat/6/simpflat/102 = flat/7/simpflat/108;
-    }
-    else
-    {
-      write flat/6/simpflat/100 = s/reify/6/conv/12/aval/0/simpflat/70;
-      write flat/6/simpflat/101 = 0.0@{Double};
-      write flat/6/simpflat/102 = 0.0@{Double};
-    }
-    read flat/6/simpflat/109 = flat/6/simpflat/100 [Error];
-    read flat/6/simpflat/110 = flat/6/simpflat/101 [Double];
-    read flat/6/simpflat/111 = flat/6/simpflat/102 [Double];
-    write flat/3/simpflat/73 = flat/6/simpflat/109;
-    write flat/3/simpflat/74 = flat/6/simpflat/110;
-    write flat/3/simpflat/75 = flat/6/simpflat/111;
+    write flat/2/simpflat/49 = flat/1/simpflat/47;
+    write flat/2/simpflat/50 = 0.0@{Double};
   }
-  read flat/3/simpflat/112 = flat/3/simpflat/73 [Error];
-  read flat/3/simpflat/113 = flat/3/simpflat/74 [Double];
-  read flat/3/simpflat/114 = flat/3/simpflat/75 [Double];
-  write acc/s/reify/6/conv/12/simpflat/39 = flat/3/simpflat/112;
-  write acc/s/reify/6/conv/12/simpflat/40 = flat/3/simpflat/113;
-  write acc/s/reify/6/conv/12/simpflat/41 = flat/3/simpflat/114;
-  init flat/25/simpflat/115@{Error} = ExceptNotAnError@{Error};
-  init flat/25/simpflat/116@{String} = ""@{String};
-  if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+  read flat/2/simpflat/51 = flat/2/simpflat/49 [Error];
+  read flat/2/simpflat/52 = flat/2/simpflat/50 [Double];
+  write acc/conv/11/simpflat/22 = flat/2/simpflat/51;
+  write acc/conv/11/simpflat/23 = flat/2/simpflat/52;
+  read conv/11/aval/1/simpflat/53 = acc/conv/11/simpflat/22 [Error];
+  read conv/11/aval/1/simpflat/54 = acc/conv/11/simpflat/23 [Double];
+  read s/reify/6/conv/12/aval/0/simpflat/59 = acc/s/reify/6/conv/12/simpflat/28 [Error];
+  read s/reify/6/conv/12/aval/0/simpflat/60 = acc/s/reify/6/conv/12/simpflat/29 [Double];
+  read s/reify/6/conv/12/aval/0/simpflat/61 = acc/s/reify/6/conv/12/simpflat/30 [Double];
+  init flat/3/simpflat/62@{Error} = ExceptNotAnError@{Error};
+  init flat/3/simpflat/63@{Double} = 0.0@{Double};
+  init flat/3/simpflat/64@{Double} = 0.0@{Double};
+  if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/59 (ExceptNotAnError@{Error}))
   {
-    write flat/25/simpflat/115 = ExceptNotAnError@{Error};
-    write flat/25/simpflat/116 = conv/0/simpflat/231;
-  }
-  else
-  {
-    write flat/25/simpflat/115 = conv/0/simpflat/230;
-    write flat/25/simpflat/116 = ""@{String};
-  }
-  read flat/25/simpflat/117 = flat/25/simpflat/115 [Error];
-  read flat/25/simpflat/118 = flat/25/simpflat/116 [String];
-  init flat/26/simpflat/119@{Error} = ExceptNotAnError@{Error};
-  init flat/26/simpflat/120@{Bool} = False@{Bool};
-  if (eq#@{Error} flat/25/simpflat/117 (ExceptNotAnError@{Error}))
-  {
-    write flat/26/simpflat/119 = ExceptNotAnError@{Error};
-    write flat/26/simpflat/120 = eq#@{String} flat/25/simpflat/118 ("torso"@{String});
-  }
-  else
-  {
-    write flat/26/simpflat/119 = flat/25/simpflat/117;
-    write flat/26/simpflat/120 = False@{Bool};
-  }
-  read flat/26/simpflat/121 = flat/26/simpflat/119 [Error];
-  read flat/26/simpflat/122 = flat/26/simpflat/120 [Bool];
-  init flat/27@{Bool} = False@{Bool};
-  if (eq#@{Error} flat/26/simpflat/121 (ExceptNotAnError@{Error}))
-  {
-    write flat/27 = flat/26/simpflat/122;
-  }
-  else
-  {
-    write flat/27 = True@{Bool};
-  }
-  read flat/27 = flat/27 [Bool];
-  if (flat/27)
-  {
-    init flat/28/simpflat/123@{Error} = ExceptNotAnError@{Error};
-    init flat/28/simpflat/124@{Int} = 0@{Int};
-    if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+    init flat/10/simpflat/65@{Error} = ExceptNotAnError@{Error};
+    init flat/10/simpflat/66@{Double} = 0.0@{Double};
+    init flat/10/simpflat/67@{Double} = 0.0@{Double};
+    if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/59 (ExceptNotAnError@{Error}))
     {
-      write flat/28/simpflat/123 = ExceptNotAnError@{Error};
-      write flat/28/simpflat/124 = conv/0/simpflat/232;
-    }
-    else
-    {
-      write flat/28/simpflat/123 = conv/0/simpflat/230;
-      write flat/28/simpflat/124 = 0@{Int};
-    }
-    read flat/28/simpflat/125 = flat/28/simpflat/123 [Error];
-    read flat/28/simpflat/126 = flat/28/simpflat/124 [Int];
-    init flat/29/simpflat/127@{Error} = ExceptNotAnError@{Error};
-    init flat/29/simpflat/128@{Double} = 0.0@{Double};
-    if (eq#@{Error} flat/28/simpflat/125 (ExceptNotAnError@{Error}))
-    {
-      write flat/29/simpflat/127 = ExceptNotAnError@{Error};
-      write flat/29/simpflat/128 = doubleOfInt# flat/28/simpflat/126;
-    }
-    else
-    {
-      write flat/29/simpflat/127 = flat/28/simpflat/125;
-      write flat/29/simpflat/128 = 0.0@{Double};
-    }
-    read flat/29/simpflat/129 = flat/29/simpflat/127 [Error];
-    read flat/29/simpflat/130 = flat/29/simpflat/128 [Double];
-    write acc/conv/60/simpflat/42 = flat/29/simpflat/129;
-    write acc/conv/60/simpflat/43 = flat/29/simpflat/130;
-    read conv/60/aval/3/simpflat/131 = acc/conv/60/simpflat/42 [Error];
-    read conv/60/aval/3/simpflat/132 = acc/conv/60/simpflat/43 [Double];
-    read a/conv/61/aval/2/simpflat/137 = acc/a/conv/61/simpflat/48 [Error];
-    read a/conv/61/aval/2/simpflat/138 = acc/a/conv/61/simpflat/49 [Double];
-    read a/conv/61/aval/2/simpflat/139 = acc/a/conv/61/simpflat/50 [Double];
-    read a/conv/61/aval/2/simpflat/140 = acc/a/conv/61/simpflat/51 [Double];
-    init flat/30/simpflat/141@{Error} = ExceptNotAnError@{Error};
-    init flat/30/simpflat/142@{Double} = 0.0@{Double};
-    init flat/30/simpflat/143@{Double} = 0.0@{Double};
-    init flat/30/simpflat/144@{Double} = 0.0@{Double};
-    if (eq#@{Error} a/conv/61/aval/2/simpflat/137 (ExceptNotAnError@{Error}))
-    {
-      let nn/conv/68 = add#@{Double} a/conv/61/aval/2/simpflat/138 (1.0@{Double});
-      init flat/33/simpflat/145@{Error} = ExceptNotAnError@{Error};
-      init flat/33/simpflat/146@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/60/aval/3/simpflat/131 (ExceptNotAnError@{Error}))
+      init flat/13/simpflat/68@{Error} = ExceptNotAnError@{Error};
+      init flat/13/simpflat/69@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/11/aval/1/simpflat/53 (ExceptNotAnError@{Error}))
       {
-        write flat/33/simpflat/145 = ExceptNotAnError@{Error};
-        write flat/33/simpflat/146 = sub#@{Double} conv/60/aval/3/simpflat/132 a/conv/61/aval/2/simpflat/139;
-      }
-      else
-      {
-        write flat/33/simpflat/145 = conv/60/aval/3/simpflat/131;
-        write flat/33/simpflat/146 = 0.0@{Double};
-      }
-      read flat/33/simpflat/147 = flat/33/simpflat/145 [Error];
-      read flat/33/simpflat/148 = flat/33/simpflat/146 [Double];
-      init flat/34/simpflat/149@{Error} = ExceptNotAnError@{Error};
-      init flat/34/simpflat/150@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/33/simpflat/147 (ExceptNotAnError@{Error}))
-      {
-        write flat/34/simpflat/149 = ExceptNotAnError@{Error};
-        write flat/34/simpflat/150 = div# flat/33/simpflat/148 nn/conv/68;
-      }
-      else
-      {
-        write flat/34/simpflat/149 = flat/33/simpflat/147;
-        write flat/34/simpflat/150 = 0.0@{Double};
-      }
-      read flat/34/simpflat/151 = flat/34/simpflat/149 [Error];
-      read flat/34/simpflat/152 = flat/34/simpflat/150 [Double];
-      init flat/35/simpflat/153@{Error} = ExceptNotAnError@{Error};
-      init flat/35/simpflat/154@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/34/simpflat/151 (ExceptNotAnError@{Error}))
-      {
-        write flat/35/simpflat/153 = ExceptNotAnError@{Error};
-        write flat/35/simpflat/154 = add#@{Double} a/conv/61/aval/2/simpflat/139 flat/34/simpflat/152;
-      }
-      else
-      {
-        write flat/35/simpflat/153 = flat/34/simpflat/151;
-        write flat/35/simpflat/154 = 0.0@{Double};
-      }
-      read flat/35/simpflat/155 = flat/35/simpflat/153 [Error];
-      read flat/35/simpflat/156 = flat/35/simpflat/154 [Double];
-      init flat/36/simpflat/157@{Error} = ExceptNotAnError@{Error};
-      init flat/36/simpflat/158@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/33/simpflat/147 (ExceptNotAnError@{Error}))
-      {
-        init flat/51/simpflat/159@{Error} = ExceptNotAnError@{Error};
-        init flat/51/simpflat/160@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv/60/aval/3/simpflat/131 (ExceptNotAnError@{Error}))
+        let conv/25 = sub#@{Double} conv/11/aval/1/simpflat/54 s/reify/6/conv/12/aval/0/simpflat/60;
+        init flat/35/simpflat/70@{Error} = ExceptNotAnError@{Error};
+        init flat/35/simpflat/71@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/25)
         {
-          init flat/57/simpflat/161@{Error} = ExceptNotAnError@{Error};
-          init flat/57/simpflat/162@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat/35/simpflat/155 (ExceptNotAnError@{Error}))
+          write flat/35/simpflat/70 = ExceptNotAnError@{Error};
+          write flat/35/simpflat/71 = sub#@{Double} conv/11/aval/1/simpflat/54 s/reify/6/conv/12/aval/0/simpflat/60;
+        }
+        else
+        {
+          write flat/35/simpflat/70 = ExceptCannotCompute@{Error};
+          write flat/35/simpflat/71 = 0.0@{Double};
+        }
+        read flat/35/simpflat/72 = flat/35/simpflat/70 [Error];
+        read flat/35/simpflat/73 = flat/35/simpflat/71 [Double];
+        write flat/13/simpflat/68 = flat/35/simpflat/72;
+        write flat/13/simpflat/69 = flat/35/simpflat/73;
+      }
+      else
+      {
+        write flat/13/simpflat/68 = conv/11/aval/1/simpflat/53;
+        write flat/13/simpflat/69 = 0.0@{Double};
+      }
+      read flat/13/simpflat/74 = flat/13/simpflat/68 [Error];
+      read flat/13/simpflat/75 = flat/13/simpflat/69 [Double];
+      init flat/14/simpflat/76@{Error} = ExceptNotAnError@{Error};
+      init flat/14/simpflat/77@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/13/simpflat/74 (ExceptNotAnError@{Error}))
+      {
+        let conv/30 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        init flat/28/simpflat/78@{Error} = ExceptNotAnError@{Error};
+        init flat/28/simpflat/79@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/30)
+        {
+          write flat/28/simpflat/78 = ExceptNotAnError@{Error};
+          write flat/28/simpflat/79 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        }
+        else
+        {
+          write flat/28/simpflat/78 = ExceptCannotCompute@{Error};
+          write flat/28/simpflat/79 = 0.0@{Double};
+        }
+        read flat/28/simpflat/80 = flat/28/simpflat/78 [Error];
+        read flat/28/simpflat/81 = flat/28/simpflat/79 [Double];
+        init flat/29/simpflat/82@{Error} = ExceptNotAnError@{Error};
+        init flat/29/simpflat/83@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/28/simpflat/80 (ExceptNotAnError@{Error}))
+        {
+          let conv/34 = div# flat/13/simpflat/75 flat/28/simpflat/81;
+          init flat/32/simpflat/84@{Error} = ExceptNotAnError@{Error};
+          init flat/32/simpflat/85@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/34)
           {
-            write flat/57/simpflat/161 = ExceptNotAnError@{Error};
-            write flat/57/simpflat/162 = sub#@{Double} conv/60/aval/3/simpflat/132 flat/35/simpflat/156;
+            write flat/32/simpflat/84 = ExceptNotAnError@{Error};
+            write flat/32/simpflat/85 = div# flat/13/simpflat/75 flat/28/simpflat/81;
           }
           else
           {
-            write flat/57/simpflat/161 = flat/35/simpflat/155;
-            write flat/57/simpflat/162 = 0.0@{Double};
+            write flat/32/simpflat/84 = ExceptCannotCompute@{Error};
+            write flat/32/simpflat/85 = 0.0@{Double};
           }
-          read flat/57/simpflat/163 = flat/57/simpflat/161 [Error];
-          read flat/57/simpflat/164 = flat/57/simpflat/162 [Double];
-          write flat/51/simpflat/159 = flat/57/simpflat/163;
-          write flat/51/simpflat/160 = flat/57/simpflat/164;
+          read flat/32/simpflat/86 = flat/32/simpflat/84 [Error];
+          read flat/32/simpflat/87 = flat/32/simpflat/85 [Double];
+          write flat/29/simpflat/82 = flat/32/simpflat/86;
+          write flat/29/simpflat/83 = flat/32/simpflat/87;
         }
         else
         {
-          write flat/51/simpflat/159 = conv/60/aval/3/simpflat/131;
-          write flat/51/simpflat/160 = 0.0@{Double};
+          write flat/29/simpflat/82 = flat/28/simpflat/80;
+          write flat/29/simpflat/83 = 0.0@{Double};
         }
-        read flat/51/simpflat/165 = flat/51/simpflat/159 [Error];
-        read flat/51/simpflat/166 = flat/51/simpflat/160 [Double];
-        init flat/52/simpflat/167@{Error} = ExceptNotAnError@{Error};
-        init flat/52/simpflat/168@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat/51/simpflat/165 (ExceptNotAnError@{Error}))
+        read flat/29/simpflat/88 = flat/29/simpflat/82 [Error];
+        read flat/29/simpflat/89 = flat/29/simpflat/83 [Double];
+        write flat/14/simpflat/76 = flat/29/simpflat/88;
+        write flat/14/simpflat/77 = flat/29/simpflat/89;
+      }
+      else
+      {
+        write flat/14/simpflat/76 = flat/13/simpflat/74;
+        write flat/14/simpflat/77 = 0.0@{Double};
+      }
+      read flat/14/simpflat/90 = flat/14/simpflat/76 [Error];
+      read flat/14/simpflat/91 = flat/14/simpflat/77 [Double];
+      init flat/15/simpflat/92@{Error} = ExceptNotAnError@{Error};
+      init flat/15/simpflat/93@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/14/simpflat/90 (ExceptNotAnError@{Error}))
+      {
+        let conv/40 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/60 flat/14/simpflat/91;
+        init flat/25/simpflat/94@{Error} = ExceptNotAnError@{Error};
+        init flat/25/simpflat/95@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/40)
         {
-          write flat/52/simpflat/167 = ExceptNotAnError@{Error};
-          write flat/52/simpflat/168 = mul#@{Double} flat/33/simpflat/148 flat/51/simpflat/166;
+          write flat/25/simpflat/94 = ExceptNotAnError@{Error};
+          write flat/25/simpflat/95 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/60 flat/14/simpflat/91;
         }
         else
         {
-          write flat/52/simpflat/167 = flat/51/simpflat/165;
-          write flat/52/simpflat/168 = 0.0@{Double};
+          write flat/25/simpflat/94 = ExceptCannotCompute@{Error};
+          write flat/25/simpflat/95 = 0.0@{Double};
         }
-        read flat/52/simpflat/169 = flat/52/simpflat/167 [Error];
-        read flat/52/simpflat/170 = flat/52/simpflat/168 [Double];
-        write flat/36/simpflat/157 = flat/52/simpflat/169;
-        write flat/36/simpflat/158 = flat/52/simpflat/170;
+        read flat/25/simpflat/96 = flat/25/simpflat/94 [Error];
+        read flat/25/simpflat/97 = flat/25/simpflat/95 [Double];
+        write flat/15/simpflat/92 = flat/25/simpflat/96;
+        write flat/15/simpflat/93 = flat/25/simpflat/97;
       }
       else
       {
-        write flat/36/simpflat/157 = flat/33/simpflat/147;
-        write flat/36/simpflat/158 = 0.0@{Double};
+        write flat/15/simpflat/92 = flat/14/simpflat/90;
+        write flat/15/simpflat/93 = 0.0@{Double};
       }
-      read flat/36/simpflat/171 = flat/36/simpflat/157 [Error];
-      read flat/36/simpflat/172 = flat/36/simpflat/158 [Double];
-      init flat/37/simpflat/173@{Error} = ExceptNotAnError@{Error};
-      init flat/37/simpflat/174@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/36/simpflat/171 (ExceptNotAnError@{Error}))
+      read flat/15/simpflat/98 = flat/15/simpflat/92 [Error];
+      read flat/15/simpflat/99 = flat/15/simpflat/93 [Double];
+      init flat/16/simpflat/100@{Error} = ExceptNotAnError@{Error};
+      init flat/16/simpflat/101@{Double} = 0.0@{Double};
+      init flat/16/simpflat/102@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/15/simpflat/98 (ExceptNotAnError@{Error}))
       {
-        write flat/37/simpflat/173 = ExceptNotAnError@{Error};
-        write flat/37/simpflat/174 = add#@{Double} a/conv/61/aval/2/simpflat/140 flat/36/simpflat/172;
-      }
-      else
-      {
-        write flat/37/simpflat/173 = flat/36/simpflat/171;
-        write flat/37/simpflat/174 = 0.0@{Double};
-      }
-      read flat/37/simpflat/175 = flat/37/simpflat/173 [Error];
-      read flat/37/simpflat/176 = flat/37/simpflat/174 [Double];
-      init flat/38/simpflat/177@{Error} = ExceptNotAnError@{Error};
-      init flat/38/simpflat/178@{Double} = 0.0@{Double};
-      init flat/38/simpflat/179@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/35/simpflat/155 (ExceptNotAnError@{Error}))
-      {
-        write flat/38/simpflat/177 = ExceptNotAnError@{Error};
-        write flat/38/simpflat/178 = add#@{Double} a/conv/61/aval/2/simpflat/138 (1.0@{Double});
-        write flat/38/simpflat/179 = flat/35/simpflat/156;
-      }
-      else
-      {
-        write flat/38/simpflat/177 = flat/35/simpflat/155;
-        write flat/38/simpflat/178 = 0.0@{Double};
-        write flat/38/simpflat/179 = 0.0@{Double};
-      }
-      read flat/38/simpflat/180 = flat/38/simpflat/177 [Error];
-      read flat/38/simpflat/181 = flat/38/simpflat/178 [Double];
-      read flat/38/simpflat/182 = flat/38/simpflat/179 [Double];
-      init flat/39/simpflat/183@{Error} = ExceptNotAnError@{Error};
-      init flat/39/simpflat/184@{Double} = 0.0@{Double};
-      init flat/39/simpflat/185@{Double} = 0.0@{Double};
-      init flat/39/simpflat/186@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/38/simpflat/180 (ExceptNotAnError@{Error}))
-      {
-        init flat/42/simpflat/187@{Error} = ExceptNotAnError@{Error};
-        init flat/42/simpflat/188@{Double} = 0.0@{Double};
-        init flat/42/simpflat/189@{Double} = 0.0@{Double};
-        init flat/42/simpflat/190@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat/37/simpflat/175 (ExceptNotAnError@{Error}))
+        let conv/45 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        init flat/19/simpflat/103@{Error} = ExceptNotAnError@{Error};
+        init flat/19/simpflat/104@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/45)
         {
-          write flat/42/simpflat/187 = ExceptNotAnError@{Error};
-          write flat/42/simpflat/188 = flat/38/simpflat/181;
-          write flat/42/simpflat/189 = flat/38/simpflat/182;
-          write flat/42/simpflat/190 = flat/37/simpflat/176;
+          write flat/19/simpflat/103 = ExceptNotAnError@{Error};
+          write flat/19/simpflat/104 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
         }
         else
         {
-          write flat/42/simpflat/187 = flat/37/simpflat/175;
-          write flat/42/simpflat/188 = 0.0@{Double};
-          write flat/42/simpflat/189 = 0.0@{Double};
-          write flat/42/simpflat/190 = 0.0@{Double};
+          write flat/19/simpflat/103 = ExceptCannotCompute@{Error};
+          write flat/19/simpflat/104 = 0.0@{Double};
         }
-        read flat/42/simpflat/191 = flat/42/simpflat/187 [Error];
-        read flat/42/simpflat/192 = flat/42/simpflat/188 [Double];
-        read flat/42/simpflat/193 = flat/42/simpflat/189 [Double];
-        read flat/42/simpflat/194 = flat/42/simpflat/190 [Double];
-        write flat/39/simpflat/183 = flat/42/simpflat/191;
-        write flat/39/simpflat/184 = flat/42/simpflat/192;
-        write flat/39/simpflat/185 = flat/42/simpflat/193;
-        write flat/39/simpflat/186 = flat/42/simpflat/194;
+        read flat/19/simpflat/105 = flat/19/simpflat/103 [Error];
+        read flat/19/simpflat/106 = flat/19/simpflat/104 [Double];
+        init flat/20/simpflat/107@{Error} = ExceptNotAnError@{Error};
+        init flat/20/simpflat/108@{Double} = 0.0@{Double};
+        init flat/20/simpflat/109@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/19/simpflat/105 (ExceptNotAnError@{Error}))
+        {
+          write flat/20/simpflat/107 = ExceptNotAnError@{Error};
+          write flat/20/simpflat/108 = flat/15/simpflat/99;
+          write flat/20/simpflat/109 = flat/19/simpflat/106;
+        }
+        else
+        {
+          write flat/20/simpflat/107 = flat/19/simpflat/105;
+          write flat/20/simpflat/108 = 0.0@{Double};
+          write flat/20/simpflat/109 = 0.0@{Double};
+        }
+        read flat/20/simpflat/110 = flat/20/simpflat/107 [Error];
+        read flat/20/simpflat/111 = flat/20/simpflat/108 [Double];
+        read flat/20/simpflat/112 = flat/20/simpflat/109 [Double];
+        write flat/16/simpflat/100 = flat/20/simpflat/110;
+        write flat/16/simpflat/101 = flat/20/simpflat/111;
+        write flat/16/simpflat/102 = flat/20/simpflat/112;
       }
       else
       {
-        write flat/39/simpflat/183 = flat/38/simpflat/180;
-        write flat/39/simpflat/184 = 0.0@{Double};
-        write flat/39/simpflat/185 = 0.0@{Double};
-        write flat/39/simpflat/186 = 0.0@{Double};
+        write flat/16/simpflat/100 = flat/15/simpflat/98;
+        write flat/16/simpflat/101 = 0.0@{Double};
+        write flat/16/simpflat/102 = 0.0@{Double};
       }
-      read flat/39/simpflat/195 = flat/39/simpflat/183 [Error];
-      read flat/39/simpflat/196 = flat/39/simpflat/184 [Double];
-      read flat/39/simpflat/197 = flat/39/simpflat/185 [Double];
-      read flat/39/simpflat/198 = flat/39/simpflat/186 [Double];
-      write flat/30/simpflat/141 = flat/39/simpflat/195;
-      write flat/30/simpflat/142 = flat/39/simpflat/196;
-      write flat/30/simpflat/143 = flat/39/simpflat/197;
-      write flat/30/simpflat/144 = flat/39/simpflat/198;
+      read flat/16/simpflat/113 = flat/16/simpflat/100 [Error];
+      read flat/16/simpflat/114 = flat/16/simpflat/101 [Double];
+      read flat/16/simpflat/115 = flat/16/simpflat/102 [Double];
+      write flat/10/simpflat/65 = flat/16/simpflat/113;
+      write flat/10/simpflat/66 = flat/16/simpflat/114;
+      write flat/10/simpflat/67 = flat/16/simpflat/115;
     }
     else
     {
-      write flat/30/simpflat/141 = a/conv/61/aval/2/simpflat/137;
-      write flat/30/simpflat/142 = 0.0@{Double};
-      write flat/30/simpflat/143 = 0.0@{Double};
-      write flat/30/simpflat/144 = 0.0@{Double};
+      write flat/10/simpflat/65 = s/reify/6/conv/12/aval/0/simpflat/59;
+      write flat/10/simpflat/66 = 0.0@{Double};
+      write flat/10/simpflat/67 = 0.0@{Double};
     }
-    read flat/30/simpflat/199 = flat/30/simpflat/141 [Error];
-    read flat/30/simpflat/200 = flat/30/simpflat/142 [Double];
-    read flat/30/simpflat/201 = flat/30/simpflat/143 [Double];
-    read flat/30/simpflat/202 = flat/30/simpflat/144 [Double];
-    write acc/a/conv/61/simpflat/48 = flat/30/simpflat/199;
-    write acc/a/conv/61/simpflat/49 = flat/30/simpflat/200;
-    write acc/a/conv/61/simpflat/50 = flat/30/simpflat/201;
-    write acc/a/conv/61/simpflat/51 = flat/30/simpflat/202;
+    read flat/10/simpflat/116 = flat/10/simpflat/65 [Error];
+    read flat/10/simpflat/117 = flat/10/simpflat/66 [Double];
+    read flat/10/simpflat/118 = flat/10/simpflat/67 [Double];
+    write flat/3/simpflat/62 = flat/10/simpflat/116;
+    write flat/3/simpflat/63 = flat/10/simpflat/117;
+    write flat/3/simpflat/64 = flat/10/simpflat/118;
+  }
+  else
+  {
+    init flat/6/simpflat/119@{Error} = ExceptNotAnError@{Error};
+    init flat/6/simpflat/120@{Double} = 0.0@{Double};
+    init flat/6/simpflat/121@{Double} = 0.0@{Double};
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s/reify/6/conv/12/aval/0/simpflat/59)
+    {
+      init flat/7/simpflat/122@{Error} = ExceptNotAnError@{Error};
+      init flat/7/simpflat/123@{Double} = 0.0@{Double};
+      init flat/7/simpflat/124@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/11/aval/1/simpflat/53 (ExceptNotAnError@{Error}))
+      {
+        write flat/7/simpflat/122 = ExceptNotAnError@{Error};
+        write flat/7/simpflat/123 = conv/11/aval/1/simpflat/54;
+        write flat/7/simpflat/124 = 1.0@{Double};
+      }
+      else
+      {
+        write flat/7/simpflat/122 = conv/11/aval/1/simpflat/53;
+        write flat/7/simpflat/123 = 0.0@{Double};
+        write flat/7/simpflat/124 = 0.0@{Double};
+      }
+      read flat/7/simpflat/125 = flat/7/simpflat/122 [Error];
+      read flat/7/simpflat/126 = flat/7/simpflat/123 [Double];
+      read flat/7/simpflat/127 = flat/7/simpflat/124 [Double];
+      write flat/6/simpflat/119 = flat/7/simpflat/125;
+      write flat/6/simpflat/120 = flat/7/simpflat/126;
+      write flat/6/simpflat/121 = flat/7/simpflat/127;
+    }
+    else
+    {
+      write flat/6/simpflat/119 = s/reify/6/conv/12/aval/0/simpflat/59;
+      write flat/6/simpflat/120 = 0.0@{Double};
+      write flat/6/simpflat/121 = 0.0@{Double};
+    }
+    read flat/6/simpflat/128 = flat/6/simpflat/119 [Error];
+    read flat/6/simpflat/129 = flat/6/simpflat/120 [Double];
+    read flat/6/simpflat/130 = flat/6/simpflat/121 [Double];
+    write flat/3/simpflat/62 = flat/6/simpflat/128;
+    write flat/3/simpflat/63 = flat/6/simpflat/129;
+    write flat/3/simpflat/64 = flat/6/simpflat/130;
+  }
+  read flat/3/simpflat/131 = flat/3/simpflat/62 [Error];
+  read flat/3/simpflat/132 = flat/3/simpflat/63 [Double];
+  read flat/3/simpflat/133 = flat/3/simpflat/64 [Double];
+  write acc/s/reify/6/conv/12/simpflat/28 = flat/3/simpflat/131;
+  write acc/s/reify/6/conv/12/simpflat/29 = flat/3/simpflat/132;
+  write acc/s/reify/6/conv/12/simpflat/30 = flat/3/simpflat/133;
+  init flat/36/simpflat/134@{Error} = ExceptNotAnError@{Error};
+  init flat/36/simpflat/135@{String} = ""@{String};
+  if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
+  {
+    write flat/36/simpflat/134 = ExceptNotAnError@{Error};
+    write flat/36/simpflat/135 = conv/0/simpflat/308;
+  }
+  else
+  {
+    write flat/36/simpflat/134 = conv/0/simpflat/307;
+    write flat/36/simpflat/135 = ""@{String};
+  }
+  read flat/36/simpflat/136 = flat/36/simpflat/134 [Error];
+  read flat/36/simpflat/137 = flat/36/simpflat/135 [String];
+  init flat/37/simpflat/138@{Error} = ExceptNotAnError@{Error};
+  init flat/37/simpflat/139@{Bool} = False@{Bool};
+  if (eq#@{Error} flat/36/simpflat/136 (ExceptNotAnError@{Error}))
+  {
+    write flat/37/simpflat/138 = ExceptNotAnError@{Error};
+    write flat/37/simpflat/139 = eq#@{String} flat/36/simpflat/137 ("torso"@{String});
+  }
+  else
+  {
+    write flat/37/simpflat/138 = flat/36/simpflat/136;
+    write flat/37/simpflat/139 = False@{Bool};
+  }
+  read flat/37/simpflat/140 = flat/37/simpflat/138 [Error];
+  read flat/37/simpflat/141 = flat/37/simpflat/139 [Bool];
+  init flat/38@{Bool} = False@{Bool};
+  if (eq#@{Error} flat/37/simpflat/140 (ExceptNotAnError@{Error}))
+  {
+    write flat/38 = flat/37/simpflat/141;
+  }
+  else
+  {
+    write flat/38 = True@{Bool};
+  }
+  read flat/38 = flat/38 [Bool];
+  if (flat/38)
+  {
+    init flat/39/simpflat/142@{Error} = ExceptNotAnError@{Error};
+    init flat/39/simpflat/143@{Int} = 0@{Int};
+    if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
+    {
+      write flat/39/simpflat/142 = ExceptNotAnError@{Error};
+      write flat/39/simpflat/143 = conv/0/simpflat/309;
+    }
+    else
+    {
+      write flat/39/simpflat/142 = conv/0/simpflat/307;
+      write flat/39/simpflat/143 = 0@{Int};
+    }
+    read flat/39/simpflat/144 = flat/39/simpflat/142 [Error];
+    read flat/39/simpflat/145 = flat/39/simpflat/143 [Int];
+    init flat/40/simpflat/146@{Error} = ExceptNotAnError@{Error};
+    init flat/40/simpflat/147@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat/39/simpflat/144 (ExceptNotAnError@{Error}))
+    {
+      write flat/40/simpflat/146 = ExceptNotAnError@{Error};
+      write flat/40/simpflat/147 = doubleOfInt# flat/39/simpflat/145;
+    }
+    else
+    {
+      write flat/40/simpflat/146 = flat/39/simpflat/144;
+      write flat/40/simpflat/147 = 0.0@{Double};
+    }
+    read flat/40/simpflat/148 = flat/40/simpflat/146 [Error];
+    read flat/40/simpflat/149 = flat/40/simpflat/147 [Double];
+    write acc/conv/76/simpflat/31 = flat/40/simpflat/148;
+    write acc/conv/76/simpflat/32 = flat/40/simpflat/149;
+    read conv/76/aval/3/simpflat/150 = acc/conv/76/simpflat/31 [Error];
+    read conv/76/aval/3/simpflat/151 = acc/conv/76/simpflat/32 [Double];
+    read a/conv/77/aval/2/simpflat/156 = acc/a/conv/77/simpflat/37 [Error];
+    read a/conv/77/aval/2/simpflat/157 = acc/a/conv/77/simpflat/38 [Double];
+    read a/conv/77/aval/2/simpflat/158 = acc/a/conv/77/simpflat/39 [Double];
+    read a/conv/77/aval/2/simpflat/159 = acc/a/conv/77/simpflat/40 [Double];
+    init flat/41/simpflat/160@{Error} = ExceptNotAnError@{Error};
+    init flat/41/simpflat/161@{Double} = 0.0@{Double};
+    init flat/41/simpflat/162@{Double} = 0.0@{Double};
+    init flat/41/simpflat/163@{Double} = 0.0@{Double};
+    if (eq#@{Error} a/conv/77/aval/2/simpflat/156 (ExceptNotAnError@{Error}))
+    {
+      let conv/84 = add#@{Double} a/conv/77/aval/2/simpflat/157 (1.0@{Double});
+      init flat/44/simpflat/164@{Error} = ExceptNotAnError@{Error};
+      init flat/44/simpflat/165@{Double} = 0.0@{Double};
+      if (doubleIsValid# conv/84)
+      {
+        write flat/44/simpflat/164 = ExceptNotAnError@{Error};
+        write flat/44/simpflat/165 = add#@{Double} a/conv/77/aval/2/simpflat/157 (1.0@{Double});
+      }
+      else
+      {
+        write flat/44/simpflat/164 = ExceptCannotCompute@{Error};
+        write flat/44/simpflat/165 = 0.0@{Double};
+      }
+      read flat/44/simpflat/166 = flat/44/simpflat/164 [Error];
+      read flat/44/simpflat/167 = flat/44/simpflat/165 [Double];
+      init flat/45/simpflat/168@{Error} = ExceptNotAnError@{Error};
+      init flat/45/simpflat/169@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/76/aval/3/simpflat/150 (ExceptNotAnError@{Error}))
+      {
+        let conv/89 = sub#@{Double} conv/76/aval/3/simpflat/151 a/conv/77/aval/2/simpflat/158;
+        init flat/89/simpflat/170@{Error} = ExceptNotAnError@{Error};
+        init flat/89/simpflat/171@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/89)
+        {
+          write flat/89/simpflat/170 = ExceptNotAnError@{Error};
+          write flat/89/simpflat/171 = sub#@{Double} conv/76/aval/3/simpflat/151 a/conv/77/aval/2/simpflat/158;
+        }
+        else
+        {
+          write flat/89/simpflat/170 = ExceptCannotCompute@{Error};
+          write flat/89/simpflat/171 = 0.0@{Double};
+        }
+        read flat/89/simpflat/172 = flat/89/simpflat/170 [Error];
+        read flat/89/simpflat/173 = flat/89/simpflat/171 [Double];
+        write flat/45/simpflat/168 = flat/89/simpflat/172;
+        write flat/45/simpflat/169 = flat/89/simpflat/173;
+      }
+      else
+      {
+        write flat/45/simpflat/168 = conv/76/aval/3/simpflat/150;
+        write flat/45/simpflat/169 = 0.0@{Double};
+      }
+      read flat/45/simpflat/174 = flat/45/simpflat/168 [Error];
+      read flat/45/simpflat/175 = flat/45/simpflat/169 [Double];
+      init flat/46/simpflat/176@{Error} = ExceptNotAnError@{Error};
+      init flat/46/simpflat/177@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/45/simpflat/174 (ExceptNotAnError@{Error}))
+      {
+        init flat/83/simpflat/178@{Error} = ExceptNotAnError@{Error};
+        init flat/83/simpflat/179@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/44/simpflat/166 (ExceptNotAnError@{Error}))
+        {
+          let conv/97 = div# flat/45/simpflat/175 flat/44/simpflat/167;
+          init flat/86/simpflat/180@{Error} = ExceptNotAnError@{Error};
+          init flat/86/simpflat/181@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/97)
+          {
+            write flat/86/simpflat/180 = ExceptNotAnError@{Error};
+            write flat/86/simpflat/181 = div# flat/45/simpflat/175 flat/44/simpflat/167;
+          }
+          else
+          {
+            write flat/86/simpflat/180 = ExceptCannotCompute@{Error};
+            write flat/86/simpflat/181 = 0.0@{Double};
+          }
+          read flat/86/simpflat/182 = flat/86/simpflat/180 [Error];
+          read flat/86/simpflat/183 = flat/86/simpflat/181 [Double];
+          write flat/83/simpflat/178 = flat/86/simpflat/182;
+          write flat/83/simpflat/179 = flat/86/simpflat/183;
+        }
+        else
+        {
+          write flat/83/simpflat/178 = flat/44/simpflat/166;
+          write flat/83/simpflat/179 = 0.0@{Double};
+        }
+        read flat/83/simpflat/184 = flat/83/simpflat/178 [Error];
+        read flat/83/simpflat/185 = flat/83/simpflat/179 [Double];
+        write flat/46/simpflat/176 = flat/83/simpflat/184;
+        write flat/46/simpflat/177 = flat/83/simpflat/185;
+      }
+      else
+      {
+        write flat/46/simpflat/176 = flat/45/simpflat/174;
+        write flat/46/simpflat/177 = 0.0@{Double};
+      }
+      read flat/46/simpflat/186 = flat/46/simpflat/176 [Error];
+      read flat/46/simpflat/187 = flat/46/simpflat/177 [Double];
+      init flat/47/simpflat/188@{Error} = ExceptNotAnError@{Error};
+      init flat/47/simpflat/189@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/46/simpflat/186 (ExceptNotAnError@{Error}))
+      {
+        let conv/103 = add#@{Double} a/conv/77/aval/2/simpflat/158 flat/46/simpflat/187;
+        init flat/80/simpflat/190@{Error} = ExceptNotAnError@{Error};
+        init flat/80/simpflat/191@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/103)
+        {
+          write flat/80/simpflat/190 = ExceptNotAnError@{Error};
+          write flat/80/simpflat/191 = add#@{Double} a/conv/77/aval/2/simpflat/158 flat/46/simpflat/187;
+        }
+        else
+        {
+          write flat/80/simpflat/190 = ExceptCannotCompute@{Error};
+          write flat/80/simpflat/191 = 0.0@{Double};
+        }
+        read flat/80/simpflat/192 = flat/80/simpflat/190 [Error];
+        read flat/80/simpflat/193 = flat/80/simpflat/191 [Double];
+        write flat/47/simpflat/188 = flat/80/simpflat/192;
+        write flat/47/simpflat/189 = flat/80/simpflat/193;
+      }
+      else
+      {
+        write flat/47/simpflat/188 = flat/46/simpflat/186;
+        write flat/47/simpflat/189 = 0.0@{Double};
+      }
+      read flat/47/simpflat/194 = flat/47/simpflat/188 [Error];
+      read flat/47/simpflat/195 = flat/47/simpflat/189 [Double];
+      init flat/48/simpflat/196@{Error} = ExceptNotAnError@{Error};
+      init flat/48/simpflat/197@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/45/simpflat/174 (ExceptNotAnError@{Error}))
+      {
+        init flat/67/simpflat/198@{Error} = ExceptNotAnError@{Error};
+        init flat/67/simpflat/199@{Double} = 0.0@{Double};
+        if (eq#@{Error} conv/76/aval/3/simpflat/150 (ExceptNotAnError@{Error}))
+        {
+          init flat/74/simpflat/200@{Error} = ExceptNotAnError@{Error};
+          init flat/74/simpflat/201@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat/47/simpflat/194 (ExceptNotAnError@{Error}))
+          {
+            let conv/113 = sub#@{Double} conv/76/aval/3/simpflat/151 flat/47/simpflat/195;
+            init flat/77/simpflat/202@{Error} = ExceptNotAnError@{Error};
+            init flat/77/simpflat/203@{Double} = 0.0@{Double};
+            if (doubleIsValid# conv/113)
+            {
+              write flat/77/simpflat/202 = ExceptNotAnError@{Error};
+              write flat/77/simpflat/203 = sub#@{Double} conv/76/aval/3/simpflat/151 flat/47/simpflat/195;
+            }
+            else
+            {
+              write flat/77/simpflat/202 = ExceptCannotCompute@{Error};
+              write flat/77/simpflat/203 = 0.0@{Double};
+            }
+            read flat/77/simpflat/204 = flat/77/simpflat/202 [Error];
+            read flat/77/simpflat/205 = flat/77/simpflat/203 [Double];
+            write flat/74/simpflat/200 = flat/77/simpflat/204;
+            write flat/74/simpflat/201 = flat/77/simpflat/205;
+          }
+          else
+          {
+            write flat/74/simpflat/200 = flat/47/simpflat/194;
+            write flat/74/simpflat/201 = 0.0@{Double};
+          }
+          read flat/74/simpflat/206 = flat/74/simpflat/200 [Error];
+          read flat/74/simpflat/207 = flat/74/simpflat/201 [Double];
+          write flat/67/simpflat/198 = flat/74/simpflat/206;
+          write flat/67/simpflat/199 = flat/74/simpflat/207;
+        }
+        else
+        {
+          write flat/67/simpflat/198 = conv/76/aval/3/simpflat/150;
+          write flat/67/simpflat/199 = 0.0@{Double};
+        }
+        read flat/67/simpflat/208 = flat/67/simpflat/198 [Error];
+        read flat/67/simpflat/209 = flat/67/simpflat/199 [Double];
+        init flat/68/simpflat/210@{Error} = ExceptNotAnError@{Error};
+        init flat/68/simpflat/211@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/67/simpflat/208 (ExceptNotAnError@{Error}))
+        {
+          let conv/119 = mul#@{Double} flat/45/simpflat/175 flat/67/simpflat/209;
+          init flat/71/simpflat/212@{Error} = ExceptNotAnError@{Error};
+          init flat/71/simpflat/213@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/119)
+          {
+            write flat/71/simpflat/212 = ExceptNotAnError@{Error};
+            write flat/71/simpflat/213 = mul#@{Double} flat/45/simpflat/175 flat/67/simpflat/209;
+          }
+          else
+          {
+            write flat/71/simpflat/212 = ExceptCannotCompute@{Error};
+            write flat/71/simpflat/213 = 0.0@{Double};
+          }
+          read flat/71/simpflat/214 = flat/71/simpflat/212 [Error];
+          read flat/71/simpflat/215 = flat/71/simpflat/213 [Double];
+          write flat/68/simpflat/210 = flat/71/simpflat/214;
+          write flat/68/simpflat/211 = flat/71/simpflat/215;
+        }
+        else
+        {
+          write flat/68/simpflat/210 = flat/67/simpflat/208;
+          write flat/68/simpflat/211 = 0.0@{Double};
+        }
+        read flat/68/simpflat/216 = flat/68/simpflat/210 [Error];
+        read flat/68/simpflat/217 = flat/68/simpflat/211 [Double];
+        write flat/48/simpflat/196 = flat/68/simpflat/216;
+        write flat/48/simpflat/197 = flat/68/simpflat/217;
+      }
+      else
+      {
+        write flat/48/simpflat/196 = flat/45/simpflat/174;
+        write flat/48/simpflat/197 = 0.0@{Double};
+      }
+      read flat/48/simpflat/218 = flat/48/simpflat/196 [Error];
+      read flat/48/simpflat/219 = flat/48/simpflat/197 [Double];
+      init flat/49/simpflat/220@{Error} = ExceptNotAnError@{Error};
+      init flat/49/simpflat/221@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/48/simpflat/218 (ExceptNotAnError@{Error}))
+      {
+        let conv/125 = add#@{Double} a/conv/77/aval/2/simpflat/159 flat/48/simpflat/219;
+        init flat/64/simpflat/222@{Error} = ExceptNotAnError@{Error};
+        init flat/64/simpflat/223@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/125)
+        {
+          write flat/64/simpflat/222 = ExceptNotAnError@{Error};
+          write flat/64/simpflat/223 = add#@{Double} a/conv/77/aval/2/simpflat/159 flat/48/simpflat/219;
+        }
+        else
+        {
+          write flat/64/simpflat/222 = ExceptCannotCompute@{Error};
+          write flat/64/simpflat/223 = 0.0@{Double};
+        }
+        read flat/64/simpflat/224 = flat/64/simpflat/222 [Error];
+        read flat/64/simpflat/225 = flat/64/simpflat/223 [Double];
+        write flat/49/simpflat/220 = flat/64/simpflat/224;
+        write flat/49/simpflat/221 = flat/64/simpflat/225;
+      }
+      else
+      {
+        write flat/49/simpflat/220 = flat/48/simpflat/218;
+        write flat/49/simpflat/221 = 0.0@{Double};
+      }
+      read flat/49/simpflat/226 = flat/49/simpflat/220 [Error];
+      read flat/49/simpflat/227 = flat/49/simpflat/221 [Double];
+      init flat/50/simpflat/228@{Error} = ExceptNotAnError@{Error};
+      init flat/50/simpflat/229@{Double} = 0.0@{Double};
+      init flat/50/simpflat/230@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/44/simpflat/166 (ExceptNotAnError@{Error}))
+      {
+        init flat/59/simpflat/231@{Error} = ExceptNotAnError@{Error};
+        init flat/59/simpflat/232@{Double} = 0.0@{Double};
+        init flat/59/simpflat/233@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/47/simpflat/194 (ExceptNotAnError@{Error}))
+        {
+          write flat/59/simpflat/231 = ExceptNotAnError@{Error};
+          write flat/59/simpflat/232 = flat/44/simpflat/167;
+          write flat/59/simpflat/233 = flat/47/simpflat/195;
+        }
+        else
+        {
+          write flat/59/simpflat/231 = flat/47/simpflat/194;
+          write flat/59/simpflat/232 = 0.0@{Double};
+          write flat/59/simpflat/233 = 0.0@{Double};
+        }
+        read flat/59/simpflat/234 = flat/59/simpflat/231 [Error];
+        read flat/59/simpflat/235 = flat/59/simpflat/232 [Double];
+        read flat/59/simpflat/236 = flat/59/simpflat/233 [Double];
+        write flat/50/simpflat/228 = flat/59/simpflat/234;
+        write flat/50/simpflat/229 = flat/59/simpflat/235;
+        write flat/50/simpflat/230 = flat/59/simpflat/236;
+      }
+      else
+      {
+        write flat/50/simpflat/228 = flat/44/simpflat/166;
+        write flat/50/simpflat/229 = 0.0@{Double};
+        write flat/50/simpflat/230 = 0.0@{Double};
+      }
+      read flat/50/simpflat/237 = flat/50/simpflat/228 [Error];
+      read flat/50/simpflat/238 = flat/50/simpflat/229 [Double];
+      read flat/50/simpflat/239 = flat/50/simpflat/230 [Double];
+      init flat/51/simpflat/240@{Error} = ExceptNotAnError@{Error};
+      init flat/51/simpflat/241@{Double} = 0.0@{Double};
+      init flat/51/simpflat/242@{Double} = 0.0@{Double};
+      init flat/51/simpflat/243@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/50/simpflat/237 (ExceptNotAnError@{Error}))
+      {
+        init flat/54/simpflat/244@{Error} = ExceptNotAnError@{Error};
+        init flat/54/simpflat/245@{Double} = 0.0@{Double};
+        init flat/54/simpflat/246@{Double} = 0.0@{Double};
+        init flat/54/simpflat/247@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/49/simpflat/226 (ExceptNotAnError@{Error}))
+        {
+          write flat/54/simpflat/244 = ExceptNotAnError@{Error};
+          write flat/54/simpflat/245 = flat/50/simpflat/238;
+          write flat/54/simpflat/246 = flat/50/simpflat/239;
+          write flat/54/simpflat/247 = flat/49/simpflat/227;
+        }
+        else
+        {
+          write flat/54/simpflat/244 = flat/49/simpflat/226;
+          write flat/54/simpflat/245 = 0.0@{Double};
+          write flat/54/simpflat/246 = 0.0@{Double};
+          write flat/54/simpflat/247 = 0.0@{Double};
+        }
+        read flat/54/simpflat/248 = flat/54/simpflat/244 [Error];
+        read flat/54/simpflat/249 = flat/54/simpflat/245 [Double];
+        read flat/54/simpflat/250 = flat/54/simpflat/246 [Double];
+        read flat/54/simpflat/251 = flat/54/simpflat/247 [Double];
+        write flat/51/simpflat/240 = flat/54/simpflat/248;
+        write flat/51/simpflat/241 = flat/54/simpflat/249;
+        write flat/51/simpflat/242 = flat/54/simpflat/250;
+        write flat/51/simpflat/243 = flat/54/simpflat/251;
+      }
+      else
+      {
+        write flat/51/simpflat/240 = flat/50/simpflat/237;
+        write flat/51/simpflat/241 = 0.0@{Double};
+        write flat/51/simpflat/242 = 0.0@{Double};
+        write flat/51/simpflat/243 = 0.0@{Double};
+      }
+      read flat/51/simpflat/252 = flat/51/simpflat/240 [Error];
+      read flat/51/simpflat/253 = flat/51/simpflat/241 [Double];
+      read flat/51/simpflat/254 = flat/51/simpflat/242 [Double];
+      read flat/51/simpflat/255 = flat/51/simpflat/243 [Double];
+      write flat/41/simpflat/160 = flat/51/simpflat/252;
+      write flat/41/simpflat/161 = flat/51/simpflat/253;
+      write flat/41/simpflat/162 = flat/51/simpflat/254;
+      write flat/41/simpflat/163 = flat/51/simpflat/255;
+    }
+    else
+    {
+      write flat/41/simpflat/160 = a/conv/77/aval/2/simpflat/156;
+      write flat/41/simpflat/161 = 0.0@{Double};
+      write flat/41/simpflat/162 = 0.0@{Double};
+      write flat/41/simpflat/163 = 0.0@{Double};
+    }
+    read flat/41/simpflat/256 = flat/41/simpflat/160 [Error];
+    read flat/41/simpflat/257 = flat/41/simpflat/161 [Double];
+    read flat/41/simpflat/258 = flat/41/simpflat/162 [Double];
+    read flat/41/simpflat/259 = flat/41/simpflat/163 [Double];
+    write acc/a/conv/77/simpflat/37 = flat/41/simpflat/256;
+    write acc/a/conv/77/simpflat/38 = flat/41/simpflat/257;
+    write acc/a/conv/77/simpflat/39 = flat/41/simpflat/258;
+    write acc/a/conv/77/simpflat/40 = flat/41/simpflat/259;
   }
 }
-save_resumable@{Error} acc/a/conv/61/simpflat/48;
-save_resumable@{Double} acc/a/conv/61/simpflat/49;
-save_resumable@{Double} acc/a/conv/61/simpflat/50;
-save_resumable@{Double} acc/a/conv/61/simpflat/51;
-save_resumable@{Error} acc/conv/60/simpflat/42;
-save_resumable@{Double} acc/conv/60/simpflat/43;
-save_resumable@{Error} acc/s/reify/6/conv/12/simpflat/39;
-save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/40;
-save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/41;
-save_resumable@{Error} acc/conv/11/simpflat/33;
-save_resumable@{Double} acc/conv/11/simpflat/34;
-read a/conv/61/simpflat/203 = acc/a/conv/61/simpflat/48 [Error];
-read a/conv/61/simpflat/204 = acc/a/conv/61/simpflat/49 [Double];
-read a/conv/61/simpflat/206 = acc/a/conv/61/simpflat/51 [Double];
-read s/reify/6/conv/12/simpflat/207 = acc/s/reify/6/conv/12/simpflat/39 [Error];
-read s/reify/6/conv/12/simpflat/208 = acc/s/reify/6/conv/12/simpflat/40 [Double];
-init flat/86/simpflat/210@{Error} = ExceptNotAnError@{Error};
-init flat/86/simpflat/211@{Double} = 0.0@{Double};
-if (eq#@{Error} s/reify/6/conv/12/simpflat/207 (ExceptNotAnError@{Error}))
+save_resumable@{Error} acc/a/conv/77/simpflat/37;
+save_resumable@{Double} acc/a/conv/77/simpflat/38;
+save_resumable@{Double} acc/a/conv/77/simpflat/39;
+save_resumable@{Double} acc/a/conv/77/simpflat/40;
+save_resumable@{Error} acc/conv/76/simpflat/31;
+save_resumable@{Double} acc/conv/76/simpflat/32;
+save_resumable@{Error} acc/s/reify/6/conv/12/simpflat/28;
+save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/29;
+save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/30;
+save_resumable@{Error} acc/conv/11/simpflat/22;
+save_resumable@{Double} acc/conv/11/simpflat/23;
+read a/conv/77/simpflat/260 = acc/a/conv/77/simpflat/37 [Error];
+read a/conv/77/simpflat/261 = acc/a/conv/77/simpflat/38 [Double];
+read a/conv/77/simpflat/263 = acc/a/conv/77/simpflat/40 [Double];
+read s/reify/6/conv/12/simpflat/264 = acc/s/reify/6/conv/12/simpflat/28 [Error];
+read s/reify/6/conv/12/simpflat/265 = acc/s/reify/6/conv/12/simpflat/29 [Double];
+init flat/110/simpflat/267@{Error} = ExceptNotAnError@{Error};
+init flat/110/simpflat/268@{Double} = 0.0@{Double};
+if (eq#@{Error} s/reify/6/conv/12/simpflat/264 (ExceptNotAnError@{Error}))
 {
-  write flat/86/simpflat/210 = ExceptNotAnError@{Error};
-  write flat/86/simpflat/211 = s/reify/6/conv/12/simpflat/208;
+  write flat/110/simpflat/267 = ExceptNotAnError@{Error};
+  write flat/110/simpflat/268 = s/reify/6/conv/12/simpflat/265;
 }
 else
 {
-  write flat/86/simpflat/210 = s/reify/6/conv/12/simpflat/207;
-  write flat/86/simpflat/211 = 0.0@{Double};
+  write flat/110/simpflat/267 = s/reify/6/conv/12/simpflat/264;
+  write flat/110/simpflat/268 = 0.0@{Double};
 }
-read flat/86/simpflat/212 = flat/86/simpflat/210 [Error];
-read flat/86/simpflat/213 = flat/86/simpflat/211 [Double];
-init flat/87/simpflat/214@{Error} = ExceptNotAnError@{Error};
-init flat/87/simpflat/215@{Double} = 0.0@{Double};
-if (eq#@{Error} flat/86/simpflat/212 (ExceptNotAnError@{Error}))
+read flat/110/simpflat/269 = flat/110/simpflat/267 [Error];
+read flat/110/simpflat/270 = flat/110/simpflat/268 [Double];
+init flat/111/simpflat/271@{Error} = ExceptNotAnError@{Error};
+init flat/111/simpflat/272@{Double} = 0.0@{Double};
+if (eq#@{Error} flat/110/simpflat/269 (ExceptNotAnError@{Error}))
 {
-  init flat/90/simpflat/216@{Error} = ExceptNotAnError@{Error};
-  init flat/90/simpflat/217@{Double} = 0.0@{Double};
-  if (eq#@{Error} a/conv/61/simpflat/203 (ExceptNotAnError@{Error}))
+  init flat/114/simpflat/273@{Error} = ExceptNotAnError@{Error};
+  init flat/114/simpflat/274@{Double} = 0.0@{Double};
+  if (eq#@{Error} a/conv/77/simpflat/260 (ExceptNotAnError@{Error}))
   {
-    let conv/116 = sub#@{Double} a/conv/61/simpflat/204 (1.0@{Double});
-    let simpflat/638 = div# a/conv/61/simpflat/206 conv/116;
-    write flat/90/simpflat/216 = ExceptNotAnError@{Error};
-    write flat/90/simpflat/217 = simpflat/638;
+    let conv/152 = sub#@{Double} a/conv/77/simpflat/261 (1.0@{Double});
+    init flat/125/simpflat/275@{Error} = ExceptNotAnError@{Error};
+    init flat/125/simpflat/276@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/152)
+    {
+      write flat/125/simpflat/275 = ExceptNotAnError@{Error};
+      write flat/125/simpflat/276 = sub#@{Double} a/conv/77/simpflat/261 (1.0@{Double});
+    }
+    else
+    {
+      write flat/125/simpflat/275 = ExceptCannotCompute@{Error};
+      write flat/125/simpflat/276 = 0.0@{Double};
+    }
+    read flat/125/simpflat/277 = flat/125/simpflat/275 [Error];
+    read flat/125/simpflat/278 = flat/125/simpflat/276 [Double];
+    init flat/126/simpflat/279@{Error} = ExceptNotAnError@{Error};
+    init flat/126/simpflat/280@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat/125/simpflat/277 (ExceptNotAnError@{Error}))
+    {
+      let conv/158 = div# a/conv/77/simpflat/263 flat/125/simpflat/278;
+      init flat/129/simpflat/281@{Error} = ExceptNotAnError@{Error};
+      init flat/129/simpflat/282@{Double} = 0.0@{Double};
+      if (doubleIsValid# conv/158)
+      {
+        write flat/129/simpflat/281 = ExceptNotAnError@{Error};
+        write flat/129/simpflat/282 = div# a/conv/77/simpflat/263 flat/125/simpflat/278;
+      }
+      else
+      {
+        write flat/129/simpflat/281 = ExceptCannotCompute@{Error};
+        write flat/129/simpflat/282 = 0.0@{Double};
+      }
+      read flat/129/simpflat/283 = flat/129/simpflat/281 [Error];
+      read flat/129/simpflat/284 = flat/129/simpflat/282 [Double];
+      write flat/126/simpflat/279 = flat/129/simpflat/283;
+      write flat/126/simpflat/280 = flat/129/simpflat/284;
+    }
+    else
+    {
+      write flat/126/simpflat/279 = flat/125/simpflat/277;
+      write flat/126/simpflat/280 = 0.0@{Double};
+    }
+    read flat/126/simpflat/285 = flat/126/simpflat/279 [Error];
+    read flat/126/simpflat/286 = flat/126/simpflat/280 [Double];
+    write flat/114/simpflat/273 = flat/126/simpflat/285;
+    write flat/114/simpflat/274 = flat/126/simpflat/286;
   }
   else
   {
-    write flat/90/simpflat/216 = a/conv/61/simpflat/203;
-    write flat/90/simpflat/217 = 0.0@{Double};
+    write flat/114/simpflat/273 = a/conv/77/simpflat/260;
+    write flat/114/simpflat/274 = 0.0@{Double};
   }
-  read flat/90/simpflat/218 = flat/90/simpflat/216 [Error];
-  read flat/90/simpflat/219 = flat/90/simpflat/217 [Double];
-  init flat/91/simpflat/220@{Error} = ExceptNotAnError@{Error};
-  init flat/91/simpflat/221@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/90/simpflat/218 (ExceptNotAnError@{Error}))
+  read flat/114/simpflat/287 = flat/114/simpflat/273 [Error];
+  read flat/114/simpflat/288 = flat/114/simpflat/274 [Double];
+  init flat/115/simpflat/289@{Error} = ExceptNotAnError@{Error};
+  init flat/115/simpflat/290@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/114/simpflat/287 (ExceptNotAnError@{Error}))
   {
-    write flat/91/simpflat/220 = ExceptNotAnError@{Error};
-    write flat/91/simpflat/221 = sqrt# flat/90/simpflat/219;
+    let conv/172 = sqrt# flat/114/simpflat/288;
+    init flat/122/simpflat/291@{Error} = ExceptNotAnError@{Error};
+    init flat/122/simpflat/292@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/172)
+    {
+      write flat/122/simpflat/291 = ExceptNotAnError@{Error};
+      write flat/122/simpflat/292 = sqrt# flat/114/simpflat/288;
+    }
+    else
+    {
+      write flat/122/simpflat/291 = ExceptCannotCompute@{Error};
+      write flat/122/simpflat/292 = 0.0@{Double};
+    }
+    read flat/122/simpflat/293 = flat/122/simpflat/291 [Error];
+    read flat/122/simpflat/294 = flat/122/simpflat/292 [Double];
+    write flat/115/simpflat/289 = flat/122/simpflat/293;
+    write flat/115/simpflat/290 = flat/122/simpflat/294;
   }
   else
   {
-    write flat/91/simpflat/220 = flat/90/simpflat/218;
-    write flat/91/simpflat/221 = 0.0@{Double};
+    write flat/115/simpflat/289 = flat/114/simpflat/287;
+    write flat/115/simpflat/290 = 0.0@{Double};
   }
-  read flat/91/simpflat/222 = flat/91/simpflat/220 [Error];
-  read flat/91/simpflat/223 = flat/91/simpflat/221 [Double];
-  init flat/92/simpflat/224@{Error} = ExceptNotAnError@{Error};
-  init flat/92/simpflat/225@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/91/simpflat/222 (ExceptNotAnError@{Error}))
+  read flat/115/simpflat/295 = flat/115/simpflat/289 [Error];
+  read flat/115/simpflat/296 = flat/115/simpflat/290 [Double];
+  init flat/116/simpflat/297@{Error} = ExceptNotAnError@{Error};
+  init flat/116/simpflat/298@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/115/simpflat/295 (ExceptNotAnError@{Error}))
   {
-    write flat/92/simpflat/224 = ExceptNotAnError@{Error};
-    write flat/92/simpflat/225 = mul#@{Double} flat/86/simpflat/213 flat/91/simpflat/223;
+    let conv/180 = mul#@{Double} flat/110/simpflat/270 flat/115/simpflat/296;
+    init flat/119/simpflat/299@{Error} = ExceptNotAnError@{Error};
+    init flat/119/simpflat/300@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/180)
+    {
+      write flat/119/simpflat/299 = ExceptNotAnError@{Error};
+      write flat/119/simpflat/300 = mul#@{Double} flat/110/simpflat/270 flat/115/simpflat/296;
+    }
+    else
+    {
+      write flat/119/simpflat/299 = ExceptCannotCompute@{Error};
+      write flat/119/simpflat/300 = 0.0@{Double};
+    }
+    read flat/119/simpflat/301 = flat/119/simpflat/299 [Error];
+    read flat/119/simpflat/302 = flat/119/simpflat/300 [Double];
+    write flat/116/simpflat/297 = flat/119/simpflat/301;
+    write flat/116/simpflat/298 = flat/119/simpflat/302;
   }
   else
   {
-    write flat/92/simpflat/224 = flat/91/simpflat/222;
-    write flat/92/simpflat/225 = 0.0@{Double};
+    write flat/116/simpflat/297 = flat/115/simpflat/295;
+    write flat/116/simpflat/298 = 0.0@{Double};
   }
-  read flat/92/simpflat/226 = flat/92/simpflat/224 [Error];
-  read flat/92/simpflat/227 = flat/92/simpflat/225 [Double];
-  write flat/87/simpflat/214 = flat/92/simpflat/226;
-  write flat/87/simpflat/215 = flat/92/simpflat/227;
+  read flat/116/simpflat/303 = flat/116/simpflat/297 [Error];
+  read flat/116/simpflat/304 = flat/116/simpflat/298 [Double];
+  write flat/111/simpflat/271 = flat/116/simpflat/303;
+  write flat/111/simpflat/272 = flat/116/simpflat/304;
 }
 else
 {
-  write flat/87/simpflat/214 = flat/86/simpflat/212;
-  write flat/87/simpflat/215 = 0.0@{Double};
+  write flat/111/simpflat/271 = flat/110/simpflat/269;
+  write flat/111/simpflat/272 = 0.0@{Double};
 }
-read flat/87/simpflat/228 = flat/87/simpflat/214 [Error];
-read flat/87/simpflat/229 = flat/87/simpflat/215 [Double];
-output@{(Sum Error Double)} repl:output (flat/87/simpflat/228@{Error}, flat/87/simpflat/229@{Double});
+read flat/111/simpflat/305 = flat/111/simpflat/271 [Error];
+read flat/111/simpflat/306 = flat/111/simpflat/272 [Double];
+output@{(Sum Error Double)} repl:output (flat/111/simpflat/305@{Error}, flat/111/simpflat/306@{Double});
 
 - Flattened Avalanche (simplified), typechecked:
 conv/3 = TIME
 conv/4 = MAX_MAP_SIZE
-init acc/conv/11/simpflat/33@{Error} = ExceptNotAnError@{Error};
-init acc/conv/11/simpflat/34@{Double} = 0.0@{Double};
-init acc/s/reify/6/conv/12/simpflat/39@{Error} = ExceptFold1NoValue@{Error};
-init acc/s/reify/6/conv/12/simpflat/40@{Double} = 0.0@{Double};
-init acc/s/reify/6/conv/12/simpflat/41@{Double} = 0.0@{Double};
-init acc/conv/60/simpflat/42@{Error} = ExceptNotAnError@{Error};
-init acc/conv/60/simpflat/43@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/48@{Error} = ExceptNotAnError@{Error};
-init acc/a/conv/61/simpflat/49@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/50@{Double} = 0.0@{Double};
-init acc/a/conv/61/simpflat/51@{Double} = 0.0@{Double};
-load_resumable@{Error} acc/a/conv/61/simpflat/48;
-load_resumable@{Double} acc/a/conv/61/simpflat/49;
-load_resumable@{Double} acc/a/conv/61/simpflat/50;
-load_resumable@{Double} acc/a/conv/61/simpflat/51;
-load_resumable@{Error} acc/conv/60/simpflat/42;
-load_resumable@{Double} acc/conv/60/simpflat/43;
-load_resumable@{Error} acc/s/reify/6/conv/12/simpflat/39;
-load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/40;
-load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/41;
-load_resumable@{Error} acc/conv/11/simpflat/33;
-load_resumable@{Double} acc/conv/11/simpflat/34;
-for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/230@{Error}, conv/0/simpflat/231@{String}, conv/0/simpflat/232@{Int}, conv/0/simpflat/233@{Time}) in new
+init acc/conv/11/simpflat/22@{Error} = ExceptNotAnError@{Error};
+init acc/conv/11/simpflat/23@{Double} = 0.0@{Double};
+init acc/s/reify/6/conv/12/simpflat/28@{Error} = ExceptFold1NoValue@{Error};
+init acc/s/reify/6/conv/12/simpflat/29@{Double} = 0.0@{Double};
+init acc/s/reify/6/conv/12/simpflat/30@{Double} = 0.0@{Double};
+init acc/conv/76/simpflat/31@{Error} = ExceptNotAnError@{Error};
+init acc/conv/76/simpflat/32@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/37@{Error} = ExceptNotAnError@{Error};
+init acc/a/conv/77/simpflat/38@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/39@{Double} = 0.0@{Double};
+init acc/a/conv/77/simpflat/40@{Double} = 0.0@{Double};
+load_resumable@{Error} acc/a/conv/77/simpflat/37;
+load_resumable@{Double} acc/a/conv/77/simpflat/38;
+load_resumable@{Double} acc/a/conv/77/simpflat/39;
+load_resumable@{Double} acc/a/conv/77/simpflat/40;
+load_resumable@{Error} acc/conv/76/simpflat/31;
+load_resumable@{Double} acc/conv/76/simpflat/32;
+load_resumable@{Error} acc/s/reify/6/conv/12/simpflat/28;
+load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/29;
+load_resumable@{Double} acc/s/reify/6/conv/12/simpflat/30;
+load_resumable@{Error} acc/conv/11/simpflat/22;
+load_resumable@{Double} acc/conv/11/simpflat/23;
+for_facts (conv/2@{Time}, conv/1@{FactIdentifier}, conv/0/simpflat/307@{Error}, conv/0/simpflat/308@{String}, conv/0/simpflat/309@{Int}, conv/0/simpflat/310@{Time}) in new
 {
-  init flat/0/simpflat/52@{Error} = ExceptNotAnError@{Error};
-  init flat/0/simpflat/53@{Int} = 0@{Int};
-  if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+  init flat/0/simpflat/41@{Error} = ExceptNotAnError@{Error};
+  init flat/0/simpflat/42@{Int} = 0@{Int};
+  if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
   {
-    write flat/0/simpflat/52 = ExceptNotAnError@{Error};
-    write flat/0/simpflat/53 = conv/0/simpflat/232;
+    write flat/0/simpflat/41 = ExceptNotAnError@{Error};
+    write flat/0/simpflat/42 = conv/0/simpflat/309;
   }
   else
   {
-    write flat/0/simpflat/52 = conv/0/simpflat/230;
-    write flat/0/simpflat/53 = 0@{Int};
+    write flat/0/simpflat/41 = conv/0/simpflat/307;
+    write flat/0/simpflat/42 = 0@{Int};
   }
-  read flat/0/simpflat/54 = flat/0/simpflat/52 [Error];
-  read flat/0/simpflat/55 = flat/0/simpflat/53 [Int];
-  init flat/1/simpflat/56@{Error} = ExceptNotAnError@{Error};
-  init flat/1/simpflat/57@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/0/simpflat/54 (ExceptNotAnError@{Error}))
+  read flat/0/simpflat/43 = flat/0/simpflat/41 [Error];
+  read flat/0/simpflat/44 = flat/0/simpflat/42 [Int];
+  init flat/1/simpflat/45@{Error} = ExceptNotAnError@{Error};
+  init flat/1/simpflat/46@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/0/simpflat/43 (ExceptNotAnError@{Error}))
   {
-    write flat/1/simpflat/56 = ExceptNotAnError@{Error};
-    write flat/1/simpflat/57 = doubleOfInt# flat/0/simpflat/55;
-  }
-  else
-  {
-    write flat/1/simpflat/56 = flat/0/simpflat/54;
-    write flat/1/simpflat/57 = 0.0@{Double};
-  }
-  read flat/1/simpflat/58 = flat/1/simpflat/56 [Error];
-  read flat/1/simpflat/59 = flat/1/simpflat/57 [Double];
-  init flat/2/simpflat/60@{Error} = ExceptNotAnError@{Error};
-  init flat/2/simpflat/61@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/1/simpflat/58 (ExceptNotAnError@{Error}))
-  {
-    write flat/2/simpflat/60 = ExceptNotAnError@{Error};
-    write flat/2/simpflat/61 = flat/1/simpflat/59;
+    write flat/1/simpflat/45 = ExceptNotAnError@{Error};
+    write flat/1/simpflat/46 = doubleOfInt# flat/0/simpflat/44;
   }
   else
   {
-    write flat/2/simpflat/60 = flat/1/simpflat/58;
-    write flat/2/simpflat/61 = 0.0@{Double};
+    write flat/1/simpflat/45 = flat/0/simpflat/43;
+    write flat/1/simpflat/46 = 0.0@{Double};
   }
-  read flat/2/simpflat/62 = flat/2/simpflat/60 [Error];
-  read flat/2/simpflat/63 = flat/2/simpflat/61 [Double];
-  write acc/conv/11/simpflat/33 = flat/2/simpflat/62;
-  write acc/conv/11/simpflat/34 = flat/2/simpflat/63;
-  read conv/11/aval/1/simpflat/64 = acc/conv/11/simpflat/33 [Error];
-  read conv/11/aval/1/simpflat/65 = acc/conv/11/simpflat/34 [Double];
-  read s/reify/6/conv/12/aval/0/simpflat/70 = acc/s/reify/6/conv/12/simpflat/39 [Error];
-  read s/reify/6/conv/12/aval/0/simpflat/71 = acc/s/reify/6/conv/12/simpflat/40 [Double];
-  read s/reify/6/conv/12/aval/0/simpflat/72 = acc/s/reify/6/conv/12/simpflat/41 [Double];
-  init flat/3/simpflat/73@{Error} = ExceptNotAnError@{Error};
-  init flat/3/simpflat/74@{Double} = 0.0@{Double};
-  init flat/3/simpflat/75@{Double} = 0.0@{Double};
-  if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/70 (ExceptNotAnError@{Error}))
+  read flat/1/simpflat/47 = flat/1/simpflat/45 [Error];
+  read flat/1/simpflat/48 = flat/1/simpflat/46 [Double];
+  init flat/2/simpflat/49@{Error} = ExceptNotAnError@{Error};
+  init flat/2/simpflat/50@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/1/simpflat/47 (ExceptNotAnError@{Error}))
   {
-    init flat/10/simpflat/76@{Error} = ExceptNotAnError@{Error};
-    init flat/10/simpflat/77@{Double} = 0.0@{Double};
-    init flat/10/simpflat/78@{Double} = 0.0@{Double};
-    if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/70 (ExceptNotAnError@{Error}))
-    {
-      init flat/13/simpflat/79@{Error} = ExceptNotAnError@{Error};
-      init flat/13/simpflat/80@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/11/aval/1/simpflat/64 (ExceptNotAnError@{Error}))
-      {
-        write flat/13/simpflat/79 = ExceptNotAnError@{Error};
-        write flat/13/simpflat/80 = sub#@{Double} conv/11/aval/1/simpflat/65 s/reify/6/conv/12/aval/0/simpflat/71;
-      }
-      else
-      {
-        write flat/13/simpflat/79 = conv/11/aval/1/simpflat/64;
-        write flat/13/simpflat/80 = 0.0@{Double};
-      }
-      read flat/13/simpflat/81 = flat/13/simpflat/79 [Error];
-      read flat/13/simpflat/82 = flat/13/simpflat/80 [Double];
-      init flat/14/simpflat/83@{Error} = ExceptNotAnError@{Error};
-      init flat/14/simpflat/84@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/13/simpflat/81 (ExceptNotAnError@{Error}))
-      {
-        write flat/14/simpflat/83 = ExceptNotAnError@{Error};
-        let simpflat/285 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/72 (1.0@{Double});
-        write flat/14/simpflat/84 = div# flat/13/simpflat/82 simpflat/285;
-      }
-      else
-      {
-        write flat/14/simpflat/83 = flat/13/simpflat/81;
-        write flat/14/simpflat/84 = 0.0@{Double};
-      }
-      read flat/14/simpflat/85 = flat/14/simpflat/83 [Error];
-      read flat/14/simpflat/86 = flat/14/simpflat/84 [Double];
-      init flat/15/simpflat/87@{Error} = ExceptNotAnError@{Error};
-      init flat/15/simpflat/88@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/14/simpflat/85 (ExceptNotAnError@{Error}))
-      {
-        write flat/15/simpflat/87 = ExceptNotAnError@{Error};
-        write flat/15/simpflat/88 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/71 flat/14/simpflat/86;
-      }
-      else
-      {
-        write flat/15/simpflat/87 = flat/14/simpflat/85;
-        write flat/15/simpflat/88 = 0.0@{Double};
-      }
-      read flat/15/simpflat/89 = flat/15/simpflat/87 [Error];
-      read flat/15/simpflat/90 = flat/15/simpflat/88 [Double];
-      init flat/16/simpflat/91@{Error} = ExceptNotAnError@{Error};
-      init flat/16/simpflat/92@{Double} = 0.0@{Double};
-      init flat/16/simpflat/93@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/15/simpflat/89 (ExceptNotAnError@{Error}))
-      {
-        write flat/16/simpflat/91 = ExceptNotAnError@{Error};
-        write flat/16/simpflat/92 = flat/15/simpflat/90;
-        write flat/16/simpflat/93 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/72 (1.0@{Double});
-      }
-      else
-      {
-        write flat/16/simpflat/91 = flat/15/simpflat/89;
-        write flat/16/simpflat/92 = 0.0@{Double};
-        write flat/16/simpflat/93 = 0.0@{Double};
-      }
-      read flat/16/simpflat/94 = flat/16/simpflat/91 [Error];
-      read flat/16/simpflat/95 = flat/16/simpflat/92 [Double];
-      read flat/16/simpflat/96 = flat/16/simpflat/93 [Double];
-      write flat/10/simpflat/76 = flat/16/simpflat/94;
-      write flat/10/simpflat/77 = flat/16/simpflat/95;
-      write flat/10/simpflat/78 = flat/16/simpflat/96;
-    }
-    else
-    {
-      write flat/10/simpflat/76 = s/reify/6/conv/12/aval/0/simpflat/70;
-      write flat/10/simpflat/77 = 0.0@{Double};
-      write flat/10/simpflat/78 = 0.0@{Double};
-    }
-    read flat/10/simpflat/97 = flat/10/simpflat/76 [Error];
-    read flat/10/simpflat/98 = flat/10/simpflat/77 [Double];
-    read flat/10/simpflat/99 = flat/10/simpflat/78 [Double];
-    write flat/3/simpflat/73 = flat/10/simpflat/97;
-    write flat/3/simpflat/74 = flat/10/simpflat/98;
-    write flat/3/simpflat/75 = flat/10/simpflat/99;
+    write flat/2/simpflat/49 = ExceptNotAnError@{Error};
+    write flat/2/simpflat/50 = flat/1/simpflat/48;
   }
   else
   {
-    init flat/6/simpflat/100@{Error} = ExceptNotAnError@{Error};
-    init flat/6/simpflat/101@{Double} = 0.0@{Double};
-    init flat/6/simpflat/102@{Double} = 0.0@{Double};
-    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s/reify/6/conv/12/aval/0/simpflat/70)
-    {
-      init flat/7/simpflat/103@{Error} = ExceptNotAnError@{Error};
-      init flat/7/simpflat/104@{Double} = 0.0@{Double};
-      init flat/7/simpflat/105@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/11/aval/1/simpflat/64 (ExceptNotAnError@{Error}))
-      {
-        write flat/7/simpflat/103 = ExceptNotAnError@{Error};
-        write flat/7/simpflat/104 = conv/11/aval/1/simpflat/65;
-        write flat/7/simpflat/105 = 1.0@{Double};
-      }
-      else
-      {
-        write flat/7/simpflat/103 = conv/11/aval/1/simpflat/64;
-        write flat/7/simpflat/104 = 0.0@{Double};
-        write flat/7/simpflat/105 = 0.0@{Double};
-      }
-      read flat/7/simpflat/106 = flat/7/simpflat/103 [Error];
-      read flat/7/simpflat/107 = flat/7/simpflat/104 [Double];
-      read flat/7/simpflat/108 = flat/7/simpflat/105 [Double];
-      write flat/6/simpflat/100 = flat/7/simpflat/106;
-      write flat/6/simpflat/101 = flat/7/simpflat/107;
-      write flat/6/simpflat/102 = flat/7/simpflat/108;
-    }
-    else
-    {
-      write flat/6/simpflat/100 = s/reify/6/conv/12/aval/0/simpflat/70;
-      write flat/6/simpflat/101 = 0.0@{Double};
-      write flat/6/simpflat/102 = 0.0@{Double};
-    }
-    read flat/6/simpflat/109 = flat/6/simpflat/100 [Error];
-    read flat/6/simpflat/110 = flat/6/simpflat/101 [Double];
-    read flat/6/simpflat/111 = flat/6/simpflat/102 [Double];
-    write flat/3/simpflat/73 = flat/6/simpflat/109;
-    write flat/3/simpflat/74 = flat/6/simpflat/110;
-    write flat/3/simpflat/75 = flat/6/simpflat/111;
+    write flat/2/simpflat/49 = flat/1/simpflat/47;
+    write flat/2/simpflat/50 = 0.0@{Double};
   }
-  read flat/3/simpflat/112 = flat/3/simpflat/73 [Error];
-  read flat/3/simpflat/113 = flat/3/simpflat/74 [Double];
-  read flat/3/simpflat/114 = flat/3/simpflat/75 [Double];
-  write acc/s/reify/6/conv/12/simpflat/39 = flat/3/simpflat/112;
-  write acc/s/reify/6/conv/12/simpflat/40 = flat/3/simpflat/113;
-  write acc/s/reify/6/conv/12/simpflat/41 = flat/3/simpflat/114;
-  init flat/25/simpflat/115@{Error} = ExceptNotAnError@{Error};
-  init flat/25/simpflat/116@{String} = ""@{String};
-  if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+  read flat/2/simpflat/51 = flat/2/simpflat/49 [Error];
+  read flat/2/simpflat/52 = flat/2/simpflat/50 [Double];
+  write acc/conv/11/simpflat/22 = flat/2/simpflat/51;
+  write acc/conv/11/simpflat/23 = flat/2/simpflat/52;
+  read conv/11/aval/1/simpflat/53 = acc/conv/11/simpflat/22 [Error];
+  read conv/11/aval/1/simpflat/54 = acc/conv/11/simpflat/23 [Double];
+  read s/reify/6/conv/12/aval/0/simpflat/59 = acc/s/reify/6/conv/12/simpflat/28 [Error];
+  read s/reify/6/conv/12/aval/0/simpflat/60 = acc/s/reify/6/conv/12/simpflat/29 [Double];
+  read s/reify/6/conv/12/aval/0/simpflat/61 = acc/s/reify/6/conv/12/simpflat/30 [Double];
+  init flat/3/simpflat/62@{Error} = ExceptNotAnError@{Error};
+  init flat/3/simpflat/63@{Double} = 0.0@{Double};
+  init flat/3/simpflat/64@{Double} = 0.0@{Double};
+  if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/59 (ExceptNotAnError@{Error}))
   {
-    write flat/25/simpflat/115 = ExceptNotAnError@{Error};
-    write flat/25/simpflat/116 = conv/0/simpflat/231;
-  }
-  else
-  {
-    write flat/25/simpflat/115 = conv/0/simpflat/230;
-    write flat/25/simpflat/116 = ""@{String};
-  }
-  read flat/25/simpflat/117 = flat/25/simpflat/115 [Error];
-  read flat/25/simpflat/118 = flat/25/simpflat/116 [String];
-  init flat/26/simpflat/119@{Error} = ExceptNotAnError@{Error};
-  init flat/26/simpflat/120@{Bool} = False@{Bool};
-  if (eq#@{Error} flat/25/simpflat/117 (ExceptNotAnError@{Error}))
-  {
-    write flat/26/simpflat/119 = ExceptNotAnError@{Error};
-    write flat/26/simpflat/120 = eq#@{String} flat/25/simpflat/118 ("torso"@{String});
-  }
-  else
-  {
-    write flat/26/simpflat/119 = flat/25/simpflat/117;
-    write flat/26/simpflat/120 = False@{Bool};
-  }
-  read flat/26/simpflat/121 = flat/26/simpflat/119 [Error];
-  read flat/26/simpflat/122 = flat/26/simpflat/120 [Bool];
-  init flat/27@{Bool} = False@{Bool};
-  if (eq#@{Error} flat/26/simpflat/121 (ExceptNotAnError@{Error}))
-  {
-    write flat/27 = flat/26/simpflat/122;
-  }
-  else
-  {
-    write flat/27 = True@{Bool};
-  }
-  read flat/27 = flat/27 [Bool];
-  if (flat/27)
-  {
-    init flat/28/simpflat/123@{Error} = ExceptNotAnError@{Error};
-    init flat/28/simpflat/124@{Int} = 0@{Int};
-    if (eq#@{Error} conv/0/simpflat/230 (ExceptNotAnError@{Error}))
+    init flat/10/simpflat/65@{Error} = ExceptNotAnError@{Error};
+    init flat/10/simpflat/66@{Double} = 0.0@{Double};
+    init flat/10/simpflat/67@{Double} = 0.0@{Double};
+    if (eq#@{Error} s/reify/6/conv/12/aval/0/simpflat/59 (ExceptNotAnError@{Error}))
     {
-      write flat/28/simpflat/123 = ExceptNotAnError@{Error};
-      write flat/28/simpflat/124 = conv/0/simpflat/232;
-    }
-    else
-    {
-      write flat/28/simpflat/123 = conv/0/simpflat/230;
-      write flat/28/simpflat/124 = 0@{Int};
-    }
-    read flat/28/simpflat/125 = flat/28/simpflat/123 [Error];
-    read flat/28/simpflat/126 = flat/28/simpflat/124 [Int];
-    init flat/29/simpflat/127@{Error} = ExceptNotAnError@{Error};
-    init flat/29/simpflat/128@{Double} = 0.0@{Double};
-    if (eq#@{Error} flat/28/simpflat/125 (ExceptNotAnError@{Error}))
-    {
-      write flat/29/simpflat/127 = ExceptNotAnError@{Error};
-      write flat/29/simpflat/128 = doubleOfInt# flat/28/simpflat/126;
-    }
-    else
-    {
-      write flat/29/simpflat/127 = flat/28/simpflat/125;
-      write flat/29/simpflat/128 = 0.0@{Double};
-    }
-    read flat/29/simpflat/129 = flat/29/simpflat/127 [Error];
-    read flat/29/simpflat/130 = flat/29/simpflat/128 [Double];
-    write acc/conv/60/simpflat/42 = flat/29/simpflat/129;
-    write acc/conv/60/simpflat/43 = flat/29/simpflat/130;
-    read conv/60/aval/3/simpflat/131 = acc/conv/60/simpflat/42 [Error];
-    read conv/60/aval/3/simpflat/132 = acc/conv/60/simpflat/43 [Double];
-    read a/conv/61/aval/2/simpflat/137 = acc/a/conv/61/simpflat/48 [Error];
-    read a/conv/61/aval/2/simpflat/138 = acc/a/conv/61/simpflat/49 [Double];
-    read a/conv/61/aval/2/simpflat/139 = acc/a/conv/61/simpflat/50 [Double];
-    read a/conv/61/aval/2/simpflat/140 = acc/a/conv/61/simpflat/51 [Double];
-    init flat/30/simpflat/141@{Error} = ExceptNotAnError@{Error};
-    init flat/30/simpflat/142@{Double} = 0.0@{Double};
-    init flat/30/simpflat/143@{Double} = 0.0@{Double};
-    init flat/30/simpflat/144@{Double} = 0.0@{Double};
-    if (eq#@{Error} a/conv/61/aval/2/simpflat/137 (ExceptNotAnError@{Error}))
-    {
-      let nn/conv/68 = add#@{Double} a/conv/61/aval/2/simpflat/138 (1.0@{Double});
-      init flat/33/simpflat/145@{Error} = ExceptNotAnError@{Error};
-      init flat/33/simpflat/146@{Double} = 0.0@{Double};
-      if (eq#@{Error} conv/60/aval/3/simpflat/131 (ExceptNotAnError@{Error}))
+      init flat/13/simpflat/68@{Error} = ExceptNotAnError@{Error};
+      init flat/13/simpflat/69@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/11/aval/1/simpflat/53 (ExceptNotAnError@{Error}))
       {
-        write flat/33/simpflat/145 = ExceptNotAnError@{Error};
-        write flat/33/simpflat/146 = sub#@{Double} conv/60/aval/3/simpflat/132 a/conv/61/aval/2/simpflat/139;
-      }
-      else
-      {
-        write flat/33/simpflat/145 = conv/60/aval/3/simpflat/131;
-        write flat/33/simpflat/146 = 0.0@{Double};
-      }
-      read flat/33/simpflat/147 = flat/33/simpflat/145 [Error];
-      read flat/33/simpflat/148 = flat/33/simpflat/146 [Double];
-      init flat/34/simpflat/149@{Error} = ExceptNotAnError@{Error};
-      init flat/34/simpflat/150@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/33/simpflat/147 (ExceptNotAnError@{Error}))
-      {
-        write flat/34/simpflat/149 = ExceptNotAnError@{Error};
-        write flat/34/simpflat/150 = div# flat/33/simpflat/148 nn/conv/68;
-      }
-      else
-      {
-        write flat/34/simpflat/149 = flat/33/simpflat/147;
-        write flat/34/simpflat/150 = 0.0@{Double};
-      }
-      read flat/34/simpflat/151 = flat/34/simpflat/149 [Error];
-      read flat/34/simpflat/152 = flat/34/simpflat/150 [Double];
-      init flat/35/simpflat/153@{Error} = ExceptNotAnError@{Error};
-      init flat/35/simpflat/154@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/34/simpflat/151 (ExceptNotAnError@{Error}))
-      {
-        write flat/35/simpflat/153 = ExceptNotAnError@{Error};
-        write flat/35/simpflat/154 = add#@{Double} a/conv/61/aval/2/simpflat/139 flat/34/simpflat/152;
-      }
-      else
-      {
-        write flat/35/simpflat/153 = flat/34/simpflat/151;
-        write flat/35/simpflat/154 = 0.0@{Double};
-      }
-      read flat/35/simpflat/155 = flat/35/simpflat/153 [Error];
-      read flat/35/simpflat/156 = flat/35/simpflat/154 [Double];
-      init flat/36/simpflat/157@{Error} = ExceptNotAnError@{Error};
-      init flat/36/simpflat/158@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/33/simpflat/147 (ExceptNotAnError@{Error}))
-      {
-        init flat/51/simpflat/159@{Error} = ExceptNotAnError@{Error};
-        init flat/51/simpflat/160@{Double} = 0.0@{Double};
-        if (eq#@{Error} conv/60/aval/3/simpflat/131 (ExceptNotAnError@{Error}))
+        let conv/25 = sub#@{Double} conv/11/aval/1/simpflat/54 s/reify/6/conv/12/aval/0/simpflat/60;
+        init flat/35/simpflat/70@{Error} = ExceptNotAnError@{Error};
+        init flat/35/simpflat/71@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/25)
         {
-          init flat/57/simpflat/161@{Error} = ExceptNotAnError@{Error};
-          init flat/57/simpflat/162@{Double} = 0.0@{Double};
-          if (eq#@{Error} flat/35/simpflat/155 (ExceptNotAnError@{Error}))
+          write flat/35/simpflat/70 = ExceptNotAnError@{Error};
+          write flat/35/simpflat/71 = sub#@{Double} conv/11/aval/1/simpflat/54 s/reify/6/conv/12/aval/0/simpflat/60;
+        }
+        else
+        {
+          write flat/35/simpflat/70 = ExceptCannotCompute@{Error};
+          write flat/35/simpflat/71 = 0.0@{Double};
+        }
+        read flat/35/simpflat/72 = flat/35/simpflat/70 [Error];
+        read flat/35/simpflat/73 = flat/35/simpflat/71 [Double];
+        write flat/13/simpflat/68 = flat/35/simpflat/72;
+        write flat/13/simpflat/69 = flat/35/simpflat/73;
+      }
+      else
+      {
+        write flat/13/simpflat/68 = conv/11/aval/1/simpflat/53;
+        write flat/13/simpflat/69 = 0.0@{Double};
+      }
+      read flat/13/simpflat/74 = flat/13/simpflat/68 [Error];
+      read flat/13/simpflat/75 = flat/13/simpflat/69 [Double];
+      init flat/14/simpflat/76@{Error} = ExceptNotAnError@{Error};
+      init flat/14/simpflat/77@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/13/simpflat/74 (ExceptNotAnError@{Error}))
+      {
+        let conv/30 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        init flat/28/simpflat/78@{Error} = ExceptNotAnError@{Error};
+        init flat/28/simpflat/79@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/30)
+        {
+          write flat/28/simpflat/78 = ExceptNotAnError@{Error};
+          write flat/28/simpflat/79 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        }
+        else
+        {
+          write flat/28/simpflat/78 = ExceptCannotCompute@{Error};
+          write flat/28/simpflat/79 = 0.0@{Double};
+        }
+        read flat/28/simpflat/80 = flat/28/simpflat/78 [Error];
+        read flat/28/simpflat/81 = flat/28/simpflat/79 [Double];
+        init flat/29/simpflat/82@{Error} = ExceptNotAnError@{Error};
+        init flat/29/simpflat/83@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/28/simpflat/80 (ExceptNotAnError@{Error}))
+        {
+          let conv/34 = div# flat/13/simpflat/75 flat/28/simpflat/81;
+          init flat/32/simpflat/84@{Error} = ExceptNotAnError@{Error};
+          init flat/32/simpflat/85@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/34)
           {
-            write flat/57/simpflat/161 = ExceptNotAnError@{Error};
-            write flat/57/simpflat/162 = sub#@{Double} conv/60/aval/3/simpflat/132 flat/35/simpflat/156;
+            write flat/32/simpflat/84 = ExceptNotAnError@{Error};
+            write flat/32/simpflat/85 = div# flat/13/simpflat/75 flat/28/simpflat/81;
           }
           else
           {
-            write flat/57/simpflat/161 = flat/35/simpflat/155;
-            write flat/57/simpflat/162 = 0.0@{Double};
+            write flat/32/simpflat/84 = ExceptCannotCompute@{Error};
+            write flat/32/simpflat/85 = 0.0@{Double};
           }
-          read flat/57/simpflat/163 = flat/57/simpflat/161 [Error];
-          read flat/57/simpflat/164 = flat/57/simpflat/162 [Double];
-          write flat/51/simpflat/159 = flat/57/simpflat/163;
-          write flat/51/simpflat/160 = flat/57/simpflat/164;
+          read flat/32/simpflat/86 = flat/32/simpflat/84 [Error];
+          read flat/32/simpflat/87 = flat/32/simpflat/85 [Double];
+          write flat/29/simpflat/82 = flat/32/simpflat/86;
+          write flat/29/simpflat/83 = flat/32/simpflat/87;
         }
         else
         {
-          write flat/51/simpflat/159 = conv/60/aval/3/simpflat/131;
-          write flat/51/simpflat/160 = 0.0@{Double};
+          write flat/29/simpflat/82 = flat/28/simpflat/80;
+          write flat/29/simpflat/83 = 0.0@{Double};
         }
-        read flat/51/simpflat/165 = flat/51/simpflat/159 [Error];
-        read flat/51/simpflat/166 = flat/51/simpflat/160 [Double];
-        init flat/52/simpflat/167@{Error} = ExceptNotAnError@{Error};
-        init flat/52/simpflat/168@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat/51/simpflat/165 (ExceptNotAnError@{Error}))
+        read flat/29/simpflat/88 = flat/29/simpflat/82 [Error];
+        read flat/29/simpflat/89 = flat/29/simpflat/83 [Double];
+        write flat/14/simpflat/76 = flat/29/simpflat/88;
+        write flat/14/simpflat/77 = flat/29/simpflat/89;
+      }
+      else
+      {
+        write flat/14/simpflat/76 = flat/13/simpflat/74;
+        write flat/14/simpflat/77 = 0.0@{Double};
+      }
+      read flat/14/simpflat/90 = flat/14/simpflat/76 [Error];
+      read flat/14/simpflat/91 = flat/14/simpflat/77 [Double];
+      init flat/15/simpflat/92@{Error} = ExceptNotAnError@{Error};
+      init flat/15/simpflat/93@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/14/simpflat/90 (ExceptNotAnError@{Error}))
+      {
+        let conv/40 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/60 flat/14/simpflat/91;
+        init flat/25/simpflat/94@{Error} = ExceptNotAnError@{Error};
+        init flat/25/simpflat/95@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/40)
         {
-          write flat/52/simpflat/167 = ExceptNotAnError@{Error};
-          write flat/52/simpflat/168 = mul#@{Double} flat/33/simpflat/148 flat/51/simpflat/166;
+          write flat/25/simpflat/94 = ExceptNotAnError@{Error};
+          write flat/25/simpflat/95 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/60 flat/14/simpflat/91;
         }
         else
         {
-          write flat/52/simpflat/167 = flat/51/simpflat/165;
-          write flat/52/simpflat/168 = 0.0@{Double};
+          write flat/25/simpflat/94 = ExceptCannotCompute@{Error};
+          write flat/25/simpflat/95 = 0.0@{Double};
         }
-        read flat/52/simpflat/169 = flat/52/simpflat/167 [Error];
-        read flat/52/simpflat/170 = flat/52/simpflat/168 [Double];
-        write flat/36/simpflat/157 = flat/52/simpflat/169;
-        write flat/36/simpflat/158 = flat/52/simpflat/170;
+        read flat/25/simpflat/96 = flat/25/simpflat/94 [Error];
+        read flat/25/simpflat/97 = flat/25/simpflat/95 [Double];
+        write flat/15/simpflat/92 = flat/25/simpflat/96;
+        write flat/15/simpflat/93 = flat/25/simpflat/97;
       }
       else
       {
-        write flat/36/simpflat/157 = flat/33/simpflat/147;
-        write flat/36/simpflat/158 = 0.0@{Double};
+        write flat/15/simpflat/92 = flat/14/simpflat/90;
+        write flat/15/simpflat/93 = 0.0@{Double};
       }
-      read flat/36/simpflat/171 = flat/36/simpflat/157 [Error];
-      read flat/36/simpflat/172 = flat/36/simpflat/158 [Double];
-      init flat/37/simpflat/173@{Error} = ExceptNotAnError@{Error};
-      init flat/37/simpflat/174@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/36/simpflat/171 (ExceptNotAnError@{Error}))
+      read flat/15/simpflat/98 = flat/15/simpflat/92 [Error];
+      read flat/15/simpflat/99 = flat/15/simpflat/93 [Double];
+      init flat/16/simpflat/100@{Error} = ExceptNotAnError@{Error};
+      init flat/16/simpflat/101@{Double} = 0.0@{Double};
+      init flat/16/simpflat/102@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/15/simpflat/98 (ExceptNotAnError@{Error}))
       {
-        write flat/37/simpflat/173 = ExceptNotAnError@{Error};
-        write flat/37/simpflat/174 = add#@{Double} a/conv/61/aval/2/simpflat/140 flat/36/simpflat/172;
-      }
-      else
-      {
-        write flat/37/simpflat/173 = flat/36/simpflat/171;
-        write flat/37/simpflat/174 = 0.0@{Double};
-      }
-      read flat/37/simpflat/175 = flat/37/simpflat/173 [Error];
-      read flat/37/simpflat/176 = flat/37/simpflat/174 [Double];
-      init flat/38/simpflat/177@{Error} = ExceptNotAnError@{Error};
-      init flat/38/simpflat/178@{Double} = 0.0@{Double};
-      init flat/38/simpflat/179@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/35/simpflat/155 (ExceptNotAnError@{Error}))
-      {
-        write flat/38/simpflat/177 = ExceptNotAnError@{Error};
-        write flat/38/simpflat/178 = add#@{Double} a/conv/61/aval/2/simpflat/138 (1.0@{Double});
-        write flat/38/simpflat/179 = flat/35/simpflat/156;
-      }
-      else
-      {
-        write flat/38/simpflat/177 = flat/35/simpflat/155;
-        write flat/38/simpflat/178 = 0.0@{Double};
-        write flat/38/simpflat/179 = 0.0@{Double};
-      }
-      read flat/38/simpflat/180 = flat/38/simpflat/177 [Error];
-      read flat/38/simpflat/181 = flat/38/simpflat/178 [Double];
-      read flat/38/simpflat/182 = flat/38/simpflat/179 [Double];
-      init flat/39/simpflat/183@{Error} = ExceptNotAnError@{Error};
-      init flat/39/simpflat/184@{Double} = 0.0@{Double};
-      init flat/39/simpflat/185@{Double} = 0.0@{Double};
-      init flat/39/simpflat/186@{Double} = 0.0@{Double};
-      if (eq#@{Error} flat/38/simpflat/180 (ExceptNotAnError@{Error}))
-      {
-        init flat/42/simpflat/187@{Error} = ExceptNotAnError@{Error};
-        init flat/42/simpflat/188@{Double} = 0.0@{Double};
-        init flat/42/simpflat/189@{Double} = 0.0@{Double};
-        init flat/42/simpflat/190@{Double} = 0.0@{Double};
-        if (eq#@{Error} flat/37/simpflat/175 (ExceptNotAnError@{Error}))
+        let conv/45 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
+        init flat/19/simpflat/103@{Error} = ExceptNotAnError@{Error};
+        init flat/19/simpflat/104@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/45)
         {
-          write flat/42/simpflat/187 = ExceptNotAnError@{Error};
-          write flat/42/simpflat/188 = flat/38/simpflat/181;
-          write flat/42/simpflat/189 = flat/38/simpflat/182;
-          write flat/42/simpflat/190 = flat/37/simpflat/176;
+          write flat/19/simpflat/103 = ExceptNotAnError@{Error};
+          write flat/19/simpflat/104 = add#@{Double} s/reify/6/conv/12/aval/0/simpflat/61 (1.0@{Double});
         }
         else
         {
-          write flat/42/simpflat/187 = flat/37/simpflat/175;
-          write flat/42/simpflat/188 = 0.0@{Double};
-          write flat/42/simpflat/189 = 0.0@{Double};
-          write flat/42/simpflat/190 = 0.0@{Double};
+          write flat/19/simpflat/103 = ExceptCannotCompute@{Error};
+          write flat/19/simpflat/104 = 0.0@{Double};
         }
-        read flat/42/simpflat/191 = flat/42/simpflat/187 [Error];
-        read flat/42/simpflat/192 = flat/42/simpflat/188 [Double];
-        read flat/42/simpflat/193 = flat/42/simpflat/189 [Double];
-        read flat/42/simpflat/194 = flat/42/simpflat/190 [Double];
-        write flat/39/simpflat/183 = flat/42/simpflat/191;
-        write flat/39/simpflat/184 = flat/42/simpflat/192;
-        write flat/39/simpflat/185 = flat/42/simpflat/193;
-        write flat/39/simpflat/186 = flat/42/simpflat/194;
+        read flat/19/simpflat/105 = flat/19/simpflat/103 [Error];
+        read flat/19/simpflat/106 = flat/19/simpflat/104 [Double];
+        init flat/20/simpflat/107@{Error} = ExceptNotAnError@{Error};
+        init flat/20/simpflat/108@{Double} = 0.0@{Double};
+        init flat/20/simpflat/109@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/19/simpflat/105 (ExceptNotAnError@{Error}))
+        {
+          write flat/20/simpflat/107 = ExceptNotAnError@{Error};
+          write flat/20/simpflat/108 = flat/15/simpflat/99;
+          write flat/20/simpflat/109 = flat/19/simpflat/106;
+        }
+        else
+        {
+          write flat/20/simpflat/107 = flat/19/simpflat/105;
+          write flat/20/simpflat/108 = 0.0@{Double};
+          write flat/20/simpflat/109 = 0.0@{Double};
+        }
+        read flat/20/simpflat/110 = flat/20/simpflat/107 [Error];
+        read flat/20/simpflat/111 = flat/20/simpflat/108 [Double];
+        read flat/20/simpflat/112 = flat/20/simpflat/109 [Double];
+        write flat/16/simpflat/100 = flat/20/simpflat/110;
+        write flat/16/simpflat/101 = flat/20/simpflat/111;
+        write flat/16/simpflat/102 = flat/20/simpflat/112;
       }
       else
       {
-        write flat/39/simpflat/183 = flat/38/simpflat/180;
-        write flat/39/simpflat/184 = 0.0@{Double};
-        write flat/39/simpflat/185 = 0.0@{Double};
-        write flat/39/simpflat/186 = 0.0@{Double};
+        write flat/16/simpflat/100 = flat/15/simpflat/98;
+        write flat/16/simpflat/101 = 0.0@{Double};
+        write flat/16/simpflat/102 = 0.0@{Double};
       }
-      read flat/39/simpflat/195 = flat/39/simpflat/183 [Error];
-      read flat/39/simpflat/196 = flat/39/simpflat/184 [Double];
-      read flat/39/simpflat/197 = flat/39/simpflat/185 [Double];
-      read flat/39/simpflat/198 = flat/39/simpflat/186 [Double];
-      write flat/30/simpflat/141 = flat/39/simpflat/195;
-      write flat/30/simpflat/142 = flat/39/simpflat/196;
-      write flat/30/simpflat/143 = flat/39/simpflat/197;
-      write flat/30/simpflat/144 = flat/39/simpflat/198;
+      read flat/16/simpflat/113 = flat/16/simpflat/100 [Error];
+      read flat/16/simpflat/114 = flat/16/simpflat/101 [Double];
+      read flat/16/simpflat/115 = flat/16/simpflat/102 [Double];
+      write flat/10/simpflat/65 = flat/16/simpflat/113;
+      write flat/10/simpflat/66 = flat/16/simpflat/114;
+      write flat/10/simpflat/67 = flat/16/simpflat/115;
     }
     else
     {
-      write flat/30/simpflat/141 = a/conv/61/aval/2/simpflat/137;
-      write flat/30/simpflat/142 = 0.0@{Double};
-      write flat/30/simpflat/143 = 0.0@{Double};
-      write flat/30/simpflat/144 = 0.0@{Double};
+      write flat/10/simpflat/65 = s/reify/6/conv/12/aval/0/simpflat/59;
+      write flat/10/simpflat/66 = 0.0@{Double};
+      write flat/10/simpflat/67 = 0.0@{Double};
     }
-    read flat/30/simpflat/199 = flat/30/simpflat/141 [Error];
-    read flat/30/simpflat/200 = flat/30/simpflat/142 [Double];
-    read flat/30/simpflat/201 = flat/30/simpflat/143 [Double];
-    read flat/30/simpflat/202 = flat/30/simpflat/144 [Double];
-    write acc/a/conv/61/simpflat/48 = flat/30/simpflat/199;
-    write acc/a/conv/61/simpflat/49 = flat/30/simpflat/200;
-    write acc/a/conv/61/simpflat/50 = flat/30/simpflat/201;
-    write acc/a/conv/61/simpflat/51 = flat/30/simpflat/202;
+    read flat/10/simpflat/116 = flat/10/simpflat/65 [Error];
+    read flat/10/simpflat/117 = flat/10/simpflat/66 [Double];
+    read flat/10/simpflat/118 = flat/10/simpflat/67 [Double];
+    write flat/3/simpflat/62 = flat/10/simpflat/116;
+    write flat/3/simpflat/63 = flat/10/simpflat/117;
+    write flat/3/simpflat/64 = flat/10/simpflat/118;
+  }
+  else
+  {
+    init flat/6/simpflat/119@{Error} = ExceptNotAnError@{Error};
+    init flat/6/simpflat/120@{Double} = 0.0@{Double};
+    init flat/6/simpflat/121@{Double} = 0.0@{Double};
+    if (eq#@{Error} (ExceptFold1NoValue@{Error}) s/reify/6/conv/12/aval/0/simpflat/59)
+    {
+      init flat/7/simpflat/122@{Error} = ExceptNotAnError@{Error};
+      init flat/7/simpflat/123@{Double} = 0.0@{Double};
+      init flat/7/simpflat/124@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/11/aval/1/simpflat/53 (ExceptNotAnError@{Error}))
+      {
+        write flat/7/simpflat/122 = ExceptNotAnError@{Error};
+        write flat/7/simpflat/123 = conv/11/aval/1/simpflat/54;
+        write flat/7/simpflat/124 = 1.0@{Double};
+      }
+      else
+      {
+        write flat/7/simpflat/122 = conv/11/aval/1/simpflat/53;
+        write flat/7/simpflat/123 = 0.0@{Double};
+        write flat/7/simpflat/124 = 0.0@{Double};
+      }
+      read flat/7/simpflat/125 = flat/7/simpflat/122 [Error];
+      read flat/7/simpflat/126 = flat/7/simpflat/123 [Double];
+      read flat/7/simpflat/127 = flat/7/simpflat/124 [Double];
+      write flat/6/simpflat/119 = flat/7/simpflat/125;
+      write flat/6/simpflat/120 = flat/7/simpflat/126;
+      write flat/6/simpflat/121 = flat/7/simpflat/127;
+    }
+    else
+    {
+      write flat/6/simpflat/119 = s/reify/6/conv/12/aval/0/simpflat/59;
+      write flat/6/simpflat/120 = 0.0@{Double};
+      write flat/6/simpflat/121 = 0.0@{Double};
+    }
+    read flat/6/simpflat/128 = flat/6/simpflat/119 [Error];
+    read flat/6/simpflat/129 = flat/6/simpflat/120 [Double];
+    read flat/6/simpflat/130 = flat/6/simpflat/121 [Double];
+    write flat/3/simpflat/62 = flat/6/simpflat/128;
+    write flat/3/simpflat/63 = flat/6/simpflat/129;
+    write flat/3/simpflat/64 = flat/6/simpflat/130;
+  }
+  read flat/3/simpflat/131 = flat/3/simpflat/62 [Error];
+  read flat/3/simpflat/132 = flat/3/simpflat/63 [Double];
+  read flat/3/simpflat/133 = flat/3/simpflat/64 [Double];
+  write acc/s/reify/6/conv/12/simpflat/28 = flat/3/simpflat/131;
+  write acc/s/reify/6/conv/12/simpflat/29 = flat/3/simpflat/132;
+  write acc/s/reify/6/conv/12/simpflat/30 = flat/3/simpflat/133;
+  init flat/36/simpflat/134@{Error} = ExceptNotAnError@{Error};
+  init flat/36/simpflat/135@{String} = ""@{String};
+  if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
+  {
+    write flat/36/simpflat/134 = ExceptNotAnError@{Error};
+    write flat/36/simpflat/135 = conv/0/simpflat/308;
+  }
+  else
+  {
+    write flat/36/simpflat/134 = conv/0/simpflat/307;
+    write flat/36/simpflat/135 = ""@{String};
+  }
+  read flat/36/simpflat/136 = flat/36/simpflat/134 [Error];
+  read flat/36/simpflat/137 = flat/36/simpflat/135 [String];
+  init flat/37/simpflat/138@{Error} = ExceptNotAnError@{Error};
+  init flat/37/simpflat/139@{Bool} = False@{Bool};
+  if (eq#@{Error} flat/36/simpflat/136 (ExceptNotAnError@{Error}))
+  {
+    write flat/37/simpflat/138 = ExceptNotAnError@{Error};
+    write flat/37/simpflat/139 = eq#@{String} flat/36/simpflat/137 ("torso"@{String});
+  }
+  else
+  {
+    write flat/37/simpflat/138 = flat/36/simpflat/136;
+    write flat/37/simpflat/139 = False@{Bool};
+  }
+  read flat/37/simpflat/140 = flat/37/simpflat/138 [Error];
+  read flat/37/simpflat/141 = flat/37/simpflat/139 [Bool];
+  init flat/38@{Bool} = False@{Bool};
+  if (eq#@{Error} flat/37/simpflat/140 (ExceptNotAnError@{Error}))
+  {
+    write flat/38 = flat/37/simpflat/141;
+  }
+  else
+  {
+    write flat/38 = True@{Bool};
+  }
+  read flat/38 = flat/38 [Bool];
+  if (flat/38)
+  {
+    init flat/39/simpflat/142@{Error} = ExceptNotAnError@{Error};
+    init flat/39/simpflat/143@{Int} = 0@{Int};
+    if (eq#@{Error} conv/0/simpflat/307 (ExceptNotAnError@{Error}))
+    {
+      write flat/39/simpflat/142 = ExceptNotAnError@{Error};
+      write flat/39/simpflat/143 = conv/0/simpflat/309;
+    }
+    else
+    {
+      write flat/39/simpflat/142 = conv/0/simpflat/307;
+      write flat/39/simpflat/143 = 0@{Int};
+    }
+    read flat/39/simpflat/144 = flat/39/simpflat/142 [Error];
+    read flat/39/simpflat/145 = flat/39/simpflat/143 [Int];
+    init flat/40/simpflat/146@{Error} = ExceptNotAnError@{Error};
+    init flat/40/simpflat/147@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat/39/simpflat/144 (ExceptNotAnError@{Error}))
+    {
+      write flat/40/simpflat/146 = ExceptNotAnError@{Error};
+      write flat/40/simpflat/147 = doubleOfInt# flat/39/simpflat/145;
+    }
+    else
+    {
+      write flat/40/simpflat/146 = flat/39/simpflat/144;
+      write flat/40/simpflat/147 = 0.0@{Double};
+    }
+    read flat/40/simpflat/148 = flat/40/simpflat/146 [Error];
+    read flat/40/simpflat/149 = flat/40/simpflat/147 [Double];
+    write acc/conv/76/simpflat/31 = flat/40/simpflat/148;
+    write acc/conv/76/simpflat/32 = flat/40/simpflat/149;
+    read conv/76/aval/3/simpflat/150 = acc/conv/76/simpflat/31 [Error];
+    read conv/76/aval/3/simpflat/151 = acc/conv/76/simpflat/32 [Double];
+    read a/conv/77/aval/2/simpflat/156 = acc/a/conv/77/simpflat/37 [Error];
+    read a/conv/77/aval/2/simpflat/157 = acc/a/conv/77/simpflat/38 [Double];
+    read a/conv/77/aval/2/simpflat/158 = acc/a/conv/77/simpflat/39 [Double];
+    read a/conv/77/aval/2/simpflat/159 = acc/a/conv/77/simpflat/40 [Double];
+    init flat/41/simpflat/160@{Error} = ExceptNotAnError@{Error};
+    init flat/41/simpflat/161@{Double} = 0.0@{Double};
+    init flat/41/simpflat/162@{Double} = 0.0@{Double};
+    init flat/41/simpflat/163@{Double} = 0.0@{Double};
+    if (eq#@{Error} a/conv/77/aval/2/simpflat/156 (ExceptNotAnError@{Error}))
+    {
+      let conv/84 = add#@{Double} a/conv/77/aval/2/simpflat/157 (1.0@{Double});
+      init flat/44/simpflat/164@{Error} = ExceptNotAnError@{Error};
+      init flat/44/simpflat/165@{Double} = 0.0@{Double};
+      if (doubleIsValid# conv/84)
+      {
+        write flat/44/simpflat/164 = ExceptNotAnError@{Error};
+        write flat/44/simpflat/165 = add#@{Double} a/conv/77/aval/2/simpflat/157 (1.0@{Double});
+      }
+      else
+      {
+        write flat/44/simpflat/164 = ExceptCannotCompute@{Error};
+        write flat/44/simpflat/165 = 0.0@{Double};
+      }
+      read flat/44/simpflat/166 = flat/44/simpflat/164 [Error];
+      read flat/44/simpflat/167 = flat/44/simpflat/165 [Double];
+      init flat/45/simpflat/168@{Error} = ExceptNotAnError@{Error};
+      init flat/45/simpflat/169@{Double} = 0.0@{Double};
+      if (eq#@{Error} conv/76/aval/3/simpflat/150 (ExceptNotAnError@{Error}))
+      {
+        let conv/89 = sub#@{Double} conv/76/aval/3/simpflat/151 a/conv/77/aval/2/simpflat/158;
+        init flat/89/simpflat/170@{Error} = ExceptNotAnError@{Error};
+        init flat/89/simpflat/171@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/89)
+        {
+          write flat/89/simpflat/170 = ExceptNotAnError@{Error};
+          write flat/89/simpflat/171 = sub#@{Double} conv/76/aval/3/simpflat/151 a/conv/77/aval/2/simpflat/158;
+        }
+        else
+        {
+          write flat/89/simpflat/170 = ExceptCannotCompute@{Error};
+          write flat/89/simpflat/171 = 0.0@{Double};
+        }
+        read flat/89/simpflat/172 = flat/89/simpflat/170 [Error];
+        read flat/89/simpflat/173 = flat/89/simpflat/171 [Double];
+        write flat/45/simpflat/168 = flat/89/simpflat/172;
+        write flat/45/simpflat/169 = flat/89/simpflat/173;
+      }
+      else
+      {
+        write flat/45/simpflat/168 = conv/76/aval/3/simpflat/150;
+        write flat/45/simpflat/169 = 0.0@{Double};
+      }
+      read flat/45/simpflat/174 = flat/45/simpflat/168 [Error];
+      read flat/45/simpflat/175 = flat/45/simpflat/169 [Double];
+      init flat/46/simpflat/176@{Error} = ExceptNotAnError@{Error};
+      init flat/46/simpflat/177@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/45/simpflat/174 (ExceptNotAnError@{Error}))
+      {
+        init flat/83/simpflat/178@{Error} = ExceptNotAnError@{Error};
+        init flat/83/simpflat/179@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/44/simpflat/166 (ExceptNotAnError@{Error}))
+        {
+          let conv/97 = div# flat/45/simpflat/175 flat/44/simpflat/167;
+          init flat/86/simpflat/180@{Error} = ExceptNotAnError@{Error};
+          init flat/86/simpflat/181@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/97)
+          {
+            write flat/86/simpflat/180 = ExceptNotAnError@{Error};
+            write flat/86/simpflat/181 = div# flat/45/simpflat/175 flat/44/simpflat/167;
+          }
+          else
+          {
+            write flat/86/simpflat/180 = ExceptCannotCompute@{Error};
+            write flat/86/simpflat/181 = 0.0@{Double};
+          }
+          read flat/86/simpflat/182 = flat/86/simpflat/180 [Error];
+          read flat/86/simpflat/183 = flat/86/simpflat/181 [Double];
+          write flat/83/simpflat/178 = flat/86/simpflat/182;
+          write flat/83/simpflat/179 = flat/86/simpflat/183;
+        }
+        else
+        {
+          write flat/83/simpflat/178 = flat/44/simpflat/166;
+          write flat/83/simpflat/179 = 0.0@{Double};
+        }
+        read flat/83/simpflat/184 = flat/83/simpflat/178 [Error];
+        read flat/83/simpflat/185 = flat/83/simpflat/179 [Double];
+        write flat/46/simpflat/176 = flat/83/simpflat/184;
+        write flat/46/simpflat/177 = flat/83/simpflat/185;
+      }
+      else
+      {
+        write flat/46/simpflat/176 = flat/45/simpflat/174;
+        write flat/46/simpflat/177 = 0.0@{Double};
+      }
+      read flat/46/simpflat/186 = flat/46/simpflat/176 [Error];
+      read flat/46/simpflat/187 = flat/46/simpflat/177 [Double];
+      init flat/47/simpflat/188@{Error} = ExceptNotAnError@{Error};
+      init flat/47/simpflat/189@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/46/simpflat/186 (ExceptNotAnError@{Error}))
+      {
+        let conv/103 = add#@{Double} a/conv/77/aval/2/simpflat/158 flat/46/simpflat/187;
+        init flat/80/simpflat/190@{Error} = ExceptNotAnError@{Error};
+        init flat/80/simpflat/191@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/103)
+        {
+          write flat/80/simpflat/190 = ExceptNotAnError@{Error};
+          write flat/80/simpflat/191 = add#@{Double} a/conv/77/aval/2/simpflat/158 flat/46/simpflat/187;
+        }
+        else
+        {
+          write flat/80/simpflat/190 = ExceptCannotCompute@{Error};
+          write flat/80/simpflat/191 = 0.0@{Double};
+        }
+        read flat/80/simpflat/192 = flat/80/simpflat/190 [Error];
+        read flat/80/simpflat/193 = flat/80/simpflat/191 [Double];
+        write flat/47/simpflat/188 = flat/80/simpflat/192;
+        write flat/47/simpflat/189 = flat/80/simpflat/193;
+      }
+      else
+      {
+        write flat/47/simpflat/188 = flat/46/simpflat/186;
+        write flat/47/simpflat/189 = 0.0@{Double};
+      }
+      read flat/47/simpflat/194 = flat/47/simpflat/188 [Error];
+      read flat/47/simpflat/195 = flat/47/simpflat/189 [Double];
+      init flat/48/simpflat/196@{Error} = ExceptNotAnError@{Error};
+      init flat/48/simpflat/197@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/45/simpflat/174 (ExceptNotAnError@{Error}))
+      {
+        init flat/67/simpflat/198@{Error} = ExceptNotAnError@{Error};
+        init flat/67/simpflat/199@{Double} = 0.0@{Double};
+        if (eq#@{Error} conv/76/aval/3/simpflat/150 (ExceptNotAnError@{Error}))
+        {
+          init flat/74/simpflat/200@{Error} = ExceptNotAnError@{Error};
+          init flat/74/simpflat/201@{Double} = 0.0@{Double};
+          if (eq#@{Error} flat/47/simpflat/194 (ExceptNotAnError@{Error}))
+          {
+            let conv/113 = sub#@{Double} conv/76/aval/3/simpflat/151 flat/47/simpflat/195;
+            init flat/77/simpflat/202@{Error} = ExceptNotAnError@{Error};
+            init flat/77/simpflat/203@{Double} = 0.0@{Double};
+            if (doubleIsValid# conv/113)
+            {
+              write flat/77/simpflat/202 = ExceptNotAnError@{Error};
+              write flat/77/simpflat/203 = sub#@{Double} conv/76/aval/3/simpflat/151 flat/47/simpflat/195;
+            }
+            else
+            {
+              write flat/77/simpflat/202 = ExceptCannotCompute@{Error};
+              write flat/77/simpflat/203 = 0.0@{Double};
+            }
+            read flat/77/simpflat/204 = flat/77/simpflat/202 [Error];
+            read flat/77/simpflat/205 = flat/77/simpflat/203 [Double];
+            write flat/74/simpflat/200 = flat/77/simpflat/204;
+            write flat/74/simpflat/201 = flat/77/simpflat/205;
+          }
+          else
+          {
+            write flat/74/simpflat/200 = flat/47/simpflat/194;
+            write flat/74/simpflat/201 = 0.0@{Double};
+          }
+          read flat/74/simpflat/206 = flat/74/simpflat/200 [Error];
+          read flat/74/simpflat/207 = flat/74/simpflat/201 [Double];
+          write flat/67/simpflat/198 = flat/74/simpflat/206;
+          write flat/67/simpflat/199 = flat/74/simpflat/207;
+        }
+        else
+        {
+          write flat/67/simpflat/198 = conv/76/aval/3/simpflat/150;
+          write flat/67/simpflat/199 = 0.0@{Double};
+        }
+        read flat/67/simpflat/208 = flat/67/simpflat/198 [Error];
+        read flat/67/simpflat/209 = flat/67/simpflat/199 [Double];
+        init flat/68/simpflat/210@{Error} = ExceptNotAnError@{Error};
+        init flat/68/simpflat/211@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/67/simpflat/208 (ExceptNotAnError@{Error}))
+        {
+          let conv/119 = mul#@{Double} flat/45/simpflat/175 flat/67/simpflat/209;
+          init flat/71/simpflat/212@{Error} = ExceptNotAnError@{Error};
+          init flat/71/simpflat/213@{Double} = 0.0@{Double};
+          if (doubleIsValid# conv/119)
+          {
+            write flat/71/simpflat/212 = ExceptNotAnError@{Error};
+            write flat/71/simpflat/213 = mul#@{Double} flat/45/simpflat/175 flat/67/simpflat/209;
+          }
+          else
+          {
+            write flat/71/simpflat/212 = ExceptCannotCompute@{Error};
+            write flat/71/simpflat/213 = 0.0@{Double};
+          }
+          read flat/71/simpflat/214 = flat/71/simpflat/212 [Error];
+          read flat/71/simpflat/215 = flat/71/simpflat/213 [Double];
+          write flat/68/simpflat/210 = flat/71/simpflat/214;
+          write flat/68/simpflat/211 = flat/71/simpflat/215;
+        }
+        else
+        {
+          write flat/68/simpflat/210 = flat/67/simpflat/208;
+          write flat/68/simpflat/211 = 0.0@{Double};
+        }
+        read flat/68/simpflat/216 = flat/68/simpflat/210 [Error];
+        read flat/68/simpflat/217 = flat/68/simpflat/211 [Double];
+        write flat/48/simpflat/196 = flat/68/simpflat/216;
+        write flat/48/simpflat/197 = flat/68/simpflat/217;
+      }
+      else
+      {
+        write flat/48/simpflat/196 = flat/45/simpflat/174;
+        write flat/48/simpflat/197 = 0.0@{Double};
+      }
+      read flat/48/simpflat/218 = flat/48/simpflat/196 [Error];
+      read flat/48/simpflat/219 = flat/48/simpflat/197 [Double];
+      init flat/49/simpflat/220@{Error} = ExceptNotAnError@{Error};
+      init flat/49/simpflat/221@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/48/simpflat/218 (ExceptNotAnError@{Error}))
+      {
+        let conv/125 = add#@{Double} a/conv/77/aval/2/simpflat/159 flat/48/simpflat/219;
+        init flat/64/simpflat/222@{Error} = ExceptNotAnError@{Error};
+        init flat/64/simpflat/223@{Double} = 0.0@{Double};
+        if (doubleIsValid# conv/125)
+        {
+          write flat/64/simpflat/222 = ExceptNotAnError@{Error};
+          write flat/64/simpflat/223 = add#@{Double} a/conv/77/aval/2/simpflat/159 flat/48/simpflat/219;
+        }
+        else
+        {
+          write flat/64/simpflat/222 = ExceptCannotCompute@{Error};
+          write flat/64/simpflat/223 = 0.0@{Double};
+        }
+        read flat/64/simpflat/224 = flat/64/simpflat/222 [Error];
+        read flat/64/simpflat/225 = flat/64/simpflat/223 [Double];
+        write flat/49/simpflat/220 = flat/64/simpflat/224;
+        write flat/49/simpflat/221 = flat/64/simpflat/225;
+      }
+      else
+      {
+        write flat/49/simpflat/220 = flat/48/simpflat/218;
+        write flat/49/simpflat/221 = 0.0@{Double};
+      }
+      read flat/49/simpflat/226 = flat/49/simpflat/220 [Error];
+      read flat/49/simpflat/227 = flat/49/simpflat/221 [Double];
+      init flat/50/simpflat/228@{Error} = ExceptNotAnError@{Error};
+      init flat/50/simpflat/229@{Double} = 0.0@{Double};
+      init flat/50/simpflat/230@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/44/simpflat/166 (ExceptNotAnError@{Error}))
+      {
+        init flat/59/simpflat/231@{Error} = ExceptNotAnError@{Error};
+        init flat/59/simpflat/232@{Double} = 0.0@{Double};
+        init flat/59/simpflat/233@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/47/simpflat/194 (ExceptNotAnError@{Error}))
+        {
+          write flat/59/simpflat/231 = ExceptNotAnError@{Error};
+          write flat/59/simpflat/232 = flat/44/simpflat/167;
+          write flat/59/simpflat/233 = flat/47/simpflat/195;
+        }
+        else
+        {
+          write flat/59/simpflat/231 = flat/47/simpflat/194;
+          write flat/59/simpflat/232 = 0.0@{Double};
+          write flat/59/simpflat/233 = 0.0@{Double};
+        }
+        read flat/59/simpflat/234 = flat/59/simpflat/231 [Error];
+        read flat/59/simpflat/235 = flat/59/simpflat/232 [Double];
+        read flat/59/simpflat/236 = flat/59/simpflat/233 [Double];
+        write flat/50/simpflat/228 = flat/59/simpflat/234;
+        write flat/50/simpflat/229 = flat/59/simpflat/235;
+        write flat/50/simpflat/230 = flat/59/simpflat/236;
+      }
+      else
+      {
+        write flat/50/simpflat/228 = flat/44/simpflat/166;
+        write flat/50/simpflat/229 = 0.0@{Double};
+        write flat/50/simpflat/230 = 0.0@{Double};
+      }
+      read flat/50/simpflat/237 = flat/50/simpflat/228 [Error];
+      read flat/50/simpflat/238 = flat/50/simpflat/229 [Double];
+      read flat/50/simpflat/239 = flat/50/simpflat/230 [Double];
+      init flat/51/simpflat/240@{Error} = ExceptNotAnError@{Error};
+      init flat/51/simpflat/241@{Double} = 0.0@{Double};
+      init flat/51/simpflat/242@{Double} = 0.0@{Double};
+      init flat/51/simpflat/243@{Double} = 0.0@{Double};
+      if (eq#@{Error} flat/50/simpflat/237 (ExceptNotAnError@{Error}))
+      {
+        init flat/54/simpflat/244@{Error} = ExceptNotAnError@{Error};
+        init flat/54/simpflat/245@{Double} = 0.0@{Double};
+        init flat/54/simpflat/246@{Double} = 0.0@{Double};
+        init flat/54/simpflat/247@{Double} = 0.0@{Double};
+        if (eq#@{Error} flat/49/simpflat/226 (ExceptNotAnError@{Error}))
+        {
+          write flat/54/simpflat/244 = ExceptNotAnError@{Error};
+          write flat/54/simpflat/245 = flat/50/simpflat/238;
+          write flat/54/simpflat/246 = flat/50/simpflat/239;
+          write flat/54/simpflat/247 = flat/49/simpflat/227;
+        }
+        else
+        {
+          write flat/54/simpflat/244 = flat/49/simpflat/226;
+          write flat/54/simpflat/245 = 0.0@{Double};
+          write flat/54/simpflat/246 = 0.0@{Double};
+          write flat/54/simpflat/247 = 0.0@{Double};
+        }
+        read flat/54/simpflat/248 = flat/54/simpflat/244 [Error];
+        read flat/54/simpflat/249 = flat/54/simpflat/245 [Double];
+        read flat/54/simpflat/250 = flat/54/simpflat/246 [Double];
+        read flat/54/simpflat/251 = flat/54/simpflat/247 [Double];
+        write flat/51/simpflat/240 = flat/54/simpflat/248;
+        write flat/51/simpflat/241 = flat/54/simpflat/249;
+        write flat/51/simpflat/242 = flat/54/simpflat/250;
+        write flat/51/simpflat/243 = flat/54/simpflat/251;
+      }
+      else
+      {
+        write flat/51/simpflat/240 = flat/50/simpflat/237;
+        write flat/51/simpflat/241 = 0.0@{Double};
+        write flat/51/simpflat/242 = 0.0@{Double};
+        write flat/51/simpflat/243 = 0.0@{Double};
+      }
+      read flat/51/simpflat/252 = flat/51/simpflat/240 [Error];
+      read flat/51/simpflat/253 = flat/51/simpflat/241 [Double];
+      read flat/51/simpflat/254 = flat/51/simpflat/242 [Double];
+      read flat/51/simpflat/255 = flat/51/simpflat/243 [Double];
+      write flat/41/simpflat/160 = flat/51/simpflat/252;
+      write flat/41/simpflat/161 = flat/51/simpflat/253;
+      write flat/41/simpflat/162 = flat/51/simpflat/254;
+      write flat/41/simpflat/163 = flat/51/simpflat/255;
+    }
+    else
+    {
+      write flat/41/simpflat/160 = a/conv/77/aval/2/simpflat/156;
+      write flat/41/simpflat/161 = 0.0@{Double};
+      write flat/41/simpflat/162 = 0.0@{Double};
+      write flat/41/simpflat/163 = 0.0@{Double};
+    }
+    read flat/41/simpflat/256 = flat/41/simpflat/160 [Error];
+    read flat/41/simpflat/257 = flat/41/simpflat/161 [Double];
+    read flat/41/simpflat/258 = flat/41/simpflat/162 [Double];
+    read flat/41/simpflat/259 = flat/41/simpflat/163 [Double];
+    write acc/a/conv/77/simpflat/37 = flat/41/simpflat/256;
+    write acc/a/conv/77/simpflat/38 = flat/41/simpflat/257;
+    write acc/a/conv/77/simpflat/39 = flat/41/simpflat/258;
+    write acc/a/conv/77/simpflat/40 = flat/41/simpflat/259;
   }
 }
-save_resumable@{Error} acc/a/conv/61/simpflat/48;
-save_resumable@{Double} acc/a/conv/61/simpflat/49;
-save_resumable@{Double} acc/a/conv/61/simpflat/50;
-save_resumable@{Double} acc/a/conv/61/simpflat/51;
-save_resumable@{Error} acc/conv/60/simpflat/42;
-save_resumable@{Double} acc/conv/60/simpflat/43;
-save_resumable@{Error} acc/s/reify/6/conv/12/simpflat/39;
-save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/40;
-save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/41;
-save_resumable@{Error} acc/conv/11/simpflat/33;
-save_resumable@{Double} acc/conv/11/simpflat/34;
-read a/conv/61/simpflat/203 = acc/a/conv/61/simpflat/48 [Error];
-read a/conv/61/simpflat/204 = acc/a/conv/61/simpflat/49 [Double];
-read a/conv/61/simpflat/206 = acc/a/conv/61/simpflat/51 [Double];
-read s/reify/6/conv/12/simpflat/207 = acc/s/reify/6/conv/12/simpflat/39 [Error];
-read s/reify/6/conv/12/simpflat/208 = acc/s/reify/6/conv/12/simpflat/40 [Double];
-init flat/86/simpflat/210@{Error} = ExceptNotAnError@{Error};
-init flat/86/simpflat/211@{Double} = 0.0@{Double};
-if (eq#@{Error} s/reify/6/conv/12/simpflat/207 (ExceptNotAnError@{Error}))
+save_resumable@{Error} acc/a/conv/77/simpflat/37;
+save_resumable@{Double} acc/a/conv/77/simpflat/38;
+save_resumable@{Double} acc/a/conv/77/simpflat/39;
+save_resumable@{Double} acc/a/conv/77/simpflat/40;
+save_resumable@{Error} acc/conv/76/simpflat/31;
+save_resumable@{Double} acc/conv/76/simpflat/32;
+save_resumable@{Error} acc/s/reify/6/conv/12/simpflat/28;
+save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/29;
+save_resumable@{Double} acc/s/reify/6/conv/12/simpflat/30;
+save_resumable@{Error} acc/conv/11/simpflat/22;
+save_resumable@{Double} acc/conv/11/simpflat/23;
+read a/conv/77/simpflat/260 = acc/a/conv/77/simpflat/37 [Error];
+read a/conv/77/simpflat/261 = acc/a/conv/77/simpflat/38 [Double];
+read a/conv/77/simpflat/263 = acc/a/conv/77/simpflat/40 [Double];
+read s/reify/6/conv/12/simpflat/264 = acc/s/reify/6/conv/12/simpflat/28 [Error];
+read s/reify/6/conv/12/simpflat/265 = acc/s/reify/6/conv/12/simpflat/29 [Double];
+init flat/110/simpflat/267@{Error} = ExceptNotAnError@{Error};
+init flat/110/simpflat/268@{Double} = 0.0@{Double};
+if (eq#@{Error} s/reify/6/conv/12/simpflat/264 (ExceptNotAnError@{Error}))
 {
-  write flat/86/simpflat/210 = ExceptNotAnError@{Error};
-  write flat/86/simpflat/211 = s/reify/6/conv/12/simpflat/208;
+  write flat/110/simpflat/267 = ExceptNotAnError@{Error};
+  write flat/110/simpflat/268 = s/reify/6/conv/12/simpflat/265;
 }
 else
 {
-  write flat/86/simpflat/210 = s/reify/6/conv/12/simpflat/207;
-  write flat/86/simpflat/211 = 0.0@{Double};
+  write flat/110/simpflat/267 = s/reify/6/conv/12/simpflat/264;
+  write flat/110/simpflat/268 = 0.0@{Double};
 }
-read flat/86/simpflat/212 = flat/86/simpflat/210 [Error];
-read flat/86/simpflat/213 = flat/86/simpflat/211 [Double];
-init flat/87/simpflat/214@{Error} = ExceptNotAnError@{Error};
-init flat/87/simpflat/215@{Double} = 0.0@{Double};
-if (eq#@{Error} flat/86/simpflat/212 (ExceptNotAnError@{Error}))
+read flat/110/simpflat/269 = flat/110/simpflat/267 [Error];
+read flat/110/simpflat/270 = flat/110/simpflat/268 [Double];
+init flat/111/simpflat/271@{Error} = ExceptNotAnError@{Error};
+init flat/111/simpflat/272@{Double} = 0.0@{Double};
+if (eq#@{Error} flat/110/simpflat/269 (ExceptNotAnError@{Error}))
 {
-  init flat/90/simpflat/216@{Error} = ExceptNotAnError@{Error};
-  init flat/90/simpflat/217@{Double} = 0.0@{Double};
-  if (eq#@{Error} a/conv/61/simpflat/203 (ExceptNotAnError@{Error}))
+  init flat/114/simpflat/273@{Error} = ExceptNotAnError@{Error};
+  init flat/114/simpflat/274@{Double} = 0.0@{Double};
+  if (eq#@{Error} a/conv/77/simpflat/260 (ExceptNotAnError@{Error}))
   {
-    let conv/116 = sub#@{Double} a/conv/61/simpflat/204 (1.0@{Double});
-    let simpflat/638 = div# a/conv/61/simpflat/206 conv/116;
-    write flat/90/simpflat/216 = ExceptNotAnError@{Error};
-    write flat/90/simpflat/217 = simpflat/638;
+    let conv/152 = sub#@{Double} a/conv/77/simpflat/261 (1.0@{Double});
+    init flat/125/simpflat/275@{Error} = ExceptNotAnError@{Error};
+    init flat/125/simpflat/276@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/152)
+    {
+      write flat/125/simpflat/275 = ExceptNotAnError@{Error};
+      write flat/125/simpflat/276 = sub#@{Double} a/conv/77/simpflat/261 (1.0@{Double});
+    }
+    else
+    {
+      write flat/125/simpflat/275 = ExceptCannotCompute@{Error};
+      write flat/125/simpflat/276 = 0.0@{Double};
+    }
+    read flat/125/simpflat/277 = flat/125/simpflat/275 [Error];
+    read flat/125/simpflat/278 = flat/125/simpflat/276 [Double];
+    init flat/126/simpflat/279@{Error} = ExceptNotAnError@{Error};
+    init flat/126/simpflat/280@{Double} = 0.0@{Double};
+    if (eq#@{Error} flat/125/simpflat/277 (ExceptNotAnError@{Error}))
+    {
+      let conv/158 = div# a/conv/77/simpflat/263 flat/125/simpflat/278;
+      init flat/129/simpflat/281@{Error} = ExceptNotAnError@{Error};
+      init flat/129/simpflat/282@{Double} = 0.0@{Double};
+      if (doubleIsValid# conv/158)
+      {
+        write flat/129/simpflat/281 = ExceptNotAnError@{Error};
+        write flat/129/simpflat/282 = div# a/conv/77/simpflat/263 flat/125/simpflat/278;
+      }
+      else
+      {
+        write flat/129/simpflat/281 = ExceptCannotCompute@{Error};
+        write flat/129/simpflat/282 = 0.0@{Double};
+      }
+      read flat/129/simpflat/283 = flat/129/simpflat/281 [Error];
+      read flat/129/simpflat/284 = flat/129/simpflat/282 [Double];
+      write flat/126/simpflat/279 = flat/129/simpflat/283;
+      write flat/126/simpflat/280 = flat/129/simpflat/284;
+    }
+    else
+    {
+      write flat/126/simpflat/279 = flat/125/simpflat/277;
+      write flat/126/simpflat/280 = 0.0@{Double};
+    }
+    read flat/126/simpflat/285 = flat/126/simpflat/279 [Error];
+    read flat/126/simpflat/286 = flat/126/simpflat/280 [Double];
+    write flat/114/simpflat/273 = flat/126/simpflat/285;
+    write flat/114/simpflat/274 = flat/126/simpflat/286;
   }
   else
   {
-    write flat/90/simpflat/216 = a/conv/61/simpflat/203;
-    write flat/90/simpflat/217 = 0.0@{Double};
+    write flat/114/simpflat/273 = a/conv/77/simpflat/260;
+    write flat/114/simpflat/274 = 0.0@{Double};
   }
-  read flat/90/simpflat/218 = flat/90/simpflat/216 [Error];
-  read flat/90/simpflat/219 = flat/90/simpflat/217 [Double];
-  init flat/91/simpflat/220@{Error} = ExceptNotAnError@{Error};
-  init flat/91/simpflat/221@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/90/simpflat/218 (ExceptNotAnError@{Error}))
+  read flat/114/simpflat/287 = flat/114/simpflat/273 [Error];
+  read flat/114/simpflat/288 = flat/114/simpflat/274 [Double];
+  init flat/115/simpflat/289@{Error} = ExceptNotAnError@{Error};
+  init flat/115/simpflat/290@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/114/simpflat/287 (ExceptNotAnError@{Error}))
   {
-    write flat/91/simpflat/220 = ExceptNotAnError@{Error};
-    write flat/91/simpflat/221 = sqrt# flat/90/simpflat/219;
+    let conv/172 = sqrt# flat/114/simpflat/288;
+    init flat/122/simpflat/291@{Error} = ExceptNotAnError@{Error};
+    init flat/122/simpflat/292@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/172)
+    {
+      write flat/122/simpflat/291 = ExceptNotAnError@{Error};
+      write flat/122/simpflat/292 = sqrt# flat/114/simpflat/288;
+    }
+    else
+    {
+      write flat/122/simpflat/291 = ExceptCannotCompute@{Error};
+      write flat/122/simpflat/292 = 0.0@{Double};
+    }
+    read flat/122/simpflat/293 = flat/122/simpflat/291 [Error];
+    read flat/122/simpflat/294 = flat/122/simpflat/292 [Double];
+    write flat/115/simpflat/289 = flat/122/simpflat/293;
+    write flat/115/simpflat/290 = flat/122/simpflat/294;
   }
   else
   {
-    write flat/91/simpflat/220 = flat/90/simpflat/218;
-    write flat/91/simpflat/221 = 0.0@{Double};
+    write flat/115/simpflat/289 = flat/114/simpflat/287;
+    write flat/115/simpflat/290 = 0.0@{Double};
   }
-  read flat/91/simpflat/222 = flat/91/simpflat/220 [Error];
-  read flat/91/simpflat/223 = flat/91/simpflat/221 [Double];
-  init flat/92/simpflat/224@{Error} = ExceptNotAnError@{Error};
-  init flat/92/simpflat/225@{Double} = 0.0@{Double};
-  if (eq#@{Error} flat/91/simpflat/222 (ExceptNotAnError@{Error}))
+  read flat/115/simpflat/295 = flat/115/simpflat/289 [Error];
+  read flat/115/simpflat/296 = flat/115/simpflat/290 [Double];
+  init flat/116/simpflat/297@{Error} = ExceptNotAnError@{Error};
+  init flat/116/simpflat/298@{Double} = 0.0@{Double};
+  if (eq#@{Error} flat/115/simpflat/295 (ExceptNotAnError@{Error}))
   {
-    write flat/92/simpflat/224 = ExceptNotAnError@{Error};
-    write flat/92/simpflat/225 = mul#@{Double} flat/86/simpflat/213 flat/91/simpflat/223;
+    let conv/180 = mul#@{Double} flat/110/simpflat/270 flat/115/simpflat/296;
+    init flat/119/simpflat/299@{Error} = ExceptNotAnError@{Error};
+    init flat/119/simpflat/300@{Double} = 0.0@{Double};
+    if (doubleIsValid# conv/180)
+    {
+      write flat/119/simpflat/299 = ExceptNotAnError@{Error};
+      write flat/119/simpflat/300 = mul#@{Double} flat/110/simpflat/270 flat/115/simpflat/296;
+    }
+    else
+    {
+      write flat/119/simpflat/299 = ExceptCannotCompute@{Error};
+      write flat/119/simpflat/300 = 0.0@{Double};
+    }
+    read flat/119/simpflat/301 = flat/119/simpflat/299 [Error];
+    read flat/119/simpflat/302 = flat/119/simpflat/300 [Double];
+    write flat/116/simpflat/297 = flat/119/simpflat/301;
+    write flat/116/simpflat/298 = flat/119/simpflat/302;
   }
   else
   {
-    write flat/92/simpflat/224 = flat/91/simpflat/222;
-    write flat/92/simpflat/225 = 0.0@{Double};
+    write flat/116/simpflat/297 = flat/115/simpflat/295;
+    write flat/116/simpflat/298 = 0.0@{Double};
   }
-  read flat/92/simpflat/226 = flat/92/simpflat/224 [Error];
-  read flat/92/simpflat/227 = flat/92/simpflat/225 [Double];
-  write flat/87/simpflat/214 = flat/92/simpflat/226;
-  write flat/87/simpflat/215 = flat/92/simpflat/227;
+  read flat/116/simpflat/303 = flat/116/simpflat/297 [Error];
+  read flat/116/simpflat/304 = flat/116/simpflat/298 [Double];
+  write flat/111/simpflat/271 = flat/116/simpflat/303;
+  write flat/111/simpflat/272 = flat/116/simpflat/304;
 }
 else
 {
-  write flat/87/simpflat/214 = flat/86/simpflat/212;
-  write flat/87/simpflat/215 = 0.0@{Double};
+  write flat/111/simpflat/271 = flat/110/simpflat/269;
+  write flat/111/simpflat/272 = 0.0@{Double};
 }
-read flat/87/simpflat/228 = flat/87/simpflat/214 [Error];
-read flat/87/simpflat/229 = flat/87/simpflat/215 [Double];
-output@{(Sum Error Double)} repl:output (flat/87/simpflat/228@{Error}, flat/87/simpflat/229@{Double});
+read flat/111/simpflat/305 = flat/111/simpflat/271 [Error];
+read flat/111/simpflat/306 = flat/111/simpflat/272 [Double];
+output@{(Sum Error Double)} repl:output (flat/111/simpflat/305@{Error}, flat/111/simpflat/306@{Double});
 
 - C:
 #line 1 "cluster state #0 - repl:input"
@@ -1191,10 +1819,10 @@ output@{(Sum Error Double)} repl:output (flat/87/simpflat/228@{Error}, flat/87/s
 typedef struct {
     itime_t          convzs3;
     iint_t           new_count;
-    ierror_t         *new_convzs0zssimpflatzs230;
-    istring_t        *new_convzs0zssimpflatzs231;
-    iint_t           *new_convzs0zssimpflatzs232;
-    itime_t          *new_convzs0zssimpflatzs233;
+    ierror_t         *new_convzs0zssimpflatzs307;
+    istring_t        *new_convzs0zssimpflatzs308;
+    iint_t           *new_convzs0zssimpflatzs309;
+    itime_t          *new_convzs0zssimpflatzs310;
 } input_replZCinput_t;
 
 typedef struct {
@@ -1211,31 +1839,31 @@ typedef struct {
     idouble_t        replZCoutputzsixzs1;
 
     /* resumables: values */
-    idouble_t        res_0_0_acczsconvzs11zssimpflatzs34;
-    ierror_t         res_0_0_acczsconvzs11zssimpflatzs33;
-    idouble_t        res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41;
-    idouble_t        res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40;
-    ierror_t         res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39;
-    ierror_t         res_0_0_acczsconvzs60zssimpflatzs42;
-    idouble_t        res_0_0_acczsconvzs60zssimpflatzs43;
-    idouble_t        res_0_0_acczsazsconvzs61zssimpflatzs49;
-    ierror_t         res_0_0_acczsazsconvzs61zssimpflatzs48;
-    idouble_t        res_0_0_acczsazsconvzs61zssimpflatzs50;
-    idouble_t        res_0_0_acczsazsconvzs61zssimpflatzs51;
+    idouble_t        res_0_0_acczsconvzs11zssimpflatzs23;
+    ierror_t         res_0_0_acczsconvzs11zssimpflatzs22;
+    idouble_t        res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30;
+    idouble_t        res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29;
+    ierror_t         res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28;
+    ierror_t         res_0_0_acczsazsconvzs77zssimpflatzs37;
+    idouble_t        res_0_0_acczsazsconvzs77zssimpflatzs39;
+    idouble_t        res_0_0_acczsazsconvzs77zssimpflatzs38;
+    ierror_t         res_0_0_acczsconvzs76zssimpflatzs31;
+    idouble_t        res_0_0_acczsconvzs76zssimpflatzs32;
+    idouble_t        res_0_0_acczsazsconvzs77zssimpflatzs40;
 
     /* resumables: has flags */
     ibool_t          has_flags_start_0_0;
-    ibool_t          has_0_0_acczsconvzs11zssimpflatzs34;
-    ibool_t          has_0_0_acczsconvzs11zssimpflatzs33;
-    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41;
-    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40;
-    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39;
-    ibool_t          has_0_0_acczsconvzs60zssimpflatzs42;
-    ibool_t          has_0_0_acczsconvzs60zssimpflatzs43;
-    ibool_t          has_0_0_acczsazsconvzs61zssimpflatzs49;
-    ibool_t          has_0_0_acczsazsconvzs61zssimpflatzs48;
-    ibool_t          has_0_0_acczsazsconvzs61zssimpflatzs50;
-    ibool_t          has_0_0_acczsazsconvzs61zssimpflatzs51;
+    ibool_t          has_0_0_acczsconvzs11zssimpflatzs23;
+    ibool_t          has_0_0_acczsconvzs11zssimpflatzs22;
+    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30;
+    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29;
+    ibool_t          has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28;
+    ibool_t          has_0_0_acczsazsconvzs77zssimpflatzs37;
+    ibool_t          has_0_0_acczsazsconvzs77zssimpflatzs39;
+    ibool_t          has_0_0_acczsazsconvzs77zssimpflatzs38;
+    ibool_t          has_0_0_acczsconvzs76zssimpflatzs31;
+    ibool_t          has_0_0_acczsconvzs76zssimpflatzs32;
+    ibool_t          has_0_0_acczsazsconvzs77zssimpflatzs40;
     ibool_t          has_flags_end_0_0;
 
 
@@ -1249,805 +1877,1186 @@ iint_t size_of_icluster_0 ()
 #line 1 "kernel function #0 - repl:input icluster_0_kernel_0"
 void icluster_0_kernel_0(icluster_0_t *s)
 {
-    idouble_t        flatzs29zssimpflatzs130;
-    ierror_t         flatzs91zssimpflatzs220;
-    idouble_t        flatzs91zssimpflatzs221;
-    ierror_t         flatzs91zssimpflatzs222;
-    idouble_t        flatzs91zssimpflatzs223;
-    ierror_t         flatzs92zssimpflatzs226;
-    idouble_t        flatzs92zssimpflatzs227;
-    ierror_t         flatzs92zssimpflatzs224;
-    idouble_t        flatzs92zssimpflatzs225;
-    idouble_t        flatzs38zssimpflatzs178;
-    idouble_t        flatzs38zssimpflatzs179;
-    ierror_t         flatzs38zssimpflatzs177;
-    idouble_t        flatzs37zssimpflatzs176;
-    idouble_t        flatzs37zssimpflatzs174;
-    ierror_t         flatzs37zssimpflatzs175;
-    ierror_t         flatzs37zssimpflatzs173;
-    ierror_t         flatzs36zssimpflatzs171;
-    idouble_t        flatzs36zssimpflatzs172;
-    istring_t        flatzs25zssimpflatzs116;
-    ierror_t         flatzs25zssimpflatzs115;
-    ierror_t         flatzs25zssimpflatzs117;
-    istring_t        flatzs25zssimpflatzs118;
-    ierror_t         flatzs26zssimpflatzs119;
-    idouble_t        flatzs33zssimpflatzs148;
-    ierror_t         flatzs33zssimpflatzs145;
-    ierror_t         flatzs33zssimpflatzs147;
-    idouble_t        flatzs33zssimpflatzs146;
-    ierror_t         flatzs34zssimpflatzs149;
-    idouble_t        flatzs30zssimpflatzs142;
-    idouble_t        flatzs30zssimpflatzs143;
-    ierror_t         flatzs30zssimpflatzs141;
-    idouble_t        flatzs30zssimpflatzs144;
-    ierror_t         flatzs3zssimpflatzs73;
-    idouble_t        flatzs3zssimpflatzs74;
-    idouble_t        flatzs3zssimpflatzs75;
-    idouble_t        flatzs90zssimpflatzs217;
-    ierror_t         flatzs90zssimpflatzs216;
-    idouble_t        flatzs90zssimpflatzs219;
-    ierror_t         flatzs90zssimpflatzs218;
-    ierror_t         flatzs34zssimpflatzs151;
-    idouble_t        flatzs34zssimpflatzs152;
-    idouble_t        flatzs34zssimpflatzs150;
-    idouble_t        flatzs36zssimpflatzs158;
-    ierror_t         flatzs36zssimpflatzs157;
-    ierror_t         flatzs35zssimpflatzs153;
-    idouble_t        flatzs35zssimpflatzs154;
-    ierror_t         flatzs35zssimpflatzs155;
-    idouble_t        flatzs35zssimpflatzs156;
-    idouble_t        acczsconvzs11zssimpflatzs34;
-    ierror_t         acczsconvzs11zssimpflatzs33;
-    idouble_t        flatzs15zssimpflatzs88;
-    ierror_t         flatzs15zssimpflatzs89;
-    ierror_t         flatzs15zssimpflatzs87;
-    idouble_t        flatzs14zssimpflatzs86;
-    idouble_t        flatzs14zssimpflatzs84;
-    ierror_t         flatzs14zssimpflatzs85;
-    ierror_t         flatzs14zssimpflatzs83;
-    idouble_t        flatzs13zssimpflatzs80;
-    ierror_t         flatzs13zssimpflatzs81;
-    idouble_t        flatzs13zssimpflatzs82;
-    ierror_t         flatzs10zssimpflatzs97;
-    idouble_t        flatzs10zssimpflatzs99;
-    idouble_t        flatzs10zssimpflatzs98;
-    idouble_t        flatzs15zssimpflatzs90;
-    idouble_t        flatzs16zssimpflatzs96;
-    idouble_t        flatzs16zssimpflatzs95;
-    ierror_t         flatzs16zssimpflatzs94;
-    idouble_t        flatzs16zssimpflatzs93;
-    idouble_t        flatzs16zssimpflatzs92;
-    ierror_t         flatzs16zssimpflatzs91;
-    ierror_t         flatzs29zssimpflatzs129;
-    idouble_t        flatzs29zssimpflatzs128;
-    ierror_t         flatzs29zssimpflatzs127;
-    ierror_t         flatzs28zssimpflatzs123;
-    iint_t           flatzs28zssimpflatzs124;
-    ierror_t         flatzs28zssimpflatzs125;
-    iint_t           flatzs28zssimpflatzs126;
-    ibool_t          flatzs26zssimpflatzs120;
-    ierror_t         flatzs26zssimpflatzs121;
-    ibool_t          flatzs26zssimpflatzs122;
-    ierror_t         flatzs13zssimpflatzs79;
-    idouble_t        flatzs10zssimpflatzs78;
-    idouble_t        flatzs10zssimpflatzs77;
-    ierror_t         flatzs10zssimpflatzs76;
-    ierror_t         flatzs3zssimpflatzs112;
-    idouble_t        flatzs3zssimpflatzs114;
-    idouble_t        flatzs3zssimpflatzs113;
-    idouble_t        flatzs6zssimpflatzs110;
-    idouble_t        flatzs6zssimpflatzs111;
-    idouble_t        flatzs7zssimpflatzs108;
-    ierror_t         flatzs7zssimpflatzs106;
-    idouble_t        flatzs7zssimpflatzs107;
-    idouble_t        flatzs7zssimpflatzs104;
-    idouble_t        flatzs7zssimpflatzs105;
-    ierror_t         flatzs7zssimpflatzs103;
-    idouble_t        flatzs6zssimpflatzs101;
-    ierror_t         flatzs6zssimpflatzs100;
-    idouble_t        flatzs6zssimpflatzs102;
-    ierror_t         flatzs6zssimpflatzs109;
-    idouble_t        flatzs38zssimpflatzs182;
-    idouble_t        flatzs38zssimpflatzs181;
-    ierror_t         flatzs38zssimpflatzs180;
-    idouble_t        flatzs39zssimpflatzs185;
-    idouble_t        flatzs39zssimpflatzs184;
-    idouble_t        flatzs39zssimpflatzs186;
-    ierror_t         flatzs39zssimpflatzs183;
-    ierror_t         flatzs30zssimpflatzs199;
-    idouble_t        flatzs39zssimpflatzs196;
-    idouble_t        flatzs39zssimpflatzs197;
-    idouble_t        flatzs39zssimpflatzs198;
-    ierror_t         flatzs39zssimpflatzs195;
-    idouble_t        flatzs30zssimpflatzs200;
-    idouble_t        flatzs30zssimpflatzs202;
-    idouble_t        flatzs30zssimpflatzs201;
-    idouble_t        acczsszsreifyzs6zsconvzs12zssimpflatzs41;
-    idouble_t        acczsszsreifyzs6zsconvzs12zssimpflatzs40;
-    idouble_t        azsconvzs61zsavalzs2zssimpflatzs140;
-    ierror_t         acczsszsreifyzs6zsconvzs12zssimpflatzs39;
-    ierror_t         azsconvzs61zssimpflatzs203;
-    idouble_t        azsconvzs61zssimpflatzs204;
-    idouble_t        azsconvzs61zssimpflatzs206;
-    idouble_t        flatzs42zssimpflatzs188;
-    idouble_t        flatzs42zssimpflatzs189;
-    ierror_t         flatzs42zssimpflatzs187;
-    ierror_t         szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70;
-    idouble_t        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs71;
-    idouble_t        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs72;
-    ierror_t         azsconvzs61zsavalzs2zssimpflatzs137;
-    idouble_t        azsconvzs61zsavalzs2zssimpflatzs139;
-    idouble_t        azsconvzs61zsavalzs2zssimpflatzs138;
-    idouble_t        convzs60zsavalzs3zssimpflatzs132;
-    ierror_t         convzs60zsavalzs3zssimpflatzs131;
-    ierror_t         flatzs42zssimpflatzs191;
-    idouble_t        flatzs42zssimpflatzs190;
-    idouble_t        flatzs42zssimpflatzs194;
-    idouble_t        flatzs42zssimpflatzs193;
-    idouble_t        flatzs42zssimpflatzs192;
-    idouble_t        flatzs52zssimpflatzs170;
-    ierror_t         acczsconvzs60zssimpflatzs42;
-    idouble_t        acczsconvzs60zssimpflatzs43;
-    ierror_t         flatzs57zssimpflatzs161;
-    ierror_t         flatzs57zssimpflatzs163;
-    idouble_t        flatzs57zssimpflatzs162;
-    idouble_t        flatzs57zssimpflatzs164;
-    ierror_t         flatzs52zssimpflatzs167;
-    ierror_t         flatzs52zssimpflatzs169;
-    idouble_t        flatzs52zssimpflatzs168;
-    ierror_t         flatzs51zssimpflatzs165;
-    idouble_t        flatzs51zssimpflatzs160;
-    idouble_t        flatzs51zssimpflatzs166;
-    idouble_t        acczsazsconvzs61zssimpflatzs49;
-    ierror_t         acczsazsconvzs61zssimpflatzs48;
-    idouble_t        acczsazsconvzs61zssimpflatzs50;
-    idouble_t        acczsazsconvzs61zssimpflatzs51;
-    ierror_t         flatzs51zssimpflatzs159;
-    ierror_t         szsreifyzs6zsconvzs12zssimpflatzs207;
-    idouble_t        szsreifyzs6zsconvzs12zssimpflatzs208;
-    ibool_t          flatzs27;
-    idouble_t        flatzs2zssimpflatzs63;
-    ierror_t         flatzs2zssimpflatzs62;
-    idouble_t        flatzs2zssimpflatzs61;
-    ierror_t         flatzs2zssimpflatzs60;
-    ierror_t         flatzs87zssimpflatzs228;
-    idouble_t        flatzs87zssimpflatzs229;
-    ierror_t         flatzs1zssimpflatzs58;
-    idouble_t        flatzs1zssimpflatzs59;
-    ierror_t         flatzs1zssimpflatzs56;
-    idouble_t        flatzs1zssimpflatzs57;
-    ierror_t         flatzs0zssimpflatzs52;
-    iint_t           flatzs0zssimpflatzs53;
-    ierror_t         flatzs0zssimpflatzs54;
-    iint_t           flatzs0zssimpflatzs55;
-    idouble_t        convzs11zsavalzs1zssimpflatzs65;
-    ierror_t         convzs11zsavalzs1zssimpflatzs64;
-    ierror_t         flatzs86zssimpflatzs212;
-    idouble_t        flatzs86zssimpflatzs211;
-    ierror_t         flatzs86zssimpflatzs210;
-    idouble_t        flatzs86zssimpflatzs213;
-    ierror_t         flatzs87zssimpflatzs214;
-    idouble_t        flatzs87zssimpflatzs215;
+    idouble_t        flatzs20zssimpflatzs109;
+    ierror_t         flatzs20zssimpflatzs107;
+    idouble_t        flatzs20zssimpflatzs108;
+    idouble_t        flatzs20zssimpflatzs112;
+    idouble_t        flatzs20zssimpflatzs111;
+    ierror_t         flatzs20zssimpflatzs110;
+    iint_t           flatzs39zssimpflatzs143;
+    ierror_t         flatzs39zssimpflatzs142;
+    ierror_t         flatzs39zssimpflatzs144;
+    iint_t           flatzs39zssimpflatzs145;
+    ibool_t          flatzs37zssimpflatzs141;
+    ierror_t         flatzs37zssimpflatzs140;
+    ierror_t         flatzs37zssimpflatzs138;
+    ibool_t          flatzs37zssimpflatzs139;
+    istring_t        flatzs36zssimpflatzs137;
+    ierror_t         flatzs36zssimpflatzs134;
+    ierror_t         flatzs36zssimpflatzs136;
+    istring_t        flatzs36zssimpflatzs135;
+    idouble_t        flatzs14zssimpflatzs91;
+    ierror_t         flatzs14zssimpflatzs90;
+    idouble_t        flatzs15zssimpflatzs99;
+    ierror_t         flatzs15zssimpflatzs98;
+    idouble_t        flatzs15zssimpflatzs93;
+    ierror_t         flatzs15zssimpflatzs92;
+    idouble_t        acczsconvzs11zssimpflatzs23;
+    ierror_t         acczsconvzs11zssimpflatzs22;
+    idouble_t        flatzs13zssimpflatzs75;
+    ierror_t         flatzs13zssimpflatzs74;
+    idouble_t        flatzs14zssimpflatzs77;
+    ierror_t         flatzs14zssimpflatzs76;
+    ierror_t         flatzs6zssimpflatzs119;
+    ierror_t         flatzs115zssimpflatzs289;
+    idouble_t        flatzs114zssimpflatzs288;
+    ierror_t         flatzs114zssimpflatzs287;
+    ierror_t         flatzs3zssimpflatzs131;
+    idouble_t        flatzs3zssimpflatzs133;
+    idouble_t        flatzs3zssimpflatzs132;
+    idouble_t        flatzs6zssimpflatzs130;
+    idouble_t        flatzs115zssimpflatzs290;
+    idouble_t        flatzs115zssimpflatzs296;
+    ierror_t         flatzs115zssimpflatzs295;
+    idouble_t        flatzs116zssimpflatzs298;
+    ierror_t         flatzs116zssimpflatzs297;
+    ierror_t         flatzs119zssimpflatzs299;
+    ierror_t         szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59;
+    idouble_t        flatzs28zssimpflatzs81;
+    ierror_t         flatzs28zssimpflatzs80;
+    idouble_t        flatzs29zssimpflatzs89;
+    ierror_t         flatzs29zssimpflatzs88;
+    idouble_t        flatzs29zssimpflatzs83;
+    ierror_t         flatzs29zssimpflatzs82;
+    idouble_t        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61;
+    idouble_t        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60;
+    ierror_t         flatzs25zssimpflatzs94;
+    idouble_t        flatzs25zssimpflatzs95;
+    ierror_t         flatzs25zssimpflatzs96;
+    idouble_t        flatzs25zssimpflatzs97;
+    ierror_t         flatzs28zssimpflatzs78;
+    idouble_t        flatzs28zssimpflatzs79;
+    idouble_t        flatzs16zssimpflatzs102;
+    ierror_t         flatzs16zssimpflatzs100;
+    idouble_t        flatzs16zssimpflatzs101;
+    ierror_t         flatzs19zssimpflatzs103;
+    ierror_t         flatzs19zssimpflatzs105;
+    idouble_t        flatzs19zssimpflatzs104;
+    idouble_t        flatzs19zssimpflatzs106;
+    ierror_t         flatzs110zssimpflatzs269;
+    idouble_t        flatzs110zssimpflatzs268;
+    ierror_t         flatzs110zssimpflatzs267;
+    idouble_t        flatzs10zssimpflatzs118;
+    ierror_t         flatzs10zssimpflatzs116;
+    idouble_t        flatzs10zssimpflatzs117;
+    idouble_t        flatzs16zssimpflatzs115;
+    ierror_t         flatzs16zssimpflatzs113;
+    idouble_t        flatzs16zssimpflatzs114;
+    ierror_t         flatzs114zssimpflatzs273;
+    idouble_t        flatzs114zssimpflatzs274;
+    idouble_t        flatzs110zssimpflatzs270;
+    idouble_t        flatzs111zssimpflatzs272;
+    ierror_t         flatzs111zssimpflatzs271;
+    idouble_t        flatzs116zssimpflatzs304;
+    ierror_t         flatzs116zssimpflatzs303;
+    idouble_t        flatzs119zssimpflatzs300;
+    idouble_t        flatzs119zssimpflatzs302;
+    ierror_t         flatzs119zssimpflatzs301;
+    idouble_t        flatzs111zssimpflatzs306;
+    ierror_t         flatzs111zssimpflatzs305;
+    ierror_t         flatzs32zssimpflatzs86;
+    idouble_t        flatzs32zssimpflatzs87;
+    ierror_t         flatzs32zssimpflatzs84;
+    idouble_t        flatzs32zssimpflatzs85;
+    idouble_t        flatzs7zssimpflatzs123;
+    idouble_t        flatzs7zssimpflatzs124;
+    ierror_t         flatzs7zssimpflatzs125;
+    idouble_t        flatzs7zssimpflatzs126;
+    idouble_t        flatzs7zssimpflatzs127;
+    ierror_t         flatzs7zssimpflatzs122;
+    idouble_t        flatzs6zssimpflatzs121;
+    idouble_t        flatzs6zssimpflatzs120;
+    idouble_t        flatzs6zssimpflatzs129;
+    ierror_t         flatzs6zssimpflatzs128;
+    idouble_t        flatzs35zssimpflatzs73;
+    ierror_t         flatzs35zssimpflatzs72;
+    idouble_t        flatzs35zssimpflatzs71;
+    ierror_t         flatzs35zssimpflatzs70;
+    ierror_t         flatzs48zssimpflatzs218;
+    idouble_t        flatzs48zssimpflatzs219;
+    idouble_t        acczsszsreifyzs6zsconvzs12zssimpflatzs30;
+    idouble_t        flatzs54zssimpflatzs246;
+    idouble_t        flatzs54zssimpflatzs247;
+    ierror_t         flatzs54zssimpflatzs244;
+    ierror_t         flatzs54zssimpflatzs248;
+    idouble_t        flatzs54zssimpflatzs249;
+    idouble_t        flatzs54zssimpflatzs245;
+    idouble_t        flatzs51zssimpflatzs243;
+    ierror_t         flatzs51zssimpflatzs240;
+    idouble_t        flatzs51zssimpflatzs242;
+    idouble_t        flatzs51zssimpflatzs241;
+    idouble_t        acczsszsreifyzs6zsconvzs12zssimpflatzs29;
+    ierror_t         acczsszsreifyzs6zsconvzs12zssimpflatzs28;
+    idouble_t        flatzs49zssimpflatzs221;
+    ierror_t         flatzs49zssimpflatzs220;
+    idouble_t        flatzs49zssimpflatzs227;
+    ierror_t         flatzs49zssimpflatzs226;
+    idouble_t        flatzs54zssimpflatzs251;
+    idouble_t        flatzs54zssimpflatzs250;
+    ierror_t         flatzs51zssimpflatzs252;
+    idouble_t        flatzs51zssimpflatzs254;
+    idouble_t        flatzs51zssimpflatzs253;
+    idouble_t        flatzs51zssimpflatzs255;
+    ierror_t         flatzs89zssimpflatzs170;
+    idouble_t        flatzs89zssimpflatzs171;
+    ierror_t         flatzs89zssimpflatzs172;
+    idouble_t        flatzs89zssimpflatzs173;
+    ierror_t         flatzs83zssimpflatzs178;
+    idouble_t        flatzs83zssimpflatzs179;
+    ierror_t         flatzs47zssimpflatzs188;
+    idouble_t        flatzs47zssimpflatzs189;
+    ierror_t         flatzs46zssimpflatzs186;
+    idouble_t        flatzs46zssimpflatzs187;
+    idouble_t        azsconvzs77zsavalzs2zssimpflatzs158;
+    idouble_t        azsconvzs77zsavalzs2zssimpflatzs159;
+    ierror_t         azsconvzs77zsavalzs2zssimpflatzs156;
+    idouble_t        azsconvzs77zsavalzs2zssimpflatzs157;
+    ierror_t         convzs76zsavalzs3zssimpflatzs150;
+    idouble_t        convzs76zsavalzs3zssimpflatzs151;
+    ierror_t         flatzs50zssimpflatzs228;
+    idouble_t        flatzs50zssimpflatzs229;
+    idouble_t        flatzs59zssimpflatzs233;
+    idouble_t        flatzs59zssimpflatzs232;
+    ierror_t         flatzs59zssimpflatzs231;
+    idouble_t        flatzs59zssimpflatzs236;
+    idouble_t        flatzs59zssimpflatzs235;
+    ierror_t         flatzs59zssimpflatzs234;
+    idouble_t        flatzs50zssimpflatzs239;
+    idouble_t        flatzs50zssimpflatzs238;
+    idouble_t        flatzs50zssimpflatzs230;
+    ierror_t         flatzs50zssimpflatzs237;
+    idouble_t        flatzs41zssimpflatzs259;
+    idouble_t        flatzs41zssimpflatzs257;
+    idouble_t        flatzs41zssimpflatzs258;
+    ierror_t         flatzs41zssimpflatzs256;
+    idouble_t        flatzs47zssimpflatzs195;
+    ierror_t         flatzs47zssimpflatzs194;
+    idouble_t        flatzs48zssimpflatzs197;
+    ierror_t         flatzs48zssimpflatzs196;
+    ierror_t         azsconvzs77zssimpflatzs260;
+    idouble_t        azsconvzs77zssimpflatzs261;
+    idouble_t        azsconvzs77zssimpflatzs263;
+    idouble_t        flatzs68zssimpflatzs217;
+    ierror_t         flatzs68zssimpflatzs210;
+    idouble_t        flatzs68zssimpflatzs211;
+    ierror_t         flatzs68zssimpflatzs216;
+    ierror_t         flatzs80zssimpflatzs192;
+    idouble_t        flatzs80zssimpflatzs193;
+    ierror_t         flatzs80zssimpflatzs190;
+    idouble_t        flatzs80zssimpflatzs191;
+    ierror_t         flatzs67zssimpflatzs208;
+    idouble_t        flatzs67zssimpflatzs209;
+    idouble_t        flatzs10zssimpflatzs66;
+    idouble_t        flatzs10zssimpflatzs67;
+    ierror_t         flatzs10zssimpflatzs65;
+    ierror_t         flatzs13zssimpflatzs68;
+    idouble_t        flatzs13zssimpflatzs69;
+    ierror_t         flatzs125zssimpflatzs277;
+    idouble_t        flatzs125zssimpflatzs276;
+    idouble_t        flatzs125zssimpflatzs278;
+    ierror_t         flatzs125zssimpflatzs275;
+    ierror_t         flatzs126zssimpflatzs279;
+    idouble_t        szsreifyzs6zsconvzs12zssimpflatzs265;
+    ierror_t         szsreifyzs6zsconvzs12zssimpflatzs264;
+    idouble_t        flatzs64zssimpflatzs225;
+    ierror_t         flatzs64zssimpflatzs224;
+    idouble_t        flatzs64zssimpflatzs223;
+    ierror_t         flatzs64zssimpflatzs222;
+    idouble_t        flatzs83zssimpflatzs185;
+    ierror_t         flatzs83zssimpflatzs184;
+    idouble_t        flatzs86zssimpflatzs181;
+    ierror_t         flatzs86zssimpflatzs180;
+    idouble_t        flatzs86zssimpflatzs183;
+    ierror_t         flatzs86zssimpflatzs182;
+    idouble_t        flatzs45zssimpflatzs175;
+    ierror_t         flatzs45zssimpflatzs174;
+    idouble_t        flatzs46zssimpflatzs177;
+    ierror_t         flatzs46zssimpflatzs176;
+    ierror_t         acczsazsconvzs77zssimpflatzs37;
+    idouble_t        acczsazsconvzs77zssimpflatzs39;
+    idouble_t        acczsazsconvzs77zssimpflatzs38;
+    ierror_t         flatzs2zssimpflatzs49;
+    ierror_t         flatzs0zssimpflatzs41;
+    iint_t           flatzs0zssimpflatzs44;
+    ierror_t         flatzs0zssimpflatzs43;
+    iint_t           flatzs0zssimpflatzs42;
+    ierror_t         flatzs1zssimpflatzs45;
+    ierror_t         flatzs1zssimpflatzs47;
+    idouble_t        flatzs1zssimpflatzs46;
+    idouble_t        flatzs1zssimpflatzs48;
+    ierror_t         flatzs129zssimpflatzs281;
+    idouble_t        flatzs129zssimpflatzs284;
+    idouble_t        flatzs129zssimpflatzs282;
+    ierror_t         flatzs129zssimpflatzs283;
+    idouble_t        flatzs126zssimpflatzs286;
+    ierror_t         flatzs126zssimpflatzs285;
+    idouble_t        flatzs126zssimpflatzs280;
+    ierror_t         flatzs71zssimpflatzs214;
+    idouble_t        flatzs71zssimpflatzs215;
+    idouble_t        flatzs71zssimpflatzs213;
+    ierror_t         flatzs71zssimpflatzs212;
+    ierror_t         acczsconvzs76zssimpflatzs31;
+    idouble_t        acczsconvzs76zssimpflatzs32;
+    idouble_t        acczsazsconvzs77zssimpflatzs40;
+    idouble_t        flatzs77zssimpflatzs205;
+    ierror_t         flatzs77zssimpflatzs204;
+    idouble_t        flatzs77zssimpflatzs203;
+    ierror_t         flatzs77zssimpflatzs202;
+    idouble_t        flatzs74zssimpflatzs201;
+    ierror_t         flatzs74zssimpflatzs206;
+    idouble_t        flatzs74zssimpflatzs207;
+    ierror_t         flatzs74zssimpflatzs200;
+    idouble_t        flatzs41zssimpflatzs162;
+    idouble_t        flatzs41zssimpflatzs163;
+    ierror_t         flatzs41zssimpflatzs160;
+    idouble_t        flatzs41zssimpflatzs161;
+    ierror_t         flatzs45zssimpflatzs168;
+    idouble_t        flatzs45zssimpflatzs169;
+    ierror_t         flatzs44zssimpflatzs164;
+    idouble_t        flatzs44zssimpflatzs165;
+    ierror_t         flatzs44zssimpflatzs166;
+    idouble_t        flatzs44zssimpflatzs167;
+    idouble_t        flatzs3zssimpflatzs63;
+    ierror_t         flatzs3zssimpflatzs62;
+    idouble_t        flatzs3zssimpflatzs64;
+    idouble_t        flatzs2zssimpflatzs50;
+    ierror_t         flatzs2zssimpflatzs51;
+    idouble_t        flatzs2zssimpflatzs52;
+    ierror_t         flatzs122zssimpflatzs293;
+    ierror_t         flatzs122zssimpflatzs291;
+    idouble_t        flatzs122zssimpflatzs292;
+    idouble_t        flatzs122zssimpflatzs294;
+    ibool_t          flatzs38;
+    idouble_t        convzs11zsavalzs1zssimpflatzs54;
+    ierror_t         convzs11zsavalzs1zssimpflatzs53;
+    idouble_t        flatzs67zssimpflatzs199;
+    ierror_t         flatzs67zssimpflatzs198;
+    idouble_t        flatzs40zssimpflatzs149;
+    ierror_t         flatzs40zssimpflatzs148;
+    ierror_t         flatzs40zssimpflatzs146;
+    idouble_t        flatzs40zssimpflatzs147;
 
     anemone_mempool_t *mempool                = s->mempool;
     itime_t          convzs3                  = s->input.convzs3;
     iint_t           convzs4                  = s->max_map_size;
 
-    acczsconvzs11zssimpflatzs33               = ierror_not_an_error;                  /* init */
-    acczsconvzs11zssimpflatzs34               = 0.0;                                  /* init */
-    acczsszsreifyzs6zsconvzs12zssimpflatzs39  = ierror_fold1_no_value;                /* init */
-    acczsszsreifyzs6zsconvzs12zssimpflatzs40  = 0.0;                                  /* init */
-    acczsszsreifyzs6zsconvzs12zssimpflatzs41  = 0.0;                                  /* init */
-    acczsconvzs60zssimpflatzs42               = ierror_not_an_error;                  /* init */
-    acczsconvzs60zssimpflatzs43               = 0.0;                                  /* init */
-    acczsazsconvzs61zssimpflatzs48            = ierror_not_an_error;                  /* init */
-    acczsazsconvzs61zssimpflatzs49            = 0.0;                                  /* init */
-    acczsazsconvzs61zssimpflatzs50            = 0.0;                                  /* init */
-    acczsazsconvzs61zssimpflatzs51            = 0.0;                                  /* init */
+    acczsconvzs11zssimpflatzs22               = ierror_not_an_error;                  /* init */
+    acczsconvzs11zssimpflatzs23               = 0.0;                                  /* init */
+    acczsszsreifyzs6zsconvzs12zssimpflatzs28  = ierror_fold1_no_value;                /* init */
+    acczsszsreifyzs6zsconvzs12zssimpflatzs29  = 0.0;                                  /* init */
+    acczsszsreifyzs6zsconvzs12zssimpflatzs30  = 0.0;                                  /* init */
+    acczsconvzs76zssimpflatzs31               = ierror_not_an_error;                  /* init */
+    acczsconvzs76zssimpflatzs32               = 0.0;                                  /* init */
+    acczsazsconvzs77zssimpflatzs37            = ierror_not_an_error;                  /* init */
+    acczsazsconvzs77zssimpflatzs38            = 0.0;                                  /* init */
+    acczsazsconvzs77zssimpflatzs39            = 0.0;                                  /* init */
+    acczsazsconvzs77zssimpflatzs40            = 0.0;                                  /* init */
     
-    if (s->has_0_0_acczsazsconvzs61zssimpflatzs48) {
-        acczsazsconvzs61zssimpflatzs48        = s->res_0_0_acczsazsconvzs61zssimpflatzs48; /* load */
+    if (s->has_0_0_acczsazsconvzs77zssimpflatzs37) {
+        acczsazsconvzs77zssimpflatzs37        = s->res_0_0_acczsazsconvzs77zssimpflatzs37; /* load */
     }
     
-    if (s->has_0_0_acczsazsconvzs61zssimpflatzs49) {
-        acczsazsconvzs61zssimpflatzs49        = s->res_0_0_acczsazsconvzs61zssimpflatzs49; /* load */
+    if (s->has_0_0_acczsazsconvzs77zssimpflatzs38) {
+        acczsazsconvzs77zssimpflatzs38        = s->res_0_0_acczsazsconvzs77zssimpflatzs38; /* load */
     }
     
-    if (s->has_0_0_acczsazsconvzs61zssimpflatzs50) {
-        acczsazsconvzs61zssimpflatzs50        = s->res_0_0_acczsazsconvzs61zssimpflatzs50; /* load */
+    if (s->has_0_0_acczsazsconvzs77zssimpflatzs39) {
+        acczsazsconvzs77zssimpflatzs39        = s->res_0_0_acczsazsconvzs77zssimpflatzs39; /* load */
     }
     
-    if (s->has_0_0_acczsazsconvzs61zssimpflatzs51) {
-        acczsazsconvzs61zssimpflatzs51        = s->res_0_0_acczsazsconvzs61zssimpflatzs51; /* load */
+    if (s->has_0_0_acczsazsconvzs77zssimpflatzs40) {
+        acczsazsconvzs77zssimpflatzs40        = s->res_0_0_acczsazsconvzs77zssimpflatzs40; /* load */
     }
     
-    if (s->has_0_0_acczsconvzs60zssimpflatzs42) {
-        acczsconvzs60zssimpflatzs42           = s->res_0_0_acczsconvzs60zssimpflatzs42; /* load */
+    if (s->has_0_0_acczsconvzs76zssimpflatzs31) {
+        acczsconvzs76zssimpflatzs31           = s->res_0_0_acczsconvzs76zssimpflatzs31; /* load */
     }
     
-    if (s->has_0_0_acczsconvzs60zssimpflatzs43) {
-        acczsconvzs60zssimpflatzs43           = s->res_0_0_acczsconvzs60zssimpflatzs43; /* load */
+    if (s->has_0_0_acczsconvzs76zssimpflatzs32) {
+        acczsconvzs76zssimpflatzs32           = s->res_0_0_acczsconvzs76zssimpflatzs32; /* load */
     }
     
-    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39) {
-        acczsszsreifyzs6zsconvzs12zssimpflatzs39 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39; /* load */
+    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28) {
+        acczsszsreifyzs6zsconvzs12zssimpflatzs28 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28; /* load */
     }
     
-    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40) {
-        acczsszsreifyzs6zsconvzs12zssimpflatzs40 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40; /* load */
+    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29) {
+        acczsszsreifyzs6zsconvzs12zssimpflatzs29 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29; /* load */
     }
     
-    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41) {
-        acczsszsreifyzs6zsconvzs12zssimpflatzs41 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41; /* load */
+    if (s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30) {
+        acczsszsreifyzs6zsconvzs12zssimpflatzs30 = s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30; /* load */
     }
     
-    if (s->has_0_0_acczsconvzs11zssimpflatzs33) {
-        acczsconvzs11zssimpflatzs33           = s->res_0_0_acczsconvzs11zssimpflatzs33; /* load */
+    if (s->has_0_0_acczsconvzs11zssimpflatzs22) {
+        acczsconvzs11zssimpflatzs22           = s->res_0_0_acczsconvzs11zssimpflatzs22; /* load */
     }
     
-    if (s->has_0_0_acczsconvzs11zssimpflatzs34) {
-        acczsconvzs11zssimpflatzs34           = s->res_0_0_acczsconvzs11zssimpflatzs34; /* load */
+    if (s->has_0_0_acczsconvzs11zssimpflatzs23) {
+        acczsconvzs11zssimpflatzs23           = s->res_0_0_acczsconvzs11zssimpflatzs23; /* load */
     }
     
     const iint_t     new_count                = s->input.new_count;
-    const ierror_t  *const new_convzs0zssimpflatzs230 = s->input.new_convzs0zssimpflatzs230;
-    const istring_t *const new_convzs0zssimpflatzs231 = s->input.new_convzs0zssimpflatzs231;
-    const iint_t    *const new_convzs0zssimpflatzs232 = s->input.new_convzs0zssimpflatzs232;
-    const itime_t   *const new_convzs0zssimpflatzs233 = s->input.new_convzs0zssimpflatzs233;
+    const ierror_t  *const new_convzs0zssimpflatzs307 = s->input.new_convzs0zssimpflatzs307;
+    const istring_t *const new_convzs0zssimpflatzs308 = s->input.new_convzs0zssimpflatzs308;
+    const iint_t    *const new_convzs0zssimpflatzs309 = s->input.new_convzs0zssimpflatzs309;
+    const itime_t   *const new_convzs0zssimpflatzs310 = s->input.new_convzs0zssimpflatzs310;
     
     for (iint_t i = 0; i < new_count; i++) {
         ifactid_t        convzs1              = i;
-        itime_t          convzs2              = new_convzs0zssimpflatzs233[i];
-        ierror_t         convzs0zssimpflatzs230 = new_convzs0zssimpflatzs230[i];
-        istring_t        convzs0zssimpflatzs231 = new_convzs0zssimpflatzs231[i];
-        iint_t           convzs0zssimpflatzs232 = new_convzs0zssimpflatzs232[i];
-        itime_t          convzs0zssimpflatzs233 = new_convzs0zssimpflatzs233[i];
-        flatzs0zssimpflatzs52                 = ierror_not_an_error;                  /* init */
-        flatzs0zssimpflatzs53                 = 0;                                    /* init */
+        itime_t          convzs2              = new_convzs0zssimpflatzs310[i];
+        ierror_t         convzs0zssimpflatzs307 = new_convzs0zssimpflatzs307[i];
+        istring_t        convzs0zssimpflatzs308 = new_convzs0zssimpflatzs308[i];
+        iint_t           convzs0zssimpflatzs309 = new_convzs0zssimpflatzs309[i];
+        itime_t          convzs0zssimpflatzs310 = new_convzs0zssimpflatzs310[i];
+        flatzs0zssimpflatzs41                 = ierror_not_an_error;                  /* init */
+        flatzs0zssimpflatzs42                 = 0;                                    /* init */
         
-        if (ierror_eq (convzs0zssimpflatzs230, ierror_not_an_error)) {
-            flatzs0zssimpflatzs52             = ierror_not_an_error;                  /* write */
-            flatzs0zssimpflatzs53             = convzs0zssimpflatzs232;               /* write */
+        if (ierror_eq (convzs0zssimpflatzs307, ierror_not_an_error)) {
+            flatzs0zssimpflatzs41             = ierror_not_an_error;                  /* write */
+            flatzs0zssimpflatzs42             = convzs0zssimpflatzs309;               /* write */
         } else {
-            flatzs0zssimpflatzs52             = convzs0zssimpflatzs230;               /* write */
-            flatzs0zssimpflatzs53             = 0;                                    /* write */
+            flatzs0zssimpflatzs41             = convzs0zssimpflatzs307;               /* write */
+            flatzs0zssimpflatzs42             = 0;                                    /* write */
         }
         
-        flatzs0zssimpflatzs54                 = flatzs0zssimpflatzs52;                /* read */
-        flatzs0zssimpflatzs55                 = flatzs0zssimpflatzs53;                /* read */
-        flatzs1zssimpflatzs56                 = ierror_not_an_error;                  /* init */
-        flatzs1zssimpflatzs57                 = 0.0;                                  /* init */
+        flatzs0zssimpflatzs43                 = flatzs0zssimpflatzs41;                /* read */
+        flatzs0zssimpflatzs44                 = flatzs0zssimpflatzs42;                /* read */
+        flatzs1zssimpflatzs45                 = ierror_not_an_error;                  /* init */
+        flatzs1zssimpflatzs46                 = 0.0;                                  /* init */
         
-        if (ierror_eq (flatzs0zssimpflatzs54, ierror_not_an_error)) {
-            flatzs1zssimpflatzs56             = ierror_not_an_error;                  /* write */
-            flatzs1zssimpflatzs57             = iint_extend (flatzs0zssimpflatzs55);  /* write */
+        if (ierror_eq (flatzs0zssimpflatzs43, ierror_not_an_error)) {
+            flatzs1zssimpflatzs45             = ierror_not_an_error;                  /* write */
+            flatzs1zssimpflatzs46             = iint_extend (flatzs0zssimpflatzs44);  /* write */
         } else {
-            flatzs1zssimpflatzs56             = flatzs0zssimpflatzs54;                /* write */
-            flatzs1zssimpflatzs57             = 0.0;                                  /* write */
+            flatzs1zssimpflatzs45             = flatzs0zssimpflatzs43;                /* write */
+            flatzs1zssimpflatzs46             = 0.0;                                  /* write */
         }
         
-        flatzs1zssimpflatzs58                 = flatzs1zssimpflatzs56;                /* read */
-        flatzs1zssimpflatzs59                 = flatzs1zssimpflatzs57;                /* read */
-        flatzs2zssimpflatzs60                 = ierror_not_an_error;                  /* init */
-        flatzs2zssimpflatzs61                 = 0.0;                                  /* init */
+        flatzs1zssimpflatzs47                 = flatzs1zssimpflatzs45;                /* read */
+        flatzs1zssimpflatzs48                 = flatzs1zssimpflatzs46;                /* read */
+        flatzs2zssimpflatzs49                 = ierror_not_an_error;                  /* init */
+        flatzs2zssimpflatzs50                 = 0.0;                                  /* init */
         
-        if (ierror_eq (flatzs1zssimpflatzs58, ierror_not_an_error)) {
-            flatzs2zssimpflatzs60             = ierror_not_an_error;                  /* write */
-            flatzs2zssimpflatzs61             = flatzs1zssimpflatzs59;                /* write */
+        if (ierror_eq (flatzs1zssimpflatzs47, ierror_not_an_error)) {
+            flatzs2zssimpflatzs49             = ierror_not_an_error;                  /* write */
+            flatzs2zssimpflatzs50             = flatzs1zssimpflatzs48;                /* write */
         } else {
-            flatzs2zssimpflatzs60             = flatzs1zssimpflatzs58;                /* write */
-            flatzs2zssimpflatzs61             = 0.0;                                  /* write */
+            flatzs2zssimpflatzs49             = flatzs1zssimpflatzs47;                /* write */
+            flatzs2zssimpflatzs50             = 0.0;                                  /* write */
         }
         
-        flatzs2zssimpflatzs62                 = flatzs2zssimpflatzs60;                /* read */
-        flatzs2zssimpflatzs63                 = flatzs2zssimpflatzs61;                /* read */
-        acczsconvzs11zssimpflatzs33           = flatzs2zssimpflatzs62;                /* write */
-        acczsconvzs11zssimpflatzs34           = flatzs2zssimpflatzs63;                /* write */
-        convzs11zsavalzs1zssimpflatzs64       = acczsconvzs11zssimpflatzs33;          /* read */
-        convzs11zsavalzs1zssimpflatzs65       = acczsconvzs11zssimpflatzs34;          /* read */
-        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70 = acczsszsreifyzs6zsconvzs12zssimpflatzs39; /* read */
-        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs71 = acczsszsreifyzs6zsconvzs12zssimpflatzs40; /* read */
-        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs72 = acczsszsreifyzs6zsconvzs12zssimpflatzs41; /* read */
-        flatzs3zssimpflatzs73                 = ierror_not_an_error;                  /* init */
-        flatzs3zssimpflatzs74                 = 0.0;                                  /* init */
-        flatzs3zssimpflatzs75                 = 0.0;                                  /* init */
+        flatzs2zssimpflatzs51                 = flatzs2zssimpflatzs49;                /* read */
+        flatzs2zssimpflatzs52                 = flatzs2zssimpflatzs50;                /* read */
+        acczsconvzs11zssimpflatzs22           = flatzs2zssimpflatzs51;                /* write */
+        acczsconvzs11zssimpflatzs23           = flatzs2zssimpflatzs52;                /* write */
+        convzs11zsavalzs1zssimpflatzs53       = acczsconvzs11zssimpflatzs22;          /* read */
+        convzs11zsavalzs1zssimpflatzs54       = acczsconvzs11zssimpflatzs23;          /* read */
+        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59 = acczsszsreifyzs6zsconvzs12zssimpflatzs28; /* read */
+        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60 = acczsszsreifyzs6zsconvzs12zssimpflatzs29; /* read */
+        szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61 = acczsszsreifyzs6zsconvzs12zssimpflatzs30; /* read */
+        flatzs3zssimpflatzs62                 = ierror_not_an_error;                  /* init */
+        flatzs3zssimpflatzs63                 = 0.0;                                  /* init */
+        flatzs3zssimpflatzs64                 = 0.0;                                  /* init */
         
-        if (ierror_eq (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70, ierror_not_an_error)) {
-            flatzs10zssimpflatzs76            = ierror_not_an_error;                  /* init */
-            flatzs10zssimpflatzs77            = 0.0;                                  /* init */
-            flatzs10zssimpflatzs78            = 0.0;                                  /* init */
+        if (ierror_eq (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59, ierror_not_an_error)) {
+            flatzs10zssimpflatzs65            = ierror_not_an_error;                  /* init */
+            flatzs10zssimpflatzs66            = 0.0;                                  /* init */
+            flatzs10zssimpflatzs67            = 0.0;                                  /* init */
             
-            if (ierror_eq (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70, ierror_not_an_error)) {
-                flatzs13zssimpflatzs79        = ierror_not_an_error;                  /* init */
-                flatzs13zssimpflatzs80        = 0.0;                                  /* init */
+            if (ierror_eq (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59, ierror_not_an_error)) {
+                flatzs13zssimpflatzs68        = ierror_not_an_error;                  /* init */
+                flatzs13zssimpflatzs69        = 0.0;                                  /* init */
                 
-                if (ierror_eq (convzs11zsavalzs1zssimpflatzs64, ierror_not_an_error)) {
-                    flatzs13zssimpflatzs79    = ierror_not_an_error;                  /* write */
-                    flatzs13zssimpflatzs80    = idouble_sub (convzs11zsavalzs1zssimpflatzs65, szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs71); /* write */
-                } else {
-                    flatzs13zssimpflatzs79    = convzs11zsavalzs1zssimpflatzs64;      /* write */
-                    flatzs13zssimpflatzs80    = 0.0;                                  /* write */
-                }
-                
-                flatzs13zssimpflatzs81        = flatzs13zssimpflatzs79;               /* read */
-                flatzs13zssimpflatzs82        = flatzs13zssimpflatzs80;               /* read */
-                flatzs14zssimpflatzs83        = ierror_not_an_error;                  /* init */
-                flatzs14zssimpflatzs84        = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs13zssimpflatzs81, ierror_not_an_error)) {
-                    flatzs14zssimpflatzs83    = ierror_not_an_error;                  /* write */
-                    idouble_t        simpflatzs285 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs72, 1.0); /* let */
-                    flatzs14zssimpflatzs84    = idouble_div (flatzs13zssimpflatzs82, simpflatzs285); /* write */
-                } else {
-                    flatzs14zssimpflatzs83    = flatzs13zssimpflatzs81;               /* write */
-                    flatzs14zssimpflatzs84    = 0.0;                                  /* write */
-                }
-                
-                flatzs14zssimpflatzs85        = flatzs14zssimpflatzs83;               /* read */
-                flatzs14zssimpflatzs86        = flatzs14zssimpflatzs84;               /* read */
-                flatzs15zssimpflatzs87        = ierror_not_an_error;                  /* init */
-                flatzs15zssimpflatzs88        = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs14zssimpflatzs85, ierror_not_an_error)) {
-                    flatzs15zssimpflatzs87    = ierror_not_an_error;                  /* write */
-                    flatzs15zssimpflatzs88    = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs71, flatzs14zssimpflatzs86); /* write */
-                } else {
-                    flatzs15zssimpflatzs87    = flatzs14zssimpflatzs85;               /* write */
-                    flatzs15zssimpflatzs88    = 0.0;                                  /* write */
-                }
-                
-                flatzs15zssimpflatzs89        = flatzs15zssimpflatzs87;               /* read */
-                flatzs15zssimpflatzs90        = flatzs15zssimpflatzs88;               /* read */
-                flatzs16zssimpflatzs91        = ierror_not_an_error;                  /* init */
-                flatzs16zssimpflatzs92        = 0.0;                                  /* init */
-                flatzs16zssimpflatzs93        = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs15zssimpflatzs89, ierror_not_an_error)) {
-                    flatzs16zssimpflatzs91    = ierror_not_an_error;                  /* write */
-                    flatzs16zssimpflatzs92    = flatzs15zssimpflatzs90;               /* write */
-                    flatzs16zssimpflatzs93    = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs72, 1.0); /* write */
-                } else {
-                    flatzs16zssimpflatzs91    = flatzs15zssimpflatzs89;               /* write */
-                    flatzs16zssimpflatzs92    = 0.0;                                  /* write */
-                    flatzs16zssimpflatzs93    = 0.0;                                  /* write */
-                }
-                
-                flatzs16zssimpflatzs94        = flatzs16zssimpflatzs91;               /* read */
-                flatzs16zssimpflatzs95        = flatzs16zssimpflatzs92;               /* read */
-                flatzs16zssimpflatzs96        = flatzs16zssimpflatzs93;               /* read */
-                flatzs10zssimpflatzs76        = flatzs16zssimpflatzs94;               /* write */
-                flatzs10zssimpflatzs77        = flatzs16zssimpflatzs95;               /* write */
-                flatzs10zssimpflatzs78        = flatzs16zssimpflatzs96;               /* write */
-            } else {
-                flatzs10zssimpflatzs76        = szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70; /* write */
-                flatzs10zssimpflatzs77        = 0.0;                                  /* write */
-                flatzs10zssimpflatzs78        = 0.0;                                  /* write */
-            }
-            
-            flatzs10zssimpflatzs97            = flatzs10zssimpflatzs76;               /* read */
-            flatzs10zssimpflatzs98            = flatzs10zssimpflatzs77;               /* read */
-            flatzs10zssimpflatzs99            = flatzs10zssimpflatzs78;               /* read */
-            flatzs3zssimpflatzs73             = flatzs10zssimpflatzs97;               /* write */
-            flatzs3zssimpflatzs74             = flatzs10zssimpflatzs98;               /* write */
-            flatzs3zssimpflatzs75             = flatzs10zssimpflatzs99;               /* write */
-        } else {
-            flatzs6zssimpflatzs100            = ierror_not_an_error;                  /* init */
-            flatzs6zssimpflatzs101            = 0.0;                                  /* init */
-            flatzs6zssimpflatzs102            = 0.0;                                  /* init */
-            
-            if (ierror_eq (ierror_fold1_no_value, szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70)) {
-                flatzs7zssimpflatzs103        = ierror_not_an_error;                  /* init */
-                flatzs7zssimpflatzs104        = 0.0;                                  /* init */
-                flatzs7zssimpflatzs105        = 0.0;                                  /* init */
-                
-                if (ierror_eq (convzs11zsavalzs1zssimpflatzs64, ierror_not_an_error)) {
-                    flatzs7zssimpflatzs103    = ierror_not_an_error;                  /* write */
-                    flatzs7zssimpflatzs104    = convzs11zsavalzs1zssimpflatzs65;      /* write */
-                    flatzs7zssimpflatzs105    = 1.0;                                  /* write */
-                } else {
-                    flatzs7zssimpflatzs103    = convzs11zsavalzs1zssimpflatzs64;      /* write */
-                    flatzs7zssimpflatzs104    = 0.0;                                  /* write */
-                    flatzs7zssimpflatzs105    = 0.0;                                  /* write */
-                }
-                
-                flatzs7zssimpflatzs106        = flatzs7zssimpflatzs103;               /* read */
-                flatzs7zssimpflatzs107        = flatzs7zssimpflatzs104;               /* read */
-                flatzs7zssimpflatzs108        = flatzs7zssimpflatzs105;               /* read */
-                flatzs6zssimpflatzs100        = flatzs7zssimpflatzs106;               /* write */
-                flatzs6zssimpflatzs101        = flatzs7zssimpflatzs107;               /* write */
-                flatzs6zssimpflatzs102        = flatzs7zssimpflatzs108;               /* write */
-            } else {
-                flatzs6zssimpflatzs100        = szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs70; /* write */
-                flatzs6zssimpflatzs101        = 0.0;                                  /* write */
-                flatzs6zssimpflatzs102        = 0.0;                                  /* write */
-            }
-            
-            flatzs6zssimpflatzs109            = flatzs6zssimpflatzs100;               /* read */
-            flatzs6zssimpflatzs110            = flatzs6zssimpflatzs101;               /* read */
-            flatzs6zssimpflatzs111            = flatzs6zssimpflatzs102;               /* read */
-            flatzs3zssimpflatzs73             = flatzs6zssimpflatzs109;               /* write */
-            flatzs3zssimpflatzs74             = flatzs6zssimpflatzs110;               /* write */
-            flatzs3zssimpflatzs75             = flatzs6zssimpflatzs111;               /* write */
-        }
-        
-        flatzs3zssimpflatzs112                = flatzs3zssimpflatzs73;                /* read */
-        flatzs3zssimpflatzs113                = flatzs3zssimpflatzs74;                /* read */
-        flatzs3zssimpflatzs114                = flatzs3zssimpflatzs75;                /* read */
-        acczsszsreifyzs6zsconvzs12zssimpflatzs39 = flatzs3zssimpflatzs112;            /* write */
-        acczsszsreifyzs6zsconvzs12zssimpflatzs40 = flatzs3zssimpflatzs113;            /* write */
-        acczsszsreifyzs6zsconvzs12zssimpflatzs41 = flatzs3zssimpflatzs114;            /* write */
-        flatzs25zssimpflatzs115               = ierror_not_an_error;                  /* init */
-        flatzs25zssimpflatzs116               = "";                                   /* init */
-        
-        if (ierror_eq (convzs0zssimpflatzs230, ierror_not_an_error)) {
-            flatzs25zssimpflatzs115           = ierror_not_an_error;                  /* write */
-            flatzs25zssimpflatzs116           = convzs0zssimpflatzs231;               /* write */
-        } else {
-            flatzs25zssimpflatzs115           = convzs0zssimpflatzs230;               /* write */
-            flatzs25zssimpflatzs116           = "";                                   /* write */
-        }
-        
-        flatzs25zssimpflatzs117               = flatzs25zssimpflatzs115;              /* read */
-        flatzs25zssimpflatzs118               = flatzs25zssimpflatzs116;              /* read */
-        flatzs26zssimpflatzs119               = ierror_not_an_error;                  /* init */
-        flatzs26zssimpflatzs120               = ifalse;                               /* init */
-        
-        if (ierror_eq (flatzs25zssimpflatzs117, ierror_not_an_error)) {
-            flatzs26zssimpflatzs119           = ierror_not_an_error;                  /* write */
-            flatzs26zssimpflatzs120           = istring_eq (flatzs25zssimpflatzs118, "torso"); /* write */
-        } else {
-            flatzs26zssimpflatzs119           = flatzs25zssimpflatzs117;              /* write */
-            flatzs26zssimpflatzs120           = ifalse;                               /* write */
-        }
-        
-        flatzs26zssimpflatzs121               = flatzs26zssimpflatzs119;              /* read */
-        flatzs26zssimpflatzs122               = flatzs26zssimpflatzs120;              /* read */
-        flatzs27                              = ifalse;                               /* init */
-        
-        if (ierror_eq (flatzs26zssimpflatzs121, ierror_not_an_error)) {
-            flatzs27                          = flatzs26zssimpflatzs122;              /* write */
-        } else {
-            flatzs27                          = itrue;                                /* write */
-        }
-        
-        flatzs27                              = flatzs27;                             /* read */
-        
-        if (flatzs27) {
-            flatzs28zssimpflatzs123           = ierror_not_an_error;                  /* init */
-            flatzs28zssimpflatzs124           = 0;                                    /* init */
-            
-            if (ierror_eq (convzs0zssimpflatzs230, ierror_not_an_error)) {
-                flatzs28zssimpflatzs123       = ierror_not_an_error;                  /* write */
-                flatzs28zssimpflatzs124       = convzs0zssimpflatzs232;               /* write */
-            } else {
-                flatzs28zssimpflatzs123       = convzs0zssimpflatzs230;               /* write */
-                flatzs28zssimpflatzs124       = 0;                                    /* write */
-            }
-            
-            flatzs28zssimpflatzs125           = flatzs28zssimpflatzs123;              /* read */
-            flatzs28zssimpflatzs126           = flatzs28zssimpflatzs124;              /* read */
-            flatzs29zssimpflatzs127           = ierror_not_an_error;                  /* init */
-            flatzs29zssimpflatzs128           = 0.0;                                  /* init */
-            
-            if (ierror_eq (flatzs28zssimpflatzs125, ierror_not_an_error)) {
-                flatzs29zssimpflatzs127       = ierror_not_an_error;                  /* write */
-                flatzs29zssimpflatzs128       = iint_extend (flatzs28zssimpflatzs126); /* write */
-            } else {
-                flatzs29zssimpflatzs127       = flatzs28zssimpflatzs125;              /* write */
-                flatzs29zssimpflatzs128       = 0.0;                                  /* write */
-            }
-            
-            flatzs29zssimpflatzs129           = flatzs29zssimpflatzs127;              /* read */
-            flatzs29zssimpflatzs130           = flatzs29zssimpflatzs128;              /* read */
-            acczsconvzs60zssimpflatzs42       = flatzs29zssimpflatzs129;              /* write */
-            acczsconvzs60zssimpflatzs43       = flatzs29zssimpflatzs130;              /* write */
-            convzs60zsavalzs3zssimpflatzs131  = acczsconvzs60zssimpflatzs42;          /* read */
-            convzs60zsavalzs3zssimpflatzs132  = acczsconvzs60zssimpflatzs43;          /* read */
-            azsconvzs61zsavalzs2zssimpflatzs137 = acczsazsconvzs61zssimpflatzs48;     /* read */
-            azsconvzs61zsavalzs2zssimpflatzs138 = acczsazsconvzs61zssimpflatzs49;     /* read */
-            azsconvzs61zsavalzs2zssimpflatzs139 = acczsazsconvzs61zssimpflatzs50;     /* read */
-            azsconvzs61zsavalzs2zssimpflatzs140 = acczsazsconvzs61zssimpflatzs51;     /* read */
-            flatzs30zssimpflatzs141           = ierror_not_an_error;                  /* init */
-            flatzs30zssimpflatzs142           = 0.0;                                  /* init */
-            flatzs30zssimpflatzs143           = 0.0;                                  /* init */
-            flatzs30zssimpflatzs144           = 0.0;                                  /* init */
-            
-            if (ierror_eq (azsconvzs61zsavalzs2zssimpflatzs137, ierror_not_an_error)) {
-                idouble_t        nnzsconvzs68 = idouble_add (azsconvzs61zsavalzs2zssimpflatzs138, 1.0); /* let */
-                flatzs33zssimpflatzs145       = ierror_not_an_error;                  /* init */
-                flatzs33zssimpflatzs146       = 0.0;                                  /* init */
-                
-                if (ierror_eq (convzs60zsavalzs3zssimpflatzs131, ierror_not_an_error)) {
-                    flatzs33zssimpflatzs145   = ierror_not_an_error;                  /* write */
-                    flatzs33zssimpflatzs146   = idouble_sub (convzs60zsavalzs3zssimpflatzs132, azsconvzs61zsavalzs2zssimpflatzs139); /* write */
-                } else {
-                    flatzs33zssimpflatzs145   = convzs60zsavalzs3zssimpflatzs131;     /* write */
-                    flatzs33zssimpflatzs146   = 0.0;                                  /* write */
-                }
-                
-                flatzs33zssimpflatzs147       = flatzs33zssimpflatzs145;              /* read */
-                flatzs33zssimpflatzs148       = flatzs33zssimpflatzs146;              /* read */
-                flatzs34zssimpflatzs149       = ierror_not_an_error;                  /* init */
-                flatzs34zssimpflatzs150       = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs33zssimpflatzs147, ierror_not_an_error)) {
-                    flatzs34zssimpflatzs149   = ierror_not_an_error;                  /* write */
-                    flatzs34zssimpflatzs150   = idouble_div (flatzs33zssimpflatzs148, nnzsconvzs68); /* write */
-                } else {
-                    flatzs34zssimpflatzs149   = flatzs33zssimpflatzs147;              /* write */
-                    flatzs34zssimpflatzs150   = 0.0;                                  /* write */
-                }
-                
-                flatzs34zssimpflatzs151       = flatzs34zssimpflatzs149;              /* read */
-                flatzs34zssimpflatzs152       = flatzs34zssimpflatzs150;              /* read */
-                flatzs35zssimpflatzs153       = ierror_not_an_error;                  /* init */
-                flatzs35zssimpflatzs154       = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs34zssimpflatzs151, ierror_not_an_error)) {
-                    flatzs35zssimpflatzs153   = ierror_not_an_error;                  /* write */
-                    flatzs35zssimpflatzs154   = idouble_add (azsconvzs61zsavalzs2zssimpflatzs139, flatzs34zssimpflatzs152); /* write */
-                } else {
-                    flatzs35zssimpflatzs153   = flatzs34zssimpflatzs151;              /* write */
-                    flatzs35zssimpflatzs154   = 0.0;                                  /* write */
-                }
-                
-                flatzs35zssimpflatzs155       = flatzs35zssimpflatzs153;              /* read */
-                flatzs35zssimpflatzs156       = flatzs35zssimpflatzs154;              /* read */
-                flatzs36zssimpflatzs157       = ierror_not_an_error;                  /* init */
-                flatzs36zssimpflatzs158       = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs33zssimpflatzs147, ierror_not_an_error)) {
-                    flatzs51zssimpflatzs159   = ierror_not_an_error;                  /* init */
-                    flatzs51zssimpflatzs160   = 0.0;                                  /* init */
+                if (ierror_eq (convzs11zsavalzs1zssimpflatzs53, ierror_not_an_error)) {
+                    idouble_t        convzs25 = idouble_sub (convzs11zsavalzs1zssimpflatzs54, szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60); /* let */
+                    flatzs35zssimpflatzs70    = ierror_not_an_error;                  /* init */
+                    flatzs35zssimpflatzs71    = 0.0;                                  /* init */
                     
-                    if (ierror_eq (convzs60zsavalzs3zssimpflatzs131, ierror_not_an_error)) {
-                        flatzs57zssimpflatzs161 = ierror_not_an_error;                /* init */
-                        flatzs57zssimpflatzs162 = 0.0;                                /* init */
+                    if (idouble_is_valid (convzs25)) {
+                        flatzs35zssimpflatzs70 = ierror_not_an_error;                 /* write */
+                        flatzs35zssimpflatzs71 = idouble_sub (convzs11zsavalzs1zssimpflatzs54, szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60); /* write */
+                    } else {
+                        flatzs35zssimpflatzs70 = ierror_cannot_compute;               /* write */
+                        flatzs35zssimpflatzs71 = 0.0;                                 /* write */
+                    }
+                    
+                    flatzs35zssimpflatzs72    = flatzs35zssimpflatzs70;               /* read */
+                    flatzs35zssimpflatzs73    = flatzs35zssimpflatzs71;               /* read */
+                    flatzs13zssimpflatzs68    = flatzs35zssimpflatzs72;               /* write */
+                    flatzs13zssimpflatzs69    = flatzs35zssimpflatzs73;               /* write */
+                } else {
+                    flatzs13zssimpflatzs68    = convzs11zsavalzs1zssimpflatzs53;      /* write */
+                    flatzs13zssimpflatzs69    = 0.0;                                  /* write */
+                }
+                
+                flatzs13zssimpflatzs74        = flatzs13zssimpflatzs68;               /* read */
+                flatzs13zssimpflatzs75        = flatzs13zssimpflatzs69;               /* read */
+                flatzs14zssimpflatzs76        = ierror_not_an_error;                  /* init */
+                flatzs14zssimpflatzs77        = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs13zssimpflatzs74, ierror_not_an_error)) {
+                    idouble_t        convzs30 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61, 1.0); /* let */
+                    flatzs28zssimpflatzs78    = ierror_not_an_error;                  /* init */
+                    flatzs28zssimpflatzs79    = 0.0;                                  /* init */
+                    
+                    if (idouble_is_valid (convzs30)) {
+                        flatzs28zssimpflatzs78 = ierror_not_an_error;                 /* write */
+                        flatzs28zssimpflatzs79 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61, 1.0); /* write */
+                    } else {
+                        flatzs28zssimpflatzs78 = ierror_cannot_compute;               /* write */
+                        flatzs28zssimpflatzs79 = 0.0;                                 /* write */
+                    }
+                    
+                    flatzs28zssimpflatzs80    = flatzs28zssimpflatzs78;               /* read */
+                    flatzs28zssimpflatzs81    = flatzs28zssimpflatzs79;               /* read */
+                    flatzs29zssimpflatzs82    = ierror_not_an_error;                  /* init */
+                    flatzs29zssimpflatzs83    = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs28zssimpflatzs80, ierror_not_an_error)) {
+                        idouble_t        convzs34 = idouble_div (flatzs13zssimpflatzs75, flatzs28zssimpflatzs81); /* let */
+                        flatzs32zssimpflatzs84 = ierror_not_an_error;                 /* init */
+                        flatzs32zssimpflatzs85 = 0.0;                                 /* init */
                         
-                        if (ierror_eq (flatzs35zssimpflatzs155, ierror_not_an_error)) {
-                            flatzs57zssimpflatzs161 = ierror_not_an_error;            /* write */
-                            flatzs57zssimpflatzs162 = idouble_sub (convzs60zsavalzs3zssimpflatzs132, flatzs35zssimpflatzs156); /* write */
+                        if (idouble_is_valid (convzs34)) {
+                            flatzs32zssimpflatzs84 = ierror_not_an_error;             /* write */
+                            flatzs32zssimpflatzs85 = idouble_div (flatzs13zssimpflatzs75, flatzs28zssimpflatzs81); /* write */
                         } else {
-                            flatzs57zssimpflatzs161 = flatzs35zssimpflatzs155;        /* write */
-                            flatzs57zssimpflatzs162 = 0.0;                            /* write */
+                            flatzs32zssimpflatzs84 = ierror_cannot_compute;           /* write */
+                            flatzs32zssimpflatzs85 = 0.0;                             /* write */
                         }
                         
-                        flatzs57zssimpflatzs163 = flatzs57zssimpflatzs161;            /* read */
-                        flatzs57zssimpflatzs164 = flatzs57zssimpflatzs162;            /* read */
-                        flatzs51zssimpflatzs159 = flatzs57zssimpflatzs163;            /* write */
-                        flatzs51zssimpflatzs160 = flatzs57zssimpflatzs164;            /* write */
+                        flatzs32zssimpflatzs86 = flatzs32zssimpflatzs84;              /* read */
+                        flatzs32zssimpflatzs87 = flatzs32zssimpflatzs85;              /* read */
+                        flatzs29zssimpflatzs82 = flatzs32zssimpflatzs86;              /* write */
+                        flatzs29zssimpflatzs83 = flatzs32zssimpflatzs87;              /* write */
                     } else {
-                        flatzs51zssimpflatzs159 = convzs60zsavalzs3zssimpflatzs131;   /* write */
-                        flatzs51zssimpflatzs160 = 0.0;                                /* write */
+                        flatzs29zssimpflatzs82 = flatzs28zssimpflatzs80;              /* write */
+                        flatzs29zssimpflatzs83 = 0.0;                                 /* write */
                     }
                     
-                    flatzs51zssimpflatzs165   = flatzs51zssimpflatzs159;              /* read */
-                    flatzs51zssimpflatzs166   = flatzs51zssimpflatzs160;              /* read */
-                    flatzs52zssimpflatzs167   = ierror_not_an_error;                  /* init */
-                    flatzs52zssimpflatzs168   = 0.0;                                  /* init */
+                    flatzs29zssimpflatzs88    = flatzs29zssimpflatzs82;               /* read */
+                    flatzs29zssimpflatzs89    = flatzs29zssimpflatzs83;               /* read */
+                    flatzs14zssimpflatzs76    = flatzs29zssimpflatzs88;               /* write */
+                    flatzs14zssimpflatzs77    = flatzs29zssimpflatzs89;               /* write */
+                } else {
+                    flatzs14zssimpflatzs76    = flatzs13zssimpflatzs74;               /* write */
+                    flatzs14zssimpflatzs77    = 0.0;                                  /* write */
+                }
+                
+                flatzs14zssimpflatzs90        = flatzs14zssimpflatzs76;               /* read */
+                flatzs14zssimpflatzs91        = flatzs14zssimpflatzs77;               /* read */
+                flatzs15zssimpflatzs92        = ierror_not_an_error;                  /* init */
+                flatzs15zssimpflatzs93        = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs14zssimpflatzs90, ierror_not_an_error)) {
+                    idouble_t        convzs40 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60, flatzs14zssimpflatzs91); /* let */
+                    flatzs25zssimpflatzs94    = ierror_not_an_error;                  /* init */
+                    flatzs25zssimpflatzs95    = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flatzs51zssimpflatzs165, ierror_not_an_error)) {
-                        flatzs52zssimpflatzs167 = ierror_not_an_error;                /* write */
-                        flatzs52zssimpflatzs168 = idouble_mul (flatzs33zssimpflatzs148, flatzs51zssimpflatzs166); /* write */
+                    if (idouble_is_valid (convzs40)) {
+                        flatzs25zssimpflatzs94 = ierror_not_an_error;                 /* write */
+                        flatzs25zssimpflatzs95 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs60, flatzs14zssimpflatzs91); /* write */
                     } else {
-                        flatzs52zssimpflatzs167 = flatzs51zssimpflatzs165;            /* write */
-                        flatzs52zssimpflatzs168 = 0.0;                                /* write */
+                        flatzs25zssimpflatzs94 = ierror_cannot_compute;               /* write */
+                        flatzs25zssimpflatzs95 = 0.0;                                 /* write */
                     }
                     
-                    flatzs52zssimpflatzs169   = flatzs52zssimpflatzs167;              /* read */
-                    flatzs52zssimpflatzs170   = flatzs52zssimpflatzs168;              /* read */
-                    flatzs36zssimpflatzs157   = flatzs52zssimpflatzs169;              /* write */
-                    flatzs36zssimpflatzs158   = flatzs52zssimpflatzs170;              /* write */
+                    flatzs25zssimpflatzs96    = flatzs25zssimpflatzs94;               /* read */
+                    flatzs25zssimpflatzs97    = flatzs25zssimpflatzs95;               /* read */
+                    flatzs15zssimpflatzs92    = flatzs25zssimpflatzs96;               /* write */
+                    flatzs15zssimpflatzs93    = flatzs25zssimpflatzs97;               /* write */
                 } else {
-                    flatzs36zssimpflatzs157   = flatzs33zssimpflatzs147;              /* write */
-                    flatzs36zssimpflatzs158   = 0.0;                                  /* write */
+                    flatzs15zssimpflatzs92    = flatzs14zssimpflatzs90;               /* write */
+                    flatzs15zssimpflatzs93    = 0.0;                                  /* write */
                 }
                 
-                flatzs36zssimpflatzs171       = flatzs36zssimpflatzs157;              /* read */
-                flatzs36zssimpflatzs172       = flatzs36zssimpflatzs158;              /* read */
-                flatzs37zssimpflatzs173       = ierror_not_an_error;                  /* init */
-                flatzs37zssimpflatzs174       = 0.0;                                  /* init */
+                flatzs15zssimpflatzs98        = flatzs15zssimpflatzs92;               /* read */
+                flatzs15zssimpflatzs99        = flatzs15zssimpflatzs93;               /* read */
+                flatzs16zssimpflatzs100       = ierror_not_an_error;                  /* init */
+                flatzs16zssimpflatzs101       = 0.0;                                  /* init */
+                flatzs16zssimpflatzs102       = 0.0;                                  /* init */
                 
-                if (ierror_eq (flatzs36zssimpflatzs171, ierror_not_an_error)) {
-                    flatzs37zssimpflatzs173   = ierror_not_an_error;                  /* write */
-                    flatzs37zssimpflatzs174   = idouble_add (azsconvzs61zsavalzs2zssimpflatzs140, flatzs36zssimpflatzs172); /* write */
-                } else {
-                    flatzs37zssimpflatzs173   = flatzs36zssimpflatzs171;              /* write */
-                    flatzs37zssimpflatzs174   = 0.0;                                  /* write */
-                }
-                
-                flatzs37zssimpflatzs175       = flatzs37zssimpflatzs173;              /* read */
-                flatzs37zssimpflatzs176       = flatzs37zssimpflatzs174;              /* read */
-                flatzs38zssimpflatzs177       = ierror_not_an_error;                  /* init */
-                flatzs38zssimpflatzs178       = 0.0;                                  /* init */
-                flatzs38zssimpflatzs179       = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs35zssimpflatzs155, ierror_not_an_error)) {
-                    flatzs38zssimpflatzs177   = ierror_not_an_error;                  /* write */
-                    flatzs38zssimpflatzs178   = idouble_add (azsconvzs61zsavalzs2zssimpflatzs138, 1.0); /* write */
-                    flatzs38zssimpflatzs179   = flatzs35zssimpflatzs156;              /* write */
-                } else {
-                    flatzs38zssimpflatzs177   = flatzs35zssimpflatzs155;              /* write */
-                    flatzs38zssimpflatzs178   = 0.0;                                  /* write */
-                    flatzs38zssimpflatzs179   = 0.0;                                  /* write */
-                }
-                
-                flatzs38zssimpflatzs180       = flatzs38zssimpflatzs177;              /* read */
-                flatzs38zssimpflatzs181       = flatzs38zssimpflatzs178;              /* read */
-                flatzs38zssimpflatzs182       = flatzs38zssimpflatzs179;              /* read */
-                flatzs39zssimpflatzs183       = ierror_not_an_error;                  /* init */
-                flatzs39zssimpflatzs184       = 0.0;                                  /* init */
-                flatzs39zssimpflatzs185       = 0.0;                                  /* init */
-                flatzs39zssimpflatzs186       = 0.0;                                  /* init */
-                
-                if (ierror_eq (flatzs38zssimpflatzs180, ierror_not_an_error)) {
-                    flatzs42zssimpflatzs187   = ierror_not_an_error;                  /* init */
-                    flatzs42zssimpflatzs188   = 0.0;                                  /* init */
-                    flatzs42zssimpflatzs189   = 0.0;                                  /* init */
-                    flatzs42zssimpflatzs190   = 0.0;                                  /* init */
+                if (ierror_eq (flatzs15zssimpflatzs98, ierror_not_an_error)) {
+                    idouble_t        convzs45 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61, 1.0); /* let */
+                    flatzs19zssimpflatzs103   = ierror_not_an_error;                  /* init */
+                    flatzs19zssimpflatzs104   = 0.0;                                  /* init */
                     
-                    if (ierror_eq (flatzs37zssimpflatzs175, ierror_not_an_error)) {
-                        flatzs42zssimpflatzs187 = ierror_not_an_error;                /* write */
-                        flatzs42zssimpflatzs188 = flatzs38zssimpflatzs181;            /* write */
-                        flatzs42zssimpflatzs189 = flatzs38zssimpflatzs182;            /* write */
-                        flatzs42zssimpflatzs190 = flatzs37zssimpflatzs176;            /* write */
+                    if (idouble_is_valid (convzs45)) {
+                        flatzs19zssimpflatzs103 = ierror_not_an_error;                /* write */
+                        flatzs19zssimpflatzs104 = idouble_add (szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs61, 1.0); /* write */
                     } else {
-                        flatzs42zssimpflatzs187 = flatzs37zssimpflatzs175;            /* write */
-                        flatzs42zssimpflatzs188 = 0.0;                                /* write */
-                        flatzs42zssimpflatzs189 = 0.0;                                /* write */
-                        flatzs42zssimpflatzs190 = 0.0;                                /* write */
+                        flatzs19zssimpflatzs103 = ierror_cannot_compute;              /* write */
+                        flatzs19zssimpflatzs104 = 0.0;                                /* write */
                     }
                     
-                    flatzs42zssimpflatzs191   = flatzs42zssimpflatzs187;              /* read */
-                    flatzs42zssimpflatzs192   = flatzs42zssimpflatzs188;              /* read */
-                    flatzs42zssimpflatzs193   = flatzs42zssimpflatzs189;              /* read */
-                    flatzs42zssimpflatzs194   = flatzs42zssimpflatzs190;              /* read */
-                    flatzs39zssimpflatzs183   = flatzs42zssimpflatzs191;              /* write */
-                    flatzs39zssimpflatzs184   = flatzs42zssimpflatzs192;              /* write */
-                    flatzs39zssimpflatzs185   = flatzs42zssimpflatzs193;              /* write */
-                    flatzs39zssimpflatzs186   = flatzs42zssimpflatzs194;              /* write */
+                    flatzs19zssimpflatzs105   = flatzs19zssimpflatzs103;              /* read */
+                    flatzs19zssimpflatzs106   = flatzs19zssimpflatzs104;              /* read */
+                    flatzs20zssimpflatzs107   = ierror_not_an_error;                  /* init */
+                    flatzs20zssimpflatzs108   = 0.0;                                  /* init */
+                    flatzs20zssimpflatzs109   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs19zssimpflatzs105, ierror_not_an_error)) {
+                        flatzs20zssimpflatzs107 = ierror_not_an_error;                /* write */
+                        flatzs20zssimpflatzs108 = flatzs15zssimpflatzs99;             /* write */
+                        flatzs20zssimpflatzs109 = flatzs19zssimpflatzs106;            /* write */
+                    } else {
+                        flatzs20zssimpflatzs107 = flatzs19zssimpflatzs105;            /* write */
+                        flatzs20zssimpflatzs108 = 0.0;                                /* write */
+                        flatzs20zssimpflatzs109 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs20zssimpflatzs110   = flatzs20zssimpflatzs107;              /* read */
+                    flatzs20zssimpflatzs111   = flatzs20zssimpflatzs108;              /* read */
+                    flatzs20zssimpflatzs112   = flatzs20zssimpflatzs109;              /* read */
+                    flatzs16zssimpflatzs100   = flatzs20zssimpflatzs110;              /* write */
+                    flatzs16zssimpflatzs101   = flatzs20zssimpflatzs111;              /* write */
+                    flatzs16zssimpflatzs102   = flatzs20zssimpflatzs112;              /* write */
                 } else {
-                    flatzs39zssimpflatzs183   = flatzs38zssimpflatzs180;              /* write */
-                    flatzs39zssimpflatzs184   = 0.0;                                  /* write */
-                    flatzs39zssimpflatzs185   = 0.0;                                  /* write */
-                    flatzs39zssimpflatzs186   = 0.0;                                  /* write */
+                    flatzs16zssimpflatzs100   = flatzs15zssimpflatzs98;               /* write */
+                    flatzs16zssimpflatzs101   = 0.0;                                  /* write */
+                    flatzs16zssimpflatzs102   = 0.0;                                  /* write */
                 }
                 
-                flatzs39zssimpflatzs195       = flatzs39zssimpflatzs183;              /* read */
-                flatzs39zssimpflatzs196       = flatzs39zssimpflatzs184;              /* read */
-                flatzs39zssimpflatzs197       = flatzs39zssimpflatzs185;              /* read */
-                flatzs39zssimpflatzs198       = flatzs39zssimpflatzs186;              /* read */
-                flatzs30zssimpflatzs141       = flatzs39zssimpflatzs195;              /* write */
-                flatzs30zssimpflatzs142       = flatzs39zssimpflatzs196;              /* write */
-                flatzs30zssimpflatzs143       = flatzs39zssimpflatzs197;              /* write */
-                flatzs30zssimpflatzs144       = flatzs39zssimpflatzs198;              /* write */
+                flatzs16zssimpflatzs113       = flatzs16zssimpflatzs100;              /* read */
+                flatzs16zssimpflatzs114       = flatzs16zssimpflatzs101;              /* read */
+                flatzs16zssimpflatzs115       = flatzs16zssimpflatzs102;              /* read */
+                flatzs10zssimpflatzs65        = flatzs16zssimpflatzs113;              /* write */
+                flatzs10zssimpflatzs66        = flatzs16zssimpflatzs114;              /* write */
+                flatzs10zssimpflatzs67        = flatzs16zssimpflatzs115;              /* write */
             } else {
-                flatzs30zssimpflatzs141       = azsconvzs61zsavalzs2zssimpflatzs137;  /* write */
-                flatzs30zssimpflatzs142       = 0.0;                                  /* write */
-                flatzs30zssimpflatzs143       = 0.0;                                  /* write */
-                flatzs30zssimpflatzs144       = 0.0;                                  /* write */
+                flatzs10zssimpflatzs65        = szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59; /* write */
+                flatzs10zssimpflatzs66        = 0.0;                                  /* write */
+                flatzs10zssimpflatzs67        = 0.0;                                  /* write */
             }
             
-            flatzs30zssimpflatzs199           = flatzs30zssimpflatzs141;              /* read */
-            flatzs30zssimpflatzs200           = flatzs30zssimpflatzs142;              /* read */
-            flatzs30zssimpflatzs201           = flatzs30zssimpflatzs143;              /* read */
-            flatzs30zssimpflatzs202           = flatzs30zssimpflatzs144;              /* read */
-            acczsazsconvzs61zssimpflatzs48    = flatzs30zssimpflatzs199;              /* write */
-            acczsazsconvzs61zssimpflatzs49    = flatzs30zssimpflatzs200;              /* write */
-            acczsazsconvzs61zssimpflatzs50    = flatzs30zssimpflatzs201;              /* write */
-            acczsazsconvzs61zssimpflatzs51    = flatzs30zssimpflatzs202;              /* write */
+            flatzs10zssimpflatzs116           = flatzs10zssimpflatzs65;               /* read */
+            flatzs10zssimpflatzs117           = flatzs10zssimpflatzs66;               /* read */
+            flatzs10zssimpflatzs118           = flatzs10zssimpflatzs67;               /* read */
+            flatzs3zssimpflatzs62             = flatzs10zssimpflatzs116;              /* write */
+            flatzs3zssimpflatzs63             = flatzs10zssimpflatzs117;              /* write */
+            flatzs3zssimpflatzs64             = flatzs10zssimpflatzs118;              /* write */
+        } else {
+            flatzs6zssimpflatzs119            = ierror_not_an_error;                  /* init */
+            flatzs6zssimpflatzs120            = 0.0;                                  /* init */
+            flatzs6zssimpflatzs121            = 0.0;                                  /* init */
+            
+            if (ierror_eq (ierror_fold1_no_value, szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59)) {
+                flatzs7zssimpflatzs122        = ierror_not_an_error;                  /* init */
+                flatzs7zssimpflatzs123        = 0.0;                                  /* init */
+                flatzs7zssimpflatzs124        = 0.0;                                  /* init */
+                
+                if (ierror_eq (convzs11zsavalzs1zssimpflatzs53, ierror_not_an_error)) {
+                    flatzs7zssimpflatzs122    = ierror_not_an_error;                  /* write */
+                    flatzs7zssimpflatzs123    = convzs11zsavalzs1zssimpflatzs54;      /* write */
+                    flatzs7zssimpflatzs124    = 1.0;                                  /* write */
+                } else {
+                    flatzs7zssimpflatzs122    = convzs11zsavalzs1zssimpflatzs53;      /* write */
+                    flatzs7zssimpflatzs123    = 0.0;                                  /* write */
+                    flatzs7zssimpflatzs124    = 0.0;                                  /* write */
+                }
+                
+                flatzs7zssimpflatzs125        = flatzs7zssimpflatzs122;               /* read */
+                flatzs7zssimpflatzs126        = flatzs7zssimpflatzs123;               /* read */
+                flatzs7zssimpflatzs127        = flatzs7zssimpflatzs124;               /* read */
+                flatzs6zssimpflatzs119        = flatzs7zssimpflatzs125;               /* write */
+                flatzs6zssimpflatzs120        = flatzs7zssimpflatzs126;               /* write */
+                flatzs6zssimpflatzs121        = flatzs7zssimpflatzs127;               /* write */
+            } else {
+                flatzs6zssimpflatzs119        = szsreifyzs6zsconvzs12zsavalzs0zssimpflatzs59; /* write */
+                flatzs6zssimpflatzs120        = 0.0;                                  /* write */
+                flatzs6zssimpflatzs121        = 0.0;                                  /* write */
+            }
+            
+            flatzs6zssimpflatzs128            = flatzs6zssimpflatzs119;               /* read */
+            flatzs6zssimpflatzs129            = flatzs6zssimpflatzs120;               /* read */
+            flatzs6zssimpflatzs130            = flatzs6zssimpflatzs121;               /* read */
+            flatzs3zssimpflatzs62             = flatzs6zssimpflatzs128;               /* write */
+            flatzs3zssimpflatzs63             = flatzs6zssimpflatzs129;               /* write */
+            flatzs3zssimpflatzs64             = flatzs6zssimpflatzs130;               /* write */
+        }
+        
+        flatzs3zssimpflatzs131                = flatzs3zssimpflatzs62;                /* read */
+        flatzs3zssimpflatzs132                = flatzs3zssimpflatzs63;                /* read */
+        flatzs3zssimpflatzs133                = flatzs3zssimpflatzs64;                /* read */
+        acczsszsreifyzs6zsconvzs12zssimpflatzs28 = flatzs3zssimpflatzs131;            /* write */
+        acczsszsreifyzs6zsconvzs12zssimpflatzs29 = flatzs3zssimpflatzs132;            /* write */
+        acczsszsreifyzs6zsconvzs12zssimpflatzs30 = flatzs3zssimpflatzs133;            /* write */
+        flatzs36zssimpflatzs134               = ierror_not_an_error;                  /* init */
+        flatzs36zssimpflatzs135               = "";                                   /* init */
+        
+        if (ierror_eq (convzs0zssimpflatzs307, ierror_not_an_error)) {
+            flatzs36zssimpflatzs134           = ierror_not_an_error;                  /* write */
+            flatzs36zssimpflatzs135           = convzs0zssimpflatzs308;               /* write */
+        } else {
+            flatzs36zssimpflatzs134           = convzs0zssimpflatzs307;               /* write */
+            flatzs36zssimpflatzs135           = "";                                   /* write */
+        }
+        
+        flatzs36zssimpflatzs136               = flatzs36zssimpflatzs134;              /* read */
+        flatzs36zssimpflatzs137               = flatzs36zssimpflatzs135;              /* read */
+        flatzs37zssimpflatzs138               = ierror_not_an_error;                  /* init */
+        flatzs37zssimpflatzs139               = ifalse;                               /* init */
+        
+        if (ierror_eq (flatzs36zssimpflatzs136, ierror_not_an_error)) {
+            flatzs37zssimpflatzs138           = ierror_not_an_error;                  /* write */
+            flatzs37zssimpflatzs139           = istring_eq (flatzs36zssimpflatzs137, "torso"); /* write */
+        } else {
+            flatzs37zssimpflatzs138           = flatzs36zssimpflatzs136;              /* write */
+            flatzs37zssimpflatzs139           = ifalse;                               /* write */
+        }
+        
+        flatzs37zssimpflatzs140               = flatzs37zssimpflatzs138;              /* read */
+        flatzs37zssimpflatzs141               = flatzs37zssimpflatzs139;              /* read */
+        flatzs38                              = ifalse;                               /* init */
+        
+        if (ierror_eq (flatzs37zssimpflatzs140, ierror_not_an_error)) {
+            flatzs38                          = flatzs37zssimpflatzs141;              /* write */
+        } else {
+            flatzs38                          = itrue;                                /* write */
+        }
+        
+        flatzs38                              = flatzs38;                             /* read */
+        
+        if (flatzs38) {
+            flatzs39zssimpflatzs142           = ierror_not_an_error;                  /* init */
+            flatzs39zssimpflatzs143           = 0;                                    /* init */
+            
+            if (ierror_eq (convzs0zssimpflatzs307, ierror_not_an_error)) {
+                flatzs39zssimpflatzs142       = ierror_not_an_error;                  /* write */
+                flatzs39zssimpflatzs143       = convzs0zssimpflatzs309;               /* write */
+            } else {
+                flatzs39zssimpflatzs142       = convzs0zssimpflatzs307;               /* write */
+                flatzs39zssimpflatzs143       = 0;                                    /* write */
+            }
+            
+            flatzs39zssimpflatzs144           = flatzs39zssimpflatzs142;              /* read */
+            flatzs39zssimpflatzs145           = flatzs39zssimpflatzs143;              /* read */
+            flatzs40zssimpflatzs146           = ierror_not_an_error;                  /* init */
+            flatzs40zssimpflatzs147           = 0.0;                                  /* init */
+            
+            if (ierror_eq (flatzs39zssimpflatzs144, ierror_not_an_error)) {
+                flatzs40zssimpflatzs146       = ierror_not_an_error;                  /* write */
+                flatzs40zssimpflatzs147       = iint_extend (flatzs39zssimpflatzs145); /* write */
+            } else {
+                flatzs40zssimpflatzs146       = flatzs39zssimpflatzs144;              /* write */
+                flatzs40zssimpflatzs147       = 0.0;                                  /* write */
+            }
+            
+            flatzs40zssimpflatzs148           = flatzs40zssimpflatzs146;              /* read */
+            flatzs40zssimpflatzs149           = flatzs40zssimpflatzs147;              /* read */
+            acczsconvzs76zssimpflatzs31       = flatzs40zssimpflatzs148;              /* write */
+            acczsconvzs76zssimpflatzs32       = flatzs40zssimpflatzs149;              /* write */
+            convzs76zsavalzs3zssimpflatzs150  = acczsconvzs76zssimpflatzs31;          /* read */
+            convzs76zsavalzs3zssimpflatzs151  = acczsconvzs76zssimpflatzs32;          /* read */
+            azsconvzs77zsavalzs2zssimpflatzs156 = acczsazsconvzs77zssimpflatzs37;     /* read */
+            azsconvzs77zsavalzs2zssimpflatzs157 = acczsazsconvzs77zssimpflatzs38;     /* read */
+            azsconvzs77zsavalzs2zssimpflatzs158 = acczsazsconvzs77zssimpflatzs39;     /* read */
+            azsconvzs77zsavalzs2zssimpflatzs159 = acczsazsconvzs77zssimpflatzs40;     /* read */
+            flatzs41zssimpflatzs160           = ierror_not_an_error;                  /* init */
+            flatzs41zssimpflatzs161           = 0.0;                                  /* init */
+            flatzs41zssimpflatzs162           = 0.0;                                  /* init */
+            flatzs41zssimpflatzs163           = 0.0;                                  /* init */
+            
+            if (ierror_eq (azsconvzs77zsavalzs2zssimpflatzs156, ierror_not_an_error)) {
+                idouble_t        convzs84     = idouble_add (azsconvzs77zsavalzs2zssimpflatzs157, 1.0); /* let */
+                flatzs44zssimpflatzs164       = ierror_not_an_error;                  /* init */
+                flatzs44zssimpflatzs165       = 0.0;                                  /* init */
+                
+                if (idouble_is_valid (convzs84)) {
+                    flatzs44zssimpflatzs164   = ierror_not_an_error;                  /* write */
+                    flatzs44zssimpflatzs165   = idouble_add (azsconvzs77zsavalzs2zssimpflatzs157, 1.0); /* write */
+                } else {
+                    flatzs44zssimpflatzs164   = ierror_cannot_compute;                /* write */
+                    flatzs44zssimpflatzs165   = 0.0;                                  /* write */
+                }
+                
+                flatzs44zssimpflatzs166       = flatzs44zssimpflatzs164;              /* read */
+                flatzs44zssimpflatzs167       = flatzs44zssimpflatzs165;              /* read */
+                flatzs45zssimpflatzs168       = ierror_not_an_error;                  /* init */
+                flatzs45zssimpflatzs169       = 0.0;                                  /* init */
+                
+                if (ierror_eq (convzs76zsavalzs3zssimpflatzs150, ierror_not_an_error)) {
+                    idouble_t        convzs89 = idouble_sub (convzs76zsavalzs3zssimpflatzs151, azsconvzs77zsavalzs2zssimpflatzs158); /* let */
+                    flatzs89zssimpflatzs170   = ierror_not_an_error;                  /* init */
+                    flatzs89zssimpflatzs171   = 0.0;                                  /* init */
+                    
+                    if (idouble_is_valid (convzs89)) {
+                        flatzs89zssimpflatzs170 = ierror_not_an_error;                /* write */
+                        flatzs89zssimpflatzs171 = idouble_sub (convzs76zsavalzs3zssimpflatzs151, azsconvzs77zsavalzs2zssimpflatzs158); /* write */
+                    } else {
+                        flatzs89zssimpflatzs170 = ierror_cannot_compute;              /* write */
+                        flatzs89zssimpflatzs171 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs89zssimpflatzs172   = flatzs89zssimpflatzs170;              /* read */
+                    flatzs89zssimpflatzs173   = flatzs89zssimpflatzs171;              /* read */
+                    flatzs45zssimpflatzs168   = flatzs89zssimpflatzs172;              /* write */
+                    flatzs45zssimpflatzs169   = flatzs89zssimpflatzs173;              /* write */
+                } else {
+                    flatzs45zssimpflatzs168   = convzs76zsavalzs3zssimpflatzs150;     /* write */
+                    flatzs45zssimpflatzs169   = 0.0;                                  /* write */
+                }
+                
+                flatzs45zssimpflatzs174       = flatzs45zssimpflatzs168;              /* read */
+                flatzs45zssimpflatzs175       = flatzs45zssimpflatzs169;              /* read */
+                flatzs46zssimpflatzs176       = ierror_not_an_error;                  /* init */
+                flatzs46zssimpflatzs177       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs45zssimpflatzs174, ierror_not_an_error)) {
+                    flatzs83zssimpflatzs178   = ierror_not_an_error;                  /* init */
+                    flatzs83zssimpflatzs179   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs44zssimpflatzs166, ierror_not_an_error)) {
+                        idouble_t        convzs97 = idouble_div (flatzs45zssimpflatzs175, flatzs44zssimpflatzs167); /* let */
+                        flatzs86zssimpflatzs180 = ierror_not_an_error;                /* init */
+                        flatzs86zssimpflatzs181 = 0.0;                                /* init */
+                        
+                        if (idouble_is_valid (convzs97)) {
+                            flatzs86zssimpflatzs180 = ierror_not_an_error;            /* write */
+                            flatzs86zssimpflatzs181 = idouble_div (flatzs45zssimpflatzs175, flatzs44zssimpflatzs167); /* write */
+                        } else {
+                            flatzs86zssimpflatzs180 = ierror_cannot_compute;          /* write */
+                            flatzs86zssimpflatzs181 = 0.0;                            /* write */
+                        }
+                        
+                        flatzs86zssimpflatzs182 = flatzs86zssimpflatzs180;            /* read */
+                        flatzs86zssimpflatzs183 = flatzs86zssimpflatzs181;            /* read */
+                        flatzs83zssimpflatzs178 = flatzs86zssimpflatzs182;            /* write */
+                        flatzs83zssimpflatzs179 = flatzs86zssimpflatzs183;            /* write */
+                    } else {
+                        flatzs83zssimpflatzs178 = flatzs44zssimpflatzs166;            /* write */
+                        flatzs83zssimpflatzs179 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs83zssimpflatzs184   = flatzs83zssimpflatzs178;              /* read */
+                    flatzs83zssimpflatzs185   = flatzs83zssimpflatzs179;              /* read */
+                    flatzs46zssimpflatzs176   = flatzs83zssimpflatzs184;              /* write */
+                    flatzs46zssimpflatzs177   = flatzs83zssimpflatzs185;              /* write */
+                } else {
+                    flatzs46zssimpflatzs176   = flatzs45zssimpflatzs174;              /* write */
+                    flatzs46zssimpflatzs177   = 0.0;                                  /* write */
+                }
+                
+                flatzs46zssimpflatzs186       = flatzs46zssimpflatzs176;              /* read */
+                flatzs46zssimpflatzs187       = flatzs46zssimpflatzs177;              /* read */
+                flatzs47zssimpflatzs188       = ierror_not_an_error;                  /* init */
+                flatzs47zssimpflatzs189       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs46zssimpflatzs186, ierror_not_an_error)) {
+                    idouble_t        convzs103 = idouble_add (azsconvzs77zsavalzs2zssimpflatzs158, flatzs46zssimpflatzs187); /* let */
+                    flatzs80zssimpflatzs190   = ierror_not_an_error;                  /* init */
+                    flatzs80zssimpflatzs191   = 0.0;                                  /* init */
+                    
+                    if (idouble_is_valid (convzs103)) {
+                        flatzs80zssimpflatzs190 = ierror_not_an_error;                /* write */
+                        flatzs80zssimpflatzs191 = idouble_add (azsconvzs77zsavalzs2zssimpflatzs158, flatzs46zssimpflatzs187); /* write */
+                    } else {
+                        flatzs80zssimpflatzs190 = ierror_cannot_compute;              /* write */
+                        flatzs80zssimpflatzs191 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs80zssimpflatzs192   = flatzs80zssimpflatzs190;              /* read */
+                    flatzs80zssimpflatzs193   = flatzs80zssimpflatzs191;              /* read */
+                    flatzs47zssimpflatzs188   = flatzs80zssimpflatzs192;              /* write */
+                    flatzs47zssimpflatzs189   = flatzs80zssimpflatzs193;              /* write */
+                } else {
+                    flatzs47zssimpflatzs188   = flatzs46zssimpflatzs186;              /* write */
+                    flatzs47zssimpflatzs189   = 0.0;                                  /* write */
+                }
+                
+                flatzs47zssimpflatzs194       = flatzs47zssimpflatzs188;              /* read */
+                flatzs47zssimpflatzs195       = flatzs47zssimpflatzs189;              /* read */
+                flatzs48zssimpflatzs196       = ierror_not_an_error;                  /* init */
+                flatzs48zssimpflatzs197       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs45zssimpflatzs174, ierror_not_an_error)) {
+                    flatzs67zssimpflatzs198   = ierror_not_an_error;                  /* init */
+                    flatzs67zssimpflatzs199   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (convzs76zsavalzs3zssimpflatzs150, ierror_not_an_error)) {
+                        flatzs74zssimpflatzs200 = ierror_not_an_error;                /* init */
+                        flatzs74zssimpflatzs201 = 0.0;                                /* init */
+                        
+                        if (ierror_eq (flatzs47zssimpflatzs194, ierror_not_an_error)) {
+                            idouble_t        convzs113 = idouble_sub (convzs76zsavalzs3zssimpflatzs151, flatzs47zssimpflatzs195); /* let */
+                            flatzs77zssimpflatzs202 = ierror_not_an_error;            /* init */
+                            flatzs77zssimpflatzs203 = 0.0;                            /* init */
+                            
+                            if (idouble_is_valid (convzs113)) {
+                                flatzs77zssimpflatzs202 = ierror_not_an_error;        /* write */
+                                flatzs77zssimpflatzs203 = idouble_sub (convzs76zsavalzs3zssimpflatzs151, flatzs47zssimpflatzs195); /* write */
+                            } else {
+                                flatzs77zssimpflatzs202 = ierror_cannot_compute;      /* write */
+                                flatzs77zssimpflatzs203 = 0.0;                        /* write */
+                            }
+                            
+                            flatzs77zssimpflatzs204 = flatzs77zssimpflatzs202;        /* read */
+                            flatzs77zssimpflatzs205 = flatzs77zssimpflatzs203;        /* read */
+                            flatzs74zssimpflatzs200 = flatzs77zssimpflatzs204;        /* write */
+                            flatzs74zssimpflatzs201 = flatzs77zssimpflatzs205;        /* write */
+                        } else {
+                            flatzs74zssimpflatzs200 = flatzs47zssimpflatzs194;        /* write */
+                            flatzs74zssimpflatzs201 = 0.0;                            /* write */
+                        }
+                        
+                        flatzs74zssimpflatzs206 = flatzs74zssimpflatzs200;            /* read */
+                        flatzs74zssimpflatzs207 = flatzs74zssimpflatzs201;            /* read */
+                        flatzs67zssimpflatzs198 = flatzs74zssimpflatzs206;            /* write */
+                        flatzs67zssimpflatzs199 = flatzs74zssimpflatzs207;            /* write */
+                    } else {
+                        flatzs67zssimpflatzs198 = convzs76zsavalzs3zssimpflatzs150;   /* write */
+                        flatzs67zssimpflatzs199 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs67zssimpflatzs208   = flatzs67zssimpflatzs198;              /* read */
+                    flatzs67zssimpflatzs209   = flatzs67zssimpflatzs199;              /* read */
+                    flatzs68zssimpflatzs210   = ierror_not_an_error;                  /* init */
+                    flatzs68zssimpflatzs211   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs67zssimpflatzs208, ierror_not_an_error)) {
+                        idouble_t        convzs119 = idouble_mul (flatzs45zssimpflatzs175, flatzs67zssimpflatzs209); /* let */
+                        flatzs71zssimpflatzs212 = ierror_not_an_error;                /* init */
+                        flatzs71zssimpflatzs213 = 0.0;                                /* init */
+                        
+                        if (idouble_is_valid (convzs119)) {
+                            flatzs71zssimpflatzs212 = ierror_not_an_error;            /* write */
+                            flatzs71zssimpflatzs213 = idouble_mul (flatzs45zssimpflatzs175, flatzs67zssimpflatzs209); /* write */
+                        } else {
+                            flatzs71zssimpflatzs212 = ierror_cannot_compute;          /* write */
+                            flatzs71zssimpflatzs213 = 0.0;                            /* write */
+                        }
+                        
+                        flatzs71zssimpflatzs214 = flatzs71zssimpflatzs212;            /* read */
+                        flatzs71zssimpflatzs215 = flatzs71zssimpflatzs213;            /* read */
+                        flatzs68zssimpflatzs210 = flatzs71zssimpflatzs214;            /* write */
+                        flatzs68zssimpflatzs211 = flatzs71zssimpflatzs215;            /* write */
+                    } else {
+                        flatzs68zssimpflatzs210 = flatzs67zssimpflatzs208;            /* write */
+                        flatzs68zssimpflatzs211 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs68zssimpflatzs216   = flatzs68zssimpflatzs210;              /* read */
+                    flatzs68zssimpflatzs217   = flatzs68zssimpflatzs211;              /* read */
+                    flatzs48zssimpflatzs196   = flatzs68zssimpflatzs216;              /* write */
+                    flatzs48zssimpflatzs197   = flatzs68zssimpflatzs217;              /* write */
+                } else {
+                    flatzs48zssimpflatzs196   = flatzs45zssimpflatzs174;              /* write */
+                    flatzs48zssimpflatzs197   = 0.0;                                  /* write */
+                }
+                
+                flatzs48zssimpflatzs218       = flatzs48zssimpflatzs196;              /* read */
+                flatzs48zssimpflatzs219       = flatzs48zssimpflatzs197;              /* read */
+                flatzs49zssimpflatzs220       = ierror_not_an_error;                  /* init */
+                flatzs49zssimpflatzs221       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs48zssimpflatzs218, ierror_not_an_error)) {
+                    idouble_t        convzs125 = idouble_add (azsconvzs77zsavalzs2zssimpflatzs159, flatzs48zssimpflatzs219); /* let */
+                    flatzs64zssimpflatzs222   = ierror_not_an_error;                  /* init */
+                    flatzs64zssimpflatzs223   = 0.0;                                  /* init */
+                    
+                    if (idouble_is_valid (convzs125)) {
+                        flatzs64zssimpflatzs222 = ierror_not_an_error;                /* write */
+                        flatzs64zssimpflatzs223 = idouble_add (azsconvzs77zsavalzs2zssimpflatzs159, flatzs48zssimpflatzs219); /* write */
+                    } else {
+                        flatzs64zssimpflatzs222 = ierror_cannot_compute;              /* write */
+                        flatzs64zssimpflatzs223 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs64zssimpflatzs224   = flatzs64zssimpflatzs222;              /* read */
+                    flatzs64zssimpflatzs225   = flatzs64zssimpflatzs223;              /* read */
+                    flatzs49zssimpflatzs220   = flatzs64zssimpflatzs224;              /* write */
+                    flatzs49zssimpflatzs221   = flatzs64zssimpflatzs225;              /* write */
+                } else {
+                    flatzs49zssimpflatzs220   = flatzs48zssimpflatzs218;              /* write */
+                    flatzs49zssimpflatzs221   = 0.0;                                  /* write */
+                }
+                
+                flatzs49zssimpflatzs226       = flatzs49zssimpflatzs220;              /* read */
+                flatzs49zssimpflatzs227       = flatzs49zssimpflatzs221;              /* read */
+                flatzs50zssimpflatzs228       = ierror_not_an_error;                  /* init */
+                flatzs50zssimpflatzs229       = 0.0;                                  /* init */
+                flatzs50zssimpflatzs230       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs44zssimpflatzs166, ierror_not_an_error)) {
+                    flatzs59zssimpflatzs231   = ierror_not_an_error;                  /* init */
+                    flatzs59zssimpflatzs232   = 0.0;                                  /* init */
+                    flatzs59zssimpflatzs233   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs47zssimpflatzs194, ierror_not_an_error)) {
+                        flatzs59zssimpflatzs231 = ierror_not_an_error;                /* write */
+                        flatzs59zssimpflatzs232 = flatzs44zssimpflatzs167;            /* write */
+                        flatzs59zssimpflatzs233 = flatzs47zssimpflatzs195;            /* write */
+                    } else {
+                        flatzs59zssimpflatzs231 = flatzs47zssimpflatzs194;            /* write */
+                        flatzs59zssimpflatzs232 = 0.0;                                /* write */
+                        flatzs59zssimpflatzs233 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs59zssimpflatzs234   = flatzs59zssimpflatzs231;              /* read */
+                    flatzs59zssimpflatzs235   = flatzs59zssimpflatzs232;              /* read */
+                    flatzs59zssimpflatzs236   = flatzs59zssimpflatzs233;              /* read */
+                    flatzs50zssimpflatzs228   = flatzs59zssimpflatzs234;              /* write */
+                    flatzs50zssimpflatzs229   = flatzs59zssimpflatzs235;              /* write */
+                    flatzs50zssimpflatzs230   = flatzs59zssimpflatzs236;              /* write */
+                } else {
+                    flatzs50zssimpflatzs228   = flatzs44zssimpflatzs166;              /* write */
+                    flatzs50zssimpflatzs229   = 0.0;                                  /* write */
+                    flatzs50zssimpflatzs230   = 0.0;                                  /* write */
+                }
+                
+                flatzs50zssimpflatzs237       = flatzs50zssimpflatzs228;              /* read */
+                flatzs50zssimpflatzs238       = flatzs50zssimpflatzs229;              /* read */
+                flatzs50zssimpflatzs239       = flatzs50zssimpflatzs230;              /* read */
+                flatzs51zssimpflatzs240       = ierror_not_an_error;                  /* init */
+                flatzs51zssimpflatzs241       = 0.0;                                  /* init */
+                flatzs51zssimpflatzs242       = 0.0;                                  /* init */
+                flatzs51zssimpflatzs243       = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs50zssimpflatzs237, ierror_not_an_error)) {
+                    flatzs54zssimpflatzs244   = ierror_not_an_error;                  /* init */
+                    flatzs54zssimpflatzs245   = 0.0;                                  /* init */
+                    flatzs54zssimpflatzs246   = 0.0;                                  /* init */
+                    flatzs54zssimpflatzs247   = 0.0;                                  /* init */
+                    
+                    if (ierror_eq (flatzs49zssimpflatzs226, ierror_not_an_error)) {
+                        flatzs54zssimpflatzs244 = ierror_not_an_error;                /* write */
+                        flatzs54zssimpflatzs245 = flatzs50zssimpflatzs238;            /* write */
+                        flatzs54zssimpflatzs246 = flatzs50zssimpflatzs239;            /* write */
+                        flatzs54zssimpflatzs247 = flatzs49zssimpflatzs227;            /* write */
+                    } else {
+                        flatzs54zssimpflatzs244 = flatzs49zssimpflatzs226;            /* write */
+                        flatzs54zssimpflatzs245 = 0.0;                                /* write */
+                        flatzs54zssimpflatzs246 = 0.0;                                /* write */
+                        flatzs54zssimpflatzs247 = 0.0;                                /* write */
+                    }
+                    
+                    flatzs54zssimpflatzs248   = flatzs54zssimpflatzs244;              /* read */
+                    flatzs54zssimpflatzs249   = flatzs54zssimpflatzs245;              /* read */
+                    flatzs54zssimpflatzs250   = flatzs54zssimpflatzs246;              /* read */
+                    flatzs54zssimpflatzs251   = flatzs54zssimpflatzs247;              /* read */
+                    flatzs51zssimpflatzs240   = flatzs54zssimpflatzs248;              /* write */
+                    flatzs51zssimpflatzs241   = flatzs54zssimpflatzs249;              /* write */
+                    flatzs51zssimpflatzs242   = flatzs54zssimpflatzs250;              /* write */
+                    flatzs51zssimpflatzs243   = flatzs54zssimpflatzs251;              /* write */
+                } else {
+                    flatzs51zssimpflatzs240   = flatzs50zssimpflatzs237;              /* write */
+                    flatzs51zssimpflatzs241   = 0.0;                                  /* write */
+                    flatzs51zssimpflatzs242   = 0.0;                                  /* write */
+                    flatzs51zssimpflatzs243   = 0.0;                                  /* write */
+                }
+                
+                flatzs51zssimpflatzs252       = flatzs51zssimpflatzs240;              /* read */
+                flatzs51zssimpflatzs253       = flatzs51zssimpflatzs241;              /* read */
+                flatzs51zssimpflatzs254       = flatzs51zssimpflatzs242;              /* read */
+                flatzs51zssimpflatzs255       = flatzs51zssimpflatzs243;              /* read */
+                flatzs41zssimpflatzs160       = flatzs51zssimpflatzs252;              /* write */
+                flatzs41zssimpflatzs161       = flatzs51zssimpflatzs253;              /* write */
+                flatzs41zssimpflatzs162       = flatzs51zssimpflatzs254;              /* write */
+                flatzs41zssimpflatzs163       = flatzs51zssimpflatzs255;              /* write */
+            } else {
+                flatzs41zssimpflatzs160       = azsconvzs77zsavalzs2zssimpflatzs156;  /* write */
+                flatzs41zssimpflatzs161       = 0.0;                                  /* write */
+                flatzs41zssimpflatzs162       = 0.0;                                  /* write */
+                flatzs41zssimpflatzs163       = 0.0;                                  /* write */
+            }
+            
+            flatzs41zssimpflatzs256           = flatzs41zssimpflatzs160;              /* read */
+            flatzs41zssimpflatzs257           = flatzs41zssimpflatzs161;              /* read */
+            flatzs41zssimpflatzs258           = flatzs41zssimpflatzs162;              /* read */
+            flatzs41zssimpflatzs259           = flatzs41zssimpflatzs163;              /* read */
+            acczsazsconvzs77zssimpflatzs37    = flatzs41zssimpflatzs256;              /* write */
+            acczsazsconvzs77zssimpflatzs38    = flatzs41zssimpflatzs257;              /* write */
+            acczsazsconvzs77zssimpflatzs39    = flatzs41zssimpflatzs258;              /* write */
+            acczsazsconvzs77zssimpflatzs40    = flatzs41zssimpflatzs259;              /* write */
         }
         
     }
     
-    s->has_0_0_acczsazsconvzs61zssimpflatzs48 = itrue;                                /* save */
-    s->res_0_0_acczsazsconvzs61zssimpflatzs48 = acczsazsconvzs61zssimpflatzs48;       /* save */
+    s->has_0_0_acczsazsconvzs77zssimpflatzs37 = itrue;                                /* save */
+    s->res_0_0_acczsazsconvzs77zssimpflatzs37 = acczsazsconvzs77zssimpflatzs37;       /* save */
     
-    s->has_0_0_acczsazsconvzs61zssimpflatzs49 = itrue;                                /* save */
-    s->res_0_0_acczsazsconvzs61zssimpflatzs49 = acczsazsconvzs61zssimpflatzs49;       /* save */
+    s->has_0_0_acczsazsconvzs77zssimpflatzs38 = itrue;                                /* save */
+    s->res_0_0_acczsazsconvzs77zssimpflatzs38 = acczsazsconvzs77zssimpflatzs38;       /* save */
     
-    s->has_0_0_acczsazsconvzs61zssimpflatzs50 = itrue;                                /* save */
-    s->res_0_0_acczsazsconvzs61zssimpflatzs50 = acczsazsconvzs61zssimpflatzs50;       /* save */
+    s->has_0_0_acczsazsconvzs77zssimpflatzs39 = itrue;                                /* save */
+    s->res_0_0_acczsazsconvzs77zssimpflatzs39 = acczsazsconvzs77zssimpflatzs39;       /* save */
     
-    s->has_0_0_acczsazsconvzs61zssimpflatzs51 = itrue;                                /* save */
-    s->res_0_0_acczsazsconvzs61zssimpflatzs51 = acczsazsconvzs61zssimpflatzs51;       /* save */
+    s->has_0_0_acczsazsconvzs77zssimpflatzs40 = itrue;                                /* save */
+    s->res_0_0_acczsazsconvzs77zssimpflatzs40 = acczsazsconvzs77zssimpflatzs40;       /* save */
     
-    s->has_0_0_acczsconvzs60zssimpflatzs42    = itrue;                                /* save */
-    s->res_0_0_acczsconvzs60zssimpflatzs42    = acczsconvzs60zssimpflatzs42;          /* save */
+    s->has_0_0_acczsconvzs76zssimpflatzs31    = itrue;                                /* save */
+    s->res_0_0_acczsconvzs76zssimpflatzs31    = acczsconvzs76zssimpflatzs31;          /* save */
     
-    s->has_0_0_acczsconvzs60zssimpflatzs43    = itrue;                                /* save */
-    s->res_0_0_acczsconvzs60zssimpflatzs43    = acczsconvzs60zssimpflatzs43;          /* save */
+    s->has_0_0_acczsconvzs76zssimpflatzs32    = itrue;                                /* save */
+    s->res_0_0_acczsconvzs76zssimpflatzs32    = acczsconvzs76zssimpflatzs32;          /* save */
     
-    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39 = itrue;                      /* save */
-    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs39 = acczsszsreifyzs6zsconvzs12zssimpflatzs39; /* save */
+    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28 = itrue;                      /* save */
+    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs28 = acczsszsreifyzs6zsconvzs12zssimpflatzs28; /* save */
     
-    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40 = itrue;                      /* save */
-    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs40 = acczsszsreifyzs6zsconvzs12zssimpflatzs40; /* save */
+    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29 = itrue;                      /* save */
+    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs29 = acczsszsreifyzs6zsconvzs12zssimpflatzs29; /* save */
     
-    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41 = itrue;                      /* save */
-    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs41 = acczsszsreifyzs6zsconvzs12zssimpflatzs41; /* save */
+    s->has_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30 = itrue;                      /* save */
+    s->res_0_0_acczsszsreifyzs6zsconvzs12zssimpflatzs30 = acczsszsreifyzs6zsconvzs12zssimpflatzs30; /* save */
     
-    s->has_0_0_acczsconvzs11zssimpflatzs33    = itrue;                                /* save */
-    s->res_0_0_acczsconvzs11zssimpflatzs33    = acczsconvzs11zssimpflatzs33;          /* save */
+    s->has_0_0_acczsconvzs11zssimpflatzs22    = itrue;                                /* save */
+    s->res_0_0_acczsconvzs11zssimpflatzs22    = acczsconvzs11zssimpflatzs22;          /* save */
     
-    s->has_0_0_acczsconvzs11zssimpflatzs34    = itrue;                                /* save */
-    s->res_0_0_acczsconvzs11zssimpflatzs34    = acczsconvzs11zssimpflatzs34;          /* save */
+    s->has_0_0_acczsconvzs11zssimpflatzs23    = itrue;                                /* save */
+    s->res_0_0_acczsconvzs11zssimpflatzs23    = acczsconvzs11zssimpflatzs23;          /* save */
     
-    azsconvzs61zssimpflatzs203                = acczsazsconvzs61zssimpflatzs48;       /* read */
-    azsconvzs61zssimpflatzs204                = acczsazsconvzs61zssimpflatzs49;       /* read */
-    azsconvzs61zssimpflatzs206                = acczsazsconvzs61zssimpflatzs51;       /* read */
-    szsreifyzs6zsconvzs12zssimpflatzs207      = acczsszsreifyzs6zsconvzs12zssimpflatzs39; /* read */
-    szsreifyzs6zsconvzs12zssimpflatzs208      = acczsszsreifyzs6zsconvzs12zssimpflatzs40; /* read */
-    flatzs86zssimpflatzs210                   = ierror_not_an_error;                  /* init */
-    flatzs86zssimpflatzs211                   = 0.0;                                  /* init */
+    azsconvzs77zssimpflatzs260                = acczsazsconvzs77zssimpflatzs37;       /* read */
+    azsconvzs77zssimpflatzs261                = acczsazsconvzs77zssimpflatzs38;       /* read */
+    azsconvzs77zssimpflatzs263                = acczsazsconvzs77zssimpflatzs40;       /* read */
+    szsreifyzs6zsconvzs12zssimpflatzs264      = acczsszsreifyzs6zsconvzs12zssimpflatzs28; /* read */
+    szsreifyzs6zsconvzs12zssimpflatzs265      = acczsszsreifyzs6zsconvzs12zssimpflatzs29; /* read */
+    flatzs110zssimpflatzs267                  = ierror_not_an_error;                  /* init */
+    flatzs110zssimpflatzs268                  = 0.0;                                  /* init */
     
-    if (ierror_eq (szsreifyzs6zsconvzs12zssimpflatzs207, ierror_not_an_error)) {
-        flatzs86zssimpflatzs210               = ierror_not_an_error;                  /* write */
-        flatzs86zssimpflatzs211               = szsreifyzs6zsconvzs12zssimpflatzs208; /* write */
+    if (ierror_eq (szsreifyzs6zsconvzs12zssimpflatzs264, ierror_not_an_error)) {
+        flatzs110zssimpflatzs267              = ierror_not_an_error;                  /* write */
+        flatzs110zssimpflatzs268              = szsreifyzs6zsconvzs12zssimpflatzs265; /* write */
     } else {
-        flatzs86zssimpflatzs210               = szsreifyzs6zsconvzs12zssimpflatzs207; /* write */
-        flatzs86zssimpflatzs211               = 0.0;                                  /* write */
+        flatzs110zssimpflatzs267              = szsreifyzs6zsconvzs12zssimpflatzs264; /* write */
+        flatzs110zssimpflatzs268              = 0.0;                                  /* write */
     }
     
-    flatzs86zssimpflatzs212                   = flatzs86zssimpflatzs210;              /* read */
-    flatzs86zssimpflatzs213                   = flatzs86zssimpflatzs211;              /* read */
-    flatzs87zssimpflatzs214                   = ierror_not_an_error;                  /* init */
-    flatzs87zssimpflatzs215                   = 0.0;                                  /* init */
+    flatzs110zssimpflatzs269                  = flatzs110zssimpflatzs267;             /* read */
+    flatzs110zssimpflatzs270                  = flatzs110zssimpflatzs268;             /* read */
+    flatzs111zssimpflatzs271                  = ierror_not_an_error;                  /* init */
+    flatzs111zssimpflatzs272                  = 0.0;                                  /* init */
     
-    if (ierror_eq (flatzs86zssimpflatzs212, ierror_not_an_error)) {
-        flatzs90zssimpflatzs216               = ierror_not_an_error;                  /* init */
-        flatzs90zssimpflatzs217               = 0.0;                                  /* init */
+    if (ierror_eq (flatzs110zssimpflatzs269, ierror_not_an_error)) {
+        flatzs114zssimpflatzs273              = ierror_not_an_error;                  /* init */
+        flatzs114zssimpflatzs274              = 0.0;                                  /* init */
         
-        if (ierror_eq (azsconvzs61zssimpflatzs203, ierror_not_an_error)) {
-            idouble_t        convzs116        = idouble_sub (azsconvzs61zssimpflatzs204, 1.0); /* let */
-            idouble_t        simpflatzs638    = idouble_div (azsconvzs61zssimpflatzs206, convzs116); /* let */
-            flatzs90zssimpflatzs216           = ierror_not_an_error;                  /* write */
-            flatzs90zssimpflatzs217           = simpflatzs638;                        /* write */
+        if (ierror_eq (azsconvzs77zssimpflatzs260, ierror_not_an_error)) {
+            idouble_t        convzs152        = idouble_sub (azsconvzs77zssimpflatzs261, 1.0); /* let */
+            flatzs125zssimpflatzs275          = ierror_not_an_error;                  /* init */
+            flatzs125zssimpflatzs276          = 0.0;                                  /* init */
+            
+            if (idouble_is_valid (convzs152)) {
+                flatzs125zssimpflatzs275      = ierror_not_an_error;                  /* write */
+                flatzs125zssimpflatzs276      = idouble_sub (azsconvzs77zssimpflatzs261, 1.0); /* write */
+            } else {
+                flatzs125zssimpflatzs275      = ierror_cannot_compute;                /* write */
+                flatzs125zssimpflatzs276      = 0.0;                                  /* write */
+            }
+            
+            flatzs125zssimpflatzs277          = flatzs125zssimpflatzs275;             /* read */
+            flatzs125zssimpflatzs278          = flatzs125zssimpflatzs276;             /* read */
+            flatzs126zssimpflatzs279          = ierror_not_an_error;                  /* init */
+            flatzs126zssimpflatzs280          = 0.0;                                  /* init */
+            
+            if (ierror_eq (flatzs125zssimpflatzs277, ierror_not_an_error)) {
+                idouble_t        convzs158    = idouble_div (azsconvzs77zssimpflatzs263, flatzs125zssimpflatzs278); /* let */
+                flatzs129zssimpflatzs281      = ierror_not_an_error;                  /* init */
+                flatzs129zssimpflatzs282      = 0.0;                                  /* init */
+                
+                if (idouble_is_valid (convzs158)) {
+                    flatzs129zssimpflatzs281  = ierror_not_an_error;                  /* write */
+                    flatzs129zssimpflatzs282  = idouble_div (azsconvzs77zssimpflatzs263, flatzs125zssimpflatzs278); /* write */
+                } else {
+                    flatzs129zssimpflatzs281  = ierror_cannot_compute;                /* write */
+                    flatzs129zssimpflatzs282  = 0.0;                                  /* write */
+                }
+                
+                flatzs129zssimpflatzs283      = flatzs129zssimpflatzs281;             /* read */
+                flatzs129zssimpflatzs284      = flatzs129zssimpflatzs282;             /* read */
+                flatzs126zssimpflatzs279      = flatzs129zssimpflatzs283;             /* write */
+                flatzs126zssimpflatzs280      = flatzs129zssimpflatzs284;             /* write */
+            } else {
+                flatzs126zssimpflatzs279      = flatzs125zssimpflatzs277;             /* write */
+                flatzs126zssimpflatzs280      = 0.0;                                  /* write */
+            }
+            
+            flatzs126zssimpflatzs285          = flatzs126zssimpflatzs279;             /* read */
+            flatzs126zssimpflatzs286          = flatzs126zssimpflatzs280;             /* read */
+            flatzs114zssimpflatzs273          = flatzs126zssimpflatzs285;             /* write */
+            flatzs114zssimpflatzs274          = flatzs126zssimpflatzs286;             /* write */
         } else {
-            flatzs90zssimpflatzs216           = azsconvzs61zssimpflatzs203;           /* write */
-            flatzs90zssimpflatzs217           = 0.0;                                  /* write */
+            flatzs114zssimpflatzs273          = azsconvzs77zssimpflatzs260;           /* write */
+            flatzs114zssimpflatzs274          = 0.0;                                  /* write */
         }
         
-        flatzs90zssimpflatzs218               = flatzs90zssimpflatzs216;              /* read */
-        flatzs90zssimpflatzs219               = flatzs90zssimpflatzs217;              /* read */
-        flatzs91zssimpflatzs220               = ierror_not_an_error;                  /* init */
-        flatzs91zssimpflatzs221               = 0.0;                                  /* init */
+        flatzs114zssimpflatzs287              = flatzs114zssimpflatzs273;             /* read */
+        flatzs114zssimpflatzs288              = flatzs114zssimpflatzs274;             /* read */
+        flatzs115zssimpflatzs289              = ierror_not_an_error;                  /* init */
+        flatzs115zssimpflatzs290              = 0.0;                                  /* init */
         
-        if (ierror_eq (flatzs90zssimpflatzs218, ierror_not_an_error)) {
-            flatzs91zssimpflatzs220           = ierror_not_an_error;                  /* write */
-            flatzs91zssimpflatzs221           = idouble_sqrt (flatzs90zssimpflatzs219); /* write */
+        if (ierror_eq (flatzs114zssimpflatzs287, ierror_not_an_error)) {
+            idouble_t        convzs172        = idouble_sqrt (flatzs114zssimpflatzs288); /* let */
+            flatzs122zssimpflatzs291          = ierror_not_an_error;                  /* init */
+            flatzs122zssimpflatzs292          = 0.0;                                  /* init */
+            
+            if (idouble_is_valid (convzs172)) {
+                flatzs122zssimpflatzs291      = ierror_not_an_error;                  /* write */
+                flatzs122zssimpflatzs292      = idouble_sqrt (flatzs114zssimpflatzs288); /* write */
+            } else {
+                flatzs122zssimpflatzs291      = ierror_cannot_compute;                /* write */
+                flatzs122zssimpflatzs292      = 0.0;                                  /* write */
+            }
+            
+            flatzs122zssimpflatzs293          = flatzs122zssimpflatzs291;             /* read */
+            flatzs122zssimpflatzs294          = flatzs122zssimpflatzs292;             /* read */
+            flatzs115zssimpflatzs289          = flatzs122zssimpflatzs293;             /* write */
+            flatzs115zssimpflatzs290          = flatzs122zssimpflatzs294;             /* write */
         } else {
-            flatzs91zssimpflatzs220           = flatzs90zssimpflatzs218;              /* write */
-            flatzs91zssimpflatzs221           = 0.0;                                  /* write */
+            flatzs115zssimpflatzs289          = flatzs114zssimpflatzs287;             /* write */
+            flatzs115zssimpflatzs290          = 0.0;                                  /* write */
         }
         
-        flatzs91zssimpflatzs222               = flatzs91zssimpflatzs220;              /* read */
-        flatzs91zssimpflatzs223               = flatzs91zssimpflatzs221;              /* read */
-        flatzs92zssimpflatzs224               = ierror_not_an_error;                  /* init */
-        flatzs92zssimpflatzs225               = 0.0;                                  /* init */
+        flatzs115zssimpflatzs295              = flatzs115zssimpflatzs289;             /* read */
+        flatzs115zssimpflatzs296              = flatzs115zssimpflatzs290;             /* read */
+        flatzs116zssimpflatzs297              = ierror_not_an_error;                  /* init */
+        flatzs116zssimpflatzs298              = 0.0;                                  /* init */
         
-        if (ierror_eq (flatzs91zssimpflatzs222, ierror_not_an_error)) {
-            flatzs92zssimpflatzs224           = ierror_not_an_error;                  /* write */
-            flatzs92zssimpflatzs225           = idouble_mul (flatzs86zssimpflatzs213, flatzs91zssimpflatzs223); /* write */
+        if (ierror_eq (flatzs115zssimpflatzs295, ierror_not_an_error)) {
+            idouble_t        convzs180        = idouble_mul (flatzs110zssimpflatzs270, flatzs115zssimpflatzs296); /* let */
+            flatzs119zssimpflatzs299          = ierror_not_an_error;                  /* init */
+            flatzs119zssimpflatzs300          = 0.0;                                  /* init */
+            
+            if (idouble_is_valid (convzs180)) {
+                flatzs119zssimpflatzs299      = ierror_not_an_error;                  /* write */
+                flatzs119zssimpflatzs300      = idouble_mul (flatzs110zssimpflatzs270, flatzs115zssimpflatzs296); /* write */
+            } else {
+                flatzs119zssimpflatzs299      = ierror_cannot_compute;                /* write */
+                flatzs119zssimpflatzs300      = 0.0;                                  /* write */
+            }
+            
+            flatzs119zssimpflatzs301          = flatzs119zssimpflatzs299;             /* read */
+            flatzs119zssimpflatzs302          = flatzs119zssimpflatzs300;             /* read */
+            flatzs116zssimpflatzs297          = flatzs119zssimpflatzs301;             /* write */
+            flatzs116zssimpflatzs298          = flatzs119zssimpflatzs302;             /* write */
         } else {
-            flatzs92zssimpflatzs224           = flatzs91zssimpflatzs222;              /* write */
-            flatzs92zssimpflatzs225           = 0.0;                                  /* write */
+            flatzs116zssimpflatzs297          = flatzs115zssimpflatzs295;             /* write */
+            flatzs116zssimpflatzs298          = 0.0;                                  /* write */
         }
         
-        flatzs92zssimpflatzs226               = flatzs92zssimpflatzs224;              /* read */
-        flatzs92zssimpflatzs227               = flatzs92zssimpflatzs225;              /* read */
-        flatzs87zssimpflatzs214               = flatzs92zssimpflatzs226;              /* write */
-        flatzs87zssimpflatzs215               = flatzs92zssimpflatzs227;              /* write */
+        flatzs116zssimpflatzs303              = flatzs116zssimpflatzs297;             /* read */
+        flatzs116zssimpflatzs304              = flatzs116zssimpflatzs298;             /* read */
+        flatzs111zssimpflatzs271              = flatzs116zssimpflatzs303;             /* write */
+        flatzs111zssimpflatzs272              = flatzs116zssimpflatzs304;             /* write */
     } else {
-        flatzs87zssimpflatzs214               = flatzs86zssimpflatzs212;              /* write */
-        flatzs87zssimpflatzs215               = 0.0;                                  /* write */
+        flatzs111zssimpflatzs271              = flatzs110zssimpflatzs269;             /* write */
+        flatzs111zssimpflatzs272              = 0.0;                                  /* write */
     }
     
-    flatzs87zssimpflatzs228                   = flatzs87zssimpflatzs214;              /* read */
-    flatzs87zssimpflatzs229                   = flatzs87zssimpflatzs215;              /* read */
-    s->replZCoutputzsixzs0                    = flatzs87zssimpflatzs228;              /* output */
-    s->replZCoutputzsixzs1                    = flatzs87zssimpflatzs229;              /* output */
+    flatzs111zssimpflatzs305                  = flatzs111zssimpflatzs271;             /* read */
+    flatzs111zssimpflatzs306                  = flatzs111zssimpflatzs272;             /* read */
+    s->replZCoutputzsixzs0                    = flatzs111zssimpflatzs305;             /* output */
+    s->replZCoutputzsixzs1                    = flatzs111zssimpflatzs306;             /* output */
 }
 
 - C evaluation:
@@ -2346,15 +3355,15 @@ void icluster_0_kernel_0(icluster_0_t *s)
 > ok, c is now off
 ok, flatten (simplified) is now off
 > > - C evaluation:
-[homer, NaN]
+[homer, tombstone]
 
 - Core evaluation:
-[homer, NaN]
+[homer, tombstone]
 
 > > - C evaluation:
-[homer, Infinity]
+[homer, tombstone]
 
 - Core evaluation:
-[homer, Infinity]
+[homer, tombstone]
 
 > 

--- a/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
+++ b/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
@@ -26,9 +26,9 @@ ok, loaded test/cli/repl/data.psv, 13 rows
 typedef struct {
     itime_t          convzs3;
     iint_t           new_count;
-    ierror_t         *new_convzs0zssimpflatzs19;
-    iint_t           *new_convzs0zssimpflatzs20;
-    itime_t          *new_convzs0zssimpflatzs21;
+    ierror_t         *new_convzs0zssimpflatzs45;
+    iint_t           *new_convzs0zssimpflatzs46;
+    itime_t          *new_convzs0zssimpflatzs47;
 } input_replZCinput_t;
 
 typedef struct {
@@ -41,20 +41,23 @@ typedef struct {
 
   /* kernel 0/0 */
     /* outputs */
-    ibool_t          replZCoutputzsixzs0;
-    iint_t           replZCoutputzsixzs1;
-    idouble_t        replZCoutputzsixzs2;
+    ierror_t         replZCoutputzsixzs0;
+    ibool_t          replZCoutputzsixzs1;
+    iint_t           replZCoutputzsixzs2;
+    idouble_t        replZCoutputzsixzs3;
 
     /* resumables: values */
-    idouble_t        res_0_0_acczsperhapszsconvzs5zssimpflatzs6;
-    iint_t           res_0_0_acczsperhapszsconvzs5zssimpflatzs5;
-    ibool_t          res_0_0_acczsperhapszsconvzs5zssimpflatzs4;
+    iint_t           res_0_0_acczsperhapszsconvzs5zssimpflatzs7;
+    ibool_t          res_0_0_acczsperhapszsconvzs5zssimpflatzs6;
+    ierror_t         res_0_0_acczsperhapszsconvzs5zssimpflatzs5;
+    idouble_t        res_0_0_acczsperhapszsconvzs5zssimpflatzs8;
 
     /* resumables: has flags */
     ibool_t          has_flags_start_0_0;
+    ibool_t          has_0_0_acczsperhapszsconvzs5zssimpflatzs7;
     ibool_t          has_0_0_acczsperhapszsconvzs5zssimpflatzs6;
     ibool_t          has_0_0_acczsperhapszsconvzs5zssimpflatzs5;
-    ibool_t          has_0_0_acczsperhapszsconvzs5zssimpflatzs4;
+    ibool_t          has_0_0_acczsperhapszsconvzs5zssimpflatzs8;
     ibool_t          has_flags_end_0_0;
 
 
@@ -68,33 +71,55 @@ iint_t size_of_icluster_0 ()
 #line 1 "kernel function #0 - repl:input icluster_0_kernel_0"
 void icluster_0_kernel_0(icluster_0_t *s)
 {
-    idouble_t        perhapszsconvzs5zsavalzs0zssimpflatzs9;
-    iint_t           perhapszsconvzs5zsavalzs0zssimpflatzs8;
-    ibool_t          perhapszsconvzs5zsavalzs0zssimpflatzs7;
-    iint_t           perhapszsconvzs5zssimpflatzs17;
-    idouble_t        perhapszsconvzs5zssimpflatzs18;
-    ibool_t          perhapszsconvzs5zssimpflatzs16;
-    idouble_t        acczsperhapszsconvzs5zssimpflatzs6;
-    iint_t           acczsperhapszsconvzs5zssimpflatzs5;
-    ibool_t          acczsperhapszsconvzs5zssimpflatzs4;
-    idouble_t        flatzs0zssimpflatzs15;
-    idouble_t        flatzs0zssimpflatzs12;
-    iint_t           flatzs0zssimpflatzs14;
-    iint_t           flatzs0zssimpflatzs11;
-    ibool_t          flatzs0zssimpflatzs13;
-    ibool_t          flatzs0zssimpflatzs10;
+    ierror_t         perhapszsconvzs5zsavalzs0zssimpflatzs9;
+    ibool_t          perhapszsconvzs5zssimpflatzs42;
+    iint_t           perhapszsconvzs5zssimpflatzs43;
+    idouble_t        perhapszsconvzs5zssimpflatzs44;
+    ierror_t         perhapszsconvzs5zssimpflatzs41;
+    ibool_t          perhapszsconvzs5zsavalzs0zssimpflatzs10;
+    iint_t           perhapszsconvzs5zsavalzs0zssimpflatzs11;
+    idouble_t        perhapszsconvzs5zsavalzs0zssimpflatzs12;
+    idouble_t        flatzs0zssimpflatzs40;
+    ibool_t          flatzs0zssimpflatzs38;
+    iint_t           flatzs0zssimpflatzs39;
+    ierror_t         flatzs0zssimpflatzs37;
+    ibool_t          flatzs7zssimpflatzs30;
+    iint_t           flatzs7zssimpflatzs31;
+    idouble_t        flatzs7zssimpflatzs32;
+    ierror_t         flatzs3zssimpflatzs33;
+    ibool_t          flatzs3zssimpflatzs34;
+    iint_t           flatzs3zssimpflatzs35;
+    idouble_t        flatzs3zssimpflatzs36;
+    iint_t           acczsperhapszsconvzs5zssimpflatzs7;
+    ibool_t          acczsperhapszsconvzs5zssimpflatzs6;
+    ierror_t         acczsperhapszsconvzs5zssimpflatzs5;
+    idouble_t        acczsperhapszsconvzs5zssimpflatzs8;
+    iint_t           flatzs0zssimpflatzs15;
+    ibool_t          flatzs0zssimpflatzs14;
+    ierror_t         flatzs0zssimpflatzs13;
+    idouble_t        flatzs0zssimpflatzs16;
+    ibool_t          flatzs3zssimpflatzs18;
+    iint_t           flatzs3zssimpflatzs19;
+    ierror_t         flatzs3zssimpflatzs17;
+    idouble_t        flatzs3zssimpflatzs20;
+    idouble_t        flatzs6zssimpflatzs22;
+    ierror_t         flatzs6zssimpflatzs23;
+    ierror_t         flatzs6zssimpflatzs21;
+    idouble_t        flatzs6zssimpflatzs24;
+    ierror_t         flatzs7zssimpflatzs29;
+    idouble_t        flatzs7zssimpflatzs28;
+    ierror_t         flatzs7zssimpflatzs25;
+    iint_t           flatzs7zssimpflatzs27;
+    ibool_t          flatzs7zssimpflatzs26;
 
     anemone_mempool_t *mempool                = s->mempool;
     itime_t          convzs3                  = s->input.convzs3;
     iint_t           convzs4                  = s->max_map_size;
 
-    acczsperhapszsconvzs5zssimpflatzs4        = ifalse;                               /* init */
-    acczsperhapszsconvzs5zssimpflatzs5        = 0;                                    /* init */
-    acczsperhapszsconvzs5zssimpflatzs6        = 0.0;                                  /* init */
-    
-    if (s->has_0_0_acczsperhapszsconvzs5zssimpflatzs4) {
-        acczsperhapszsconvzs5zssimpflatzs4    = s->res_0_0_acczsperhapszsconvzs5zssimpflatzs4; /* load */
-    }
+    acczsperhapszsconvzs5zssimpflatzs5        = ierror_not_an_error;                  /* init */
+    acczsperhapszsconvzs5zssimpflatzs6        = ifalse;                               /* init */
+    acczsperhapszsconvzs5zssimpflatzs7        = 0;                                    /* init */
+    acczsperhapszsconvzs5zssimpflatzs8        = 0.0;                                  /* init */
     
     if (s->has_0_0_acczsperhapszsconvzs5zssimpflatzs5) {
         acczsperhapszsconvzs5zssimpflatzs5    = s->res_0_0_acczsperhapszsconvzs5zssimpflatzs5; /* load */
@@ -104,46 +129,113 @@ void icluster_0_kernel_0(icluster_0_t *s)
         acczsperhapszsconvzs5zssimpflatzs6    = s->res_0_0_acczsperhapszsconvzs5zssimpflatzs6; /* load */
     }
     
+    if (s->has_0_0_acczsperhapszsconvzs5zssimpflatzs7) {
+        acczsperhapszsconvzs5zssimpflatzs7    = s->res_0_0_acczsperhapszsconvzs5zssimpflatzs7; /* load */
+    }
+    
+    if (s->has_0_0_acczsperhapszsconvzs5zssimpflatzs8) {
+        acczsperhapszsconvzs5zssimpflatzs8    = s->res_0_0_acczsperhapszsconvzs5zssimpflatzs8; /* load */
+    }
+    
     const iint_t     new_count                = s->input.new_count;
-    const ierror_t  *const new_convzs0zssimpflatzs19 = s->input.new_convzs0zssimpflatzs19;
-    const iint_t    *const new_convzs0zssimpflatzs20 = s->input.new_convzs0zssimpflatzs20;
-    const itime_t   *const new_convzs0zssimpflatzs21 = s->input.new_convzs0zssimpflatzs21;
+    const ierror_t  *const new_convzs0zssimpflatzs45 = s->input.new_convzs0zssimpflatzs45;
+    const iint_t    *const new_convzs0zssimpflatzs46 = s->input.new_convzs0zssimpflatzs46;
+    const itime_t   *const new_convzs0zssimpflatzs47 = s->input.new_convzs0zssimpflatzs47;
     
     for (iint_t i = 0; i < new_count; i++) {
         ifactid_t        convzs1              = i;
-        itime_t          convzs2              = new_convzs0zssimpflatzs21[i];
-        ierror_t         convzs0zssimpflatzs19 = new_convzs0zssimpflatzs19[i];
-        iint_t           convzs0zssimpflatzs20 = new_convzs0zssimpflatzs20[i];
-        itime_t          convzs0zssimpflatzs21 = new_convzs0zssimpflatzs21[i];
-        perhapszsconvzs5zsavalzs0zssimpflatzs7 = acczsperhapszsconvzs5zssimpflatzs4;  /* read */
-        perhapszsconvzs5zsavalzs0zssimpflatzs8 = acczsperhapszsconvzs5zssimpflatzs5;  /* read */
-        perhapszsconvzs5zsavalzs0zssimpflatzs9 = acczsperhapszsconvzs5zssimpflatzs6;  /* read */
-        flatzs0zssimpflatzs10                 = ifalse;                               /* init */
-        flatzs0zssimpflatzs11                 = 0;                                    /* init */
-        flatzs0zssimpflatzs12                 = 0.0;                                  /* init */
+        itime_t          convzs2              = new_convzs0zssimpflatzs47[i];
+        ierror_t         convzs0zssimpflatzs45 = new_convzs0zssimpflatzs45[i];
+        iint_t           convzs0zssimpflatzs46 = new_convzs0zssimpflatzs46[i];
+        itime_t          convzs0zssimpflatzs47 = new_convzs0zssimpflatzs47[i];
+        perhapszsconvzs5zsavalzs0zssimpflatzs9 = acczsperhapszsconvzs5zssimpflatzs5;  /* read */
+        perhapszsconvzs5zsavalzs0zssimpflatzs10 = acczsperhapszsconvzs5zssimpflatzs6; /* read */
+        perhapszsconvzs5zsavalzs0zssimpflatzs11 = acczsperhapszsconvzs5zssimpflatzs7; /* read */
+        perhapszsconvzs5zsavalzs0zssimpflatzs12 = acczsperhapszsconvzs5zssimpflatzs8; /* read */
+        flatzs0zssimpflatzs13                 = ierror_not_an_error;                  /* init */
+        flatzs0zssimpflatzs14                 = ifalse;                               /* init */
+        flatzs0zssimpflatzs15                 = 0;                                    /* init */
+        flatzs0zssimpflatzs16                 = 0.0;                                  /* init */
         
-        if (perhapszsconvzs5zsavalzs0zssimpflatzs7) {
-            flatzs0zssimpflatzs10             = ifalse;                               /* write */
-            iint_t           simpflatzs28     = idouble_trunc (perhapszsconvzs5zsavalzs0zssimpflatzs9); /* let */
-            flatzs0zssimpflatzs11             = iint_add (simpflatzs28, 1);           /* write */
-            flatzs0zssimpflatzs12             = 0.0;                                  /* write */
+        if (ierror_eq (perhapszsconvzs5zsavalzs0zssimpflatzs9, ierror_not_an_error)) {
+            flatzs3zssimpflatzs17             = ierror_not_an_error;                  /* init */
+            flatzs3zssimpflatzs18             = ifalse;                               /* init */
+            flatzs3zssimpflatzs19             = 0;                                    /* init */
+            flatzs3zssimpflatzs20             = 0.0;                                  /* init */
+            
+            if (perhapszsconvzs5zsavalzs0zssimpflatzs10) {
+                flatzs3zssimpflatzs17         = ierror_not_an_error;                  /* write */
+                flatzs3zssimpflatzs18         = ifalse;                               /* write */
+                iint_t           simpflatzs59 = idouble_trunc (perhapszsconvzs5zsavalzs0zssimpflatzs12); /* let */
+                flatzs3zssimpflatzs19         = iint_add (simpflatzs59, 1);           /* write */
+                flatzs3zssimpflatzs20         = 0.0;                                  /* write */
+            } else {
+                idouble_t        simpflatzs66 = iint_extend (perhapszsconvzs5zsavalzs0zssimpflatzs11); /* let */
+                idouble_t        convzs9      = idouble_add (simpflatzs66, 1.0);      /* let */
+                flatzs6zssimpflatzs21         = ierror_not_an_error;                  /* init */
+                flatzs6zssimpflatzs22         = 0.0;                                  /* init */
+                
+                if (idouble_is_valid (convzs9)) {
+                    flatzs6zssimpflatzs21     = ierror_not_an_error;                  /* write */
+                    flatzs6zssimpflatzs22     = idouble_add (simpflatzs66, 1.0);      /* write */
+                } else {
+                    flatzs6zssimpflatzs21     = ierror_cannot_compute;                /* write */
+                    flatzs6zssimpflatzs22     = 0.0;                                  /* write */
+                }
+                
+                flatzs6zssimpflatzs23         = flatzs6zssimpflatzs21;                /* read */
+                flatzs6zssimpflatzs24         = flatzs6zssimpflatzs22;                /* read */
+                flatzs7zssimpflatzs25         = ierror_not_an_error;                  /* init */
+                flatzs7zssimpflatzs26         = ifalse;                               /* init */
+                flatzs7zssimpflatzs27         = 0;                                    /* init */
+                flatzs7zssimpflatzs28         = 0.0;                                  /* init */
+                
+                if (ierror_eq (flatzs6zssimpflatzs23, ierror_not_an_error)) {
+                    flatzs7zssimpflatzs25     = ierror_not_an_error;                  /* write */
+                    flatzs7zssimpflatzs26     = itrue;                                /* write */
+                    flatzs7zssimpflatzs27     = 0;                                    /* write */
+                    flatzs7zssimpflatzs28     = flatzs6zssimpflatzs24;                /* write */
+                } else {
+                    flatzs7zssimpflatzs25     = flatzs6zssimpflatzs23;                /* write */
+                    flatzs7zssimpflatzs26     = ifalse;                               /* write */
+                    flatzs7zssimpflatzs27     = 0;                                    /* write */
+                    flatzs7zssimpflatzs28     = 0.0;                                  /* write */
+                }
+                
+                flatzs7zssimpflatzs29         = flatzs7zssimpflatzs25;                /* read */
+                flatzs7zssimpflatzs30         = flatzs7zssimpflatzs26;                /* read */
+                flatzs7zssimpflatzs31         = flatzs7zssimpflatzs27;                /* read */
+                flatzs7zssimpflatzs32         = flatzs7zssimpflatzs28;                /* read */
+                flatzs3zssimpflatzs17         = flatzs7zssimpflatzs29;                /* write */
+                flatzs3zssimpflatzs18         = flatzs7zssimpflatzs30;                /* write */
+                flatzs3zssimpflatzs19         = flatzs7zssimpflatzs31;                /* write */
+                flatzs3zssimpflatzs20         = flatzs7zssimpflatzs32;                /* write */
+            }
+            
+            flatzs3zssimpflatzs33             = flatzs3zssimpflatzs17;                /* read */
+            flatzs3zssimpflatzs34             = flatzs3zssimpflatzs18;                /* read */
+            flatzs3zssimpflatzs35             = flatzs3zssimpflatzs19;                /* read */
+            flatzs3zssimpflatzs36             = flatzs3zssimpflatzs20;                /* read */
+            flatzs0zssimpflatzs13             = flatzs3zssimpflatzs33;                /* write */
+            flatzs0zssimpflatzs14             = flatzs3zssimpflatzs34;                /* write */
+            flatzs0zssimpflatzs15             = flatzs3zssimpflatzs35;                /* write */
+            flatzs0zssimpflatzs16             = flatzs3zssimpflatzs36;                /* write */
         } else {
-            flatzs0zssimpflatzs10             = itrue;                                /* write */
-            flatzs0zssimpflatzs11             = 0;                                    /* write */
-            idouble_t        simpflatzs41     = iint_extend (perhapszsconvzs5zsavalzs0zssimpflatzs8); /* let */
-            flatzs0zssimpflatzs12             = idouble_add (simpflatzs41, 1.0);      /* write */
+            flatzs0zssimpflatzs13             = perhapszsconvzs5zsavalzs0zssimpflatzs9; /* write */
+            flatzs0zssimpflatzs14             = ifalse;                               /* write */
+            flatzs0zssimpflatzs15             = 0;                                    /* write */
+            flatzs0zssimpflatzs16             = 0.0;                                  /* write */
         }
         
-        flatzs0zssimpflatzs13                 = flatzs0zssimpflatzs10;                /* read */
-        flatzs0zssimpflatzs14                 = flatzs0zssimpflatzs11;                /* read */
-        flatzs0zssimpflatzs15                 = flatzs0zssimpflatzs12;                /* read */
-        acczsperhapszsconvzs5zssimpflatzs4    = flatzs0zssimpflatzs13;                /* write */
-        acczsperhapszsconvzs5zssimpflatzs5    = flatzs0zssimpflatzs14;                /* write */
-        acczsperhapszsconvzs5zssimpflatzs6    = flatzs0zssimpflatzs15;                /* write */
+        flatzs0zssimpflatzs37                 = flatzs0zssimpflatzs13;                /* read */
+        flatzs0zssimpflatzs38                 = flatzs0zssimpflatzs14;                /* read */
+        flatzs0zssimpflatzs39                 = flatzs0zssimpflatzs15;                /* read */
+        flatzs0zssimpflatzs40                 = flatzs0zssimpflatzs16;                /* read */
+        acczsperhapszsconvzs5zssimpflatzs5    = flatzs0zssimpflatzs37;                /* write */
+        acczsperhapszsconvzs5zssimpflatzs6    = flatzs0zssimpflatzs38;                /* write */
+        acczsperhapszsconvzs5zssimpflatzs7    = flatzs0zssimpflatzs39;                /* write */
+        acczsperhapszsconvzs5zssimpflatzs8    = flatzs0zssimpflatzs40;                /* write */
     }
-    
-    s->has_0_0_acczsperhapszsconvzs5zssimpflatzs4 = itrue;                            /* save */
-    s->res_0_0_acczsperhapszsconvzs5zssimpflatzs4 = acczsperhapszsconvzs5zssimpflatzs4; /* save */
     
     s->has_0_0_acczsperhapszsconvzs5zssimpflatzs5 = itrue;                            /* save */
     s->res_0_0_acczsperhapszsconvzs5zssimpflatzs5 = acczsperhapszsconvzs5zssimpflatzs5; /* save */
@@ -151,12 +243,20 @@ void icluster_0_kernel_0(icluster_0_t *s)
     s->has_0_0_acczsperhapszsconvzs5zssimpflatzs6 = itrue;                            /* save */
     s->res_0_0_acczsperhapszsconvzs5zssimpflatzs6 = acczsperhapszsconvzs5zssimpflatzs6; /* save */
     
-    perhapszsconvzs5zssimpflatzs16            = acczsperhapszsconvzs5zssimpflatzs4;   /* read */
-    perhapszsconvzs5zssimpflatzs17            = acczsperhapszsconvzs5zssimpflatzs5;   /* read */
-    perhapszsconvzs5zssimpflatzs18            = acczsperhapszsconvzs5zssimpflatzs6;   /* read */
-    s->replZCoutputzsixzs0                    = perhapszsconvzs5zssimpflatzs16;       /* output */
-    s->replZCoutputzsixzs1                    = perhapszsconvzs5zssimpflatzs17;       /* output */
-    s->replZCoutputzsixzs2                    = perhapszsconvzs5zssimpflatzs18;       /* output */
+    s->has_0_0_acczsperhapszsconvzs5zssimpflatzs7 = itrue;                            /* save */
+    s->res_0_0_acczsperhapszsconvzs5zssimpflatzs7 = acczsperhapszsconvzs5zssimpflatzs7; /* save */
+    
+    s->has_0_0_acczsperhapszsconvzs5zssimpflatzs8 = itrue;                            /* save */
+    s->res_0_0_acczsperhapszsconvzs5zssimpflatzs8 = acczsperhapszsconvzs5zssimpflatzs8; /* save */
+    
+    perhapszsconvzs5zssimpflatzs41            = acczsperhapszsconvzs5zssimpflatzs5;   /* read */
+    perhapszsconvzs5zssimpflatzs42            = acczsperhapszsconvzs5zssimpflatzs6;   /* read */
+    perhapszsconvzs5zssimpflatzs43            = acczsperhapszsconvzs5zssimpflatzs7;   /* read */
+    perhapszsconvzs5zssimpflatzs44            = acczsperhapszsconvzs5zssimpflatzs8;   /* read */
+    s->replZCoutputzsixzs0                    = perhapszsconvzs5zssimpflatzs41;       /* output */
+    s->replZCoutputzsixzs1                    = perhapszsconvzs5zssimpflatzs42;       /* output */
+    s->replZCoutputzsixzs2                    = perhapszsconvzs5zssimpflatzs43;       /* output */
+    s->replZCoutputzsixzs3                    = perhapszsconvzs5zssimpflatzs44;       /* output */
 }
 
 - C evaluation:

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Builtin.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Builtin.hs
@@ -27,6 +27,7 @@ data PrimBuiltinMath
  | PrimBuiltinLog
  | PrimBuiltinExp
  | PrimBuiltinSqrt
+ | PrimBuiltinDoubleIsValid
  deriving (Eq, Ord, Show, Enum, Bounded)
 
 -- | Built-in map functions
@@ -64,6 +65,7 @@ instance Pretty PrimBuiltinMath where
    PrimBuiltinRound           -> "round#"
    PrimBuiltinTruncate        -> "trunc#"
    PrimBuiltinToDoubleFromInt -> "doubleOfInt#"
+   PrimBuiltinDoubleIsValid   -> "doubleIsValid#"
 
 instance Pretty PrimBuiltinMap where
  pretty p = case p of

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
@@ -139,6 +139,12 @@ evalPrim p originalP vs
       | otherwise
       -> primError
 
+     PrimBuiltinFun (PrimBuiltinMath  PrimBuiltinDoubleIsValid)
+      | [VBase (VDouble i)] <- vs
+      -> return $ VBase $ VBool $ not (isNaN i || isInfinite i)
+      | otherwise
+      -> primError
+
      PrimBuiltinFun (PrimBuiltinMap (PrimBuiltinKeys _ _))
       | [VBase (VMap m)] <- vs
       -> return $ VBase $ VArray $ Map.keys m

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
@@ -143,6 +143,8 @@ typeOfPrim p
      -> FunT [funOfVal DoubleT] IntT
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinTruncate)
      -> FunT [funOfVal DoubleT] IntT
+    PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinDoubleIsValid)
+     -> FunT [funOfVal DoubleT] BoolT
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinRound)
      -> FunT [funOfVal DoubleT] IntT
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinDiv)

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -612,7 +612,7 @@ generateX x env
            returnPoss' <- TypeVar <$> fresh
            let consPs  =  require a (CPossibilityJoin returnPoss' scrutPs returnPoss)
 
-           (pats', subs, consA) <- generateP a scrutT returnType returnTemp returnPoss pats (substE sub env)
+           (pats', subs, consA) <- generateP a scrutT returnType returnTemp' returnTemp returnPoss pats (substE sub env)
 
            let t'    = canonT
                      $ Temporality returnTemp'
@@ -634,18 +634,19 @@ generateP
   => a
   -> Type n                 -- ^ scrutinee type
   -> Type n                 -- ^ result base type
-  -> Type n                 -- ^ result temporality
+  -> Type n                 -- ^ top-level result temporality
+  -> Type n                 -- ^ chained result temporality of previous alternative
   -> Type n                 -- ^ result possibility
   -> [(Pattern n, Exp a n)] -- ^ pattern and alternative
   -> GenEnv n
   -> Gen a n ([(Pattern n, Exp'C a n)], SubstT n, GenConstraintSet a n)
 
-generateP ann _ _ resTm resPs [] _
+generateP ann _ _ _ resTm resPs [] _
  = do   let consT = require ann (CEquals resTm TemporalityPure)
         let consP = require ann (CEquals resPs PossibilityDefinitely)
         return ([], Map.empty, concat [consT, consP])
 
-generateP ann scrutTy resTy resTm resPs ((pat, alt):rest) env
+generateP ann scrutTy resTy resTmTop resTm resPs ((pat, alt):rest) env
  = do   (t, envp) <- goPat pat env
 
         let (_,_,datS) = decomposeT $ canonT scrutTy
@@ -669,7 +670,7 @@ generateP ann scrutTy resTy resTm resPs ((pat, alt):rest) env
                   , require (annotOfExp alt) (CPossibilityJoin resPs resPs' altPs)
                   ]
 
-        (rest', subs, consr) <- generateP ann scrutTy resTy resTp' resPs' rest (substE sub env)
+        (rest', subs, consr) <- generateP ann scrutTy resTy resTmTop resTp' resPs' rest (substE sub env)
         let cons'       = concat [conss, consa, consT, consr]
         let alt''       = substTX subs alt'
         let subs'       = compose sub subs
@@ -686,11 +687,23 @@ generateP ann scrutTy resTy resTm resPs ((pat, alt):rest) env
    = (,e) . TypeVar <$> fresh
 
   goPat (PatVariable n) e
-   = do let (tmpS,_,_)  = decomposeT $ canonT scrutTy
-        datV              <- TypeVar <$> fresh
+   = do datV              <- TypeVar <$> fresh
         -- The bound variable is actually Definite, because the case will only succeed
         -- if the scrutinee is an actual value.
-        let env'           = bindT n (recomposeT (tmpS, Nothing, datV)) e
+        --
+        -- CASEHACK: pattern bindings have the temporality of the whole case.
+        -- This is to work around a flaw in the conversion to Core.
+        -- We cannot convert this:
+        -- > case (Left 0)
+        -- >  | Left l  -> fold a = l : l * 2 ~> a
+        -- >  | Right r -> fold b = r : r / 2 ~> b
+        -- > end
+        -- Because conversion would require a case at each step: in the zero of the fold,
+        -- and in the kons of the fold, as well as in pre and eject.
+        -- So we outlaw this, by making sure the pattern binding has temporality of the
+        -- return: which means this example is ill-typed, as the binding (l :: Aggregate _)
+        -- could only be used at the end of the fold.
+        let env'           = bindT n (recomposeT (Just resTmTop, Nothing, datV)) e
         return (datV, env')
 
   goPat (PatCon ConSome  [p]) e

--- a/icicle-source/src/Icicle/Source/Query/Constructor.hs
+++ b/icicle-source/src/Icicle/Source/Query/Constructor.hs
@@ -6,6 +6,7 @@ module Icicle.Source.Query.Constructor (
     Constructor (..)
   , Pattern (..)
   , substOfPattern
+  , boundOfPattern
   , arityOfConstructor
   ) where
 
@@ -15,6 +16,7 @@ import                  Icicle.Internal.Pretty
 import                  P
 
 import qualified        Data.Map as Map
+import qualified        Data.Set as Set
 
 data Constructor
  -- Option
@@ -42,6 +44,11 @@ data Pattern n
  | PatVariable (Name n)
  deriving (Show, Eq, Ord)
 
+boundOfPattern :: Eq n => Pattern n -> Set.Set (Name n)
+boundOfPattern p = case p of
+ PatCon c ps   -> Set.unions $ fmap boundOfPattern ps
+ PatDefault    -> Set.empty
+ PatVariable n -> Set.singleton n
 
 -- | Given a pattern and a value,
 -- check if the value matches the pattern, and if so,

--- a/icicle-source/src/Icicle/Source/Query/Constructor.hs
+++ b/icicle-source/src/Icicle/Source/Query/Constructor.hs
@@ -46,7 +46,7 @@ data Pattern n
 
 boundOfPattern :: Eq n => Pattern n -> Set.Set (Name n)
 boundOfPattern p = case p of
- PatCon c ps   -> Set.unions $ fmap boundOfPattern ps
+ PatCon _ ps   -> Set.unions $ fmap boundOfPattern ps
  PatDefault    -> Set.empty
  PatVariable n -> Set.singleton n
 

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -4,6 +4,7 @@
 -- So we must generate a fresh name for any forall binders.
 {-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE PatternGuards #-}
 module Icicle.Source.Query.Prim (
     primLookup'
   , primReturnsPossibly
@@ -24,12 +25,17 @@ import                  Data.Hashable (Hashable)
 primLookup' :: Hashable n => Prim -> Fresh.Fresh n (FunctionType n)
 primLookup' p
  = case p of
-    Op (ArithUnary _)
-     -> fNum $ \at -> ([at], at)
+    -- Negate on Doubles will not introduce NaN or Inf
+    Op (ArithUnary Negate)
+     -> fNumDefinitely $ \at -> ([at], at)
+
+    -- Pretty much any binary operation on Doubles might return NaN or Inf. This includes addition when the numbers are very large.
     Op (ArithBinary _)
-     -> fNum $ \at -> ([at, at], at)
+     -> fNumPossibly $ \at -> ([at, at], at)
+
+    -- Division will almost certainly return NaN or Inf
     Op (ArithDouble Div)
-     -> f0 [DoubleT, DoubleT] DoubleT
+     -> f0 [DoubleT, DoubleT] possiblyDouble
 
     Op (Relation _)
      -> f1 $ \a at -> FunctionType [a] [] [at, at] BoolT
@@ -48,8 +54,9 @@ primLookup' p
            let bt = TypeVar b
            return $ FunctionType [a,b] [] [at, bt] (PairT at bt)
 
+    -- Literals will not be NaN or Inf
     Lit (LitInt _)
-     -> fNum $ \at -> ([], at)
+     -> fNumDefinitely $ \at -> ([], at)
     Lit (LitDouble _)
      -> f0 [] DoubleT
     Lit (LitString _)
@@ -57,24 +64,26 @@ primLookup' p
     Lit (LitTime _)
      -> f0 [] TimeT
 
+    -- Most Double operations can introduce NaN or Inf
     Fun (BuiltinMath Log)
-     -> f0 [DoubleT] DoubleT
+     -> f0 [DoubleT] possiblyDouble
     Fun (BuiltinMath Exp)
-     -> f0 [DoubleT] DoubleT
+     -> f0 [DoubleT] possiblyDouble
     Fun (BuiltinMath Sqrt)
-     -> f0 [DoubleT] DoubleT
+     -> f0 [DoubleT] possiblyDouble
+    -- But conversions are OK
     Fun (BuiltinMath ToDouble)
-     -> fNum $ \at -> ([at], DoubleT)
+     -> fNumDefinitely $ \at -> ([at], DoubleT)
     Fun (BuiltinMath Abs)
-     -> fNum $ \at -> ([at], at)
+     -> fNumDefinitely $ \at -> ([at], at)
     Fun (BuiltinMath Floor)
-     -> fNum $ \at -> ([at], IntT)
+     -> fNumDefinitely $ \at -> ([at], IntT)
     Fun (BuiltinMath Ceiling)
-     -> fNum $ \at -> ([at], IntT)
+     -> fNumDefinitely $ \at -> ([at], IntT)
     Fun (BuiltinMath Round)
-     -> fNum $ \at -> ([at], IntT)
+     -> fNumDefinitely $ \at -> ([at], IntT)
     Fun (BuiltinMath Truncate)
-     -> fNum $ \at -> ([at], IntT)
+     -> fNumDefinitely $ \at -> ([at], IntT)
 
     Fun (BuiltinTime DaysBetween)
      -> f0 [TimeT, TimeT] IntT
@@ -143,8 +152,22 @@ primLookup' p
   f0 argsT resT
    = return $ FunctionType [] [] argsT resT
 
+  -- A num operation that can introduce NaN or Inf and must be checked
+  fNumPossibly f
+   = fNum $ \pt at ->
+     let (args,ret) = f at
+     in  (args, Possibility pt ret)
+
+  -- Safe number operations
+  fNumDefinitely f
+   = f1 $ \a at ->
+     let (args,ret) = f at
+     in  FunctionType [a] [CIsNum at] args ret
+
   fNum f
-   = f1 (\a at -> uncurry (FunctionType [a] [CIsNum at]) (f at))
+   = f2 (\a at p pt -> uncurry (FunctionType [a,p] [CPossibilityOfNum pt at]) (f pt at))
+
+  possiblyDouble = Possibility PossibilityPossibly DoubleT
 
   f1 f
    = do n <- Fresh.fresh
@@ -156,8 +179,25 @@ primLookup' p
         return $ f n1 (TypeVar n1) n2 (TypeVar n2)
 
 
-primReturnsPossibly :: Prim -> Bool
-primReturnsPossibly (Fun (BuiltinData Box))      = True
-primReturnsPossibly (Fun (BuiltinMap MapInsert)) = True
-primReturnsPossibly _                            = False
+-- There must be a better way.
+-- When an expression returns Possibly, it is hard to know whether that's because the function returns Possibly,
+-- or if it's a pure function applied to a Possibly argument which needs to be reboxed.
+-- This should probably be figured out and inserted during type inference.
+-- As it is, we're looking at the expression and the result of type inference to decide - trying to work backwards to
+-- figure out what inference did.
+primReturnsPossibly :: Prim -> Type n -> Bool
+primReturnsPossibly (Fun (BuiltinData Box))      _ = True
+primReturnsPossibly (Fun (BuiltinMap MapInsert)) _ = True
+primReturnsPossibly p ty
+ | (_, pos, dat)       <- decomposeT ty
+ , DoubleT             <- dat
+ , Just PossibilityPossibly <- pos
+ = case p of
+    Op (ArithBinary _)     -> True
+    Op (ArithDouble Div)   -> True
+    Fun (BuiltinMath Log)  -> True
+    Fun (BuiltinMath Exp)  -> True
+    Fun (BuiltinMath Sqrt) -> True
+    _                      -> False
+primReturnsPossibly _ _                          = False
 

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -23,8 +23,8 @@ import                  Data.Hashable (Hashable)
 
 
 primLookup' :: Hashable n => Prim -> Fresh.Fresh n (FunctionType n)
-primLookup' p
- = case p of
+primLookup' prim
+ = case prim of
     -- Negate on Doubles will not introduce NaN or Inf
     Op (ArithUnary Negate)
      -> fNumDefinitely $ \at -> ([at], at)

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -429,6 +429,7 @@ primInsertOrUpdate tk tv xm xk xvz xvu = do
 primCheckDouble :: Hashable n => C.Exp () n -> ConvertM a n (C.Exp () n)
 primCheckDouble fx = do
   n'x <- lift F.fresh
+  n'unit <- lift F.fresh
   let v'x    = CE.XVar () n'x
   let tsum   = T.SumT T.ErrorT T.DoubleT
 
@@ -442,7 +443,7 @@ primCheckDouble fx = do
 
   return $ CE.makeLets () [(n'x, fx)]
          $ apps (C.PrimFold C.PrimFoldBool tsum)
-         [ vright, verr, xvalid ]
+         [ CE.xLam n'unit T.UnitT vright, CE.xLam n'unit T.UnitT verr, xvalid ]
 
  where
   apps f xs = CE.makeApps () (CE.XPrim () f) xs

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -64,7 +64,6 @@ convertPrim p ann resT xts = go p
          Nothing -> convertError $ ConvertErrorPrimNoArguments ann num_args p
          Just a' -> return a'
 
-
   -- Literals
   go (Lit (LitInt i))
    | (_, _, DoubleT) <- decomposeT resT
@@ -126,16 +125,23 @@ convertPrim p ann resT xts = go p
   -- Arithmetic
   goop (ArithUnary Negate)
    = primmin <$> (Min.PrimArithUnary Min.PrimArithNegate <$> tArithArg 1)
-  goop (ArithBinary Add)
-   = primmin <$> (Min.PrimArithBinary Min.PrimArithPlus <$> tArithArg 2)
-  goop (ArithBinary Sub)
-   = primmin <$> (Min.PrimArithBinary Min.PrimArithMinus <$> tArithArg 2)
-  goop (ArithBinary Mul)
-   = primmin <$> (Min.PrimArithBinary Min.PrimArithMul <$> tArithArg 2)
-  goop (ArithBinary Pow)
-   = primmin <$> (Min.PrimArithBinary Min.PrimArithPow <$> tArithArg 2)
+
+  goop (ArithBinary f) = do
+   tt <- tArithArg 2
+   let p' = case f of
+             Add -> Min.PrimArithPlus
+             Sub -> Min.PrimArithMinus
+             Mul -> Min.PrimArithMul
+             Pow -> Min.PrimArithPow
+   let fx = primmin (Min.PrimArithBinary p' tt)
+   case tt of
+    T.ArithDoubleT ->
+      primCheckDouble fx
+    T.ArithIntT ->
+      return fx
+
   goop (ArithDouble Div)
-   = return $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinDiv
+   = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinDiv
 
   -- Logic
   goop (LogicalUnary Not)
@@ -243,11 +249,11 @@ convertPrim p ann resT xts = go p
 
   -- Source built-in primitives that map to common built-ins.
   gomath Log
-   = return $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinLog
+   = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinLog
   gomath Exp
-   = return $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinExp
+   = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinExp
   gomath Sqrt
-   = return $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinSqrt
+   = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinSqrt
 
   gomath Abs
    = case xts of
@@ -420,3 +426,24 @@ primInsertOrUpdate tk tv xm xk xvz xvu = do
   apps f xs = CE.makeApps () (CE.XPrim () f) xs
   bf = C.PrimMinimal . Min.PrimBuiltinFun
 
+primCheckDouble :: Hashable n => C.Exp () n -> ConvertM a n (C.Exp () n)
+primCheckDouble fx = do
+  n'x <- lift F.fresh
+  let v'x    = CE.XVar () n'x
+  let tsum   = T.SumT T.ErrorT T.DoubleT
+
+  let xvalid = apps (bf $ Min.PrimBuiltinMath $ Min.PrimBuiltinDoubleIsValid) [ v'x ]
+
+  -- TODO: add ExceptNotANumber
+  let verr   = CE.XValue () (T.SumT T.ErrorT T.DoubleT)
+             $ V.VLeft $ V.VError V.ExceptCannotCompute
+  let vright = apps (C.PrimMinimal $ Min.PrimConst $ Min.PrimConstRight T.ErrorT T.DoubleT)
+             [ v'x ]
+
+  return $ CE.makeLets () [(n'x, fx)]
+         $ apps (C.PrimFold C.PrimFoldBool tsum)
+         [ vright, verr, xvalid ]
+
+ where
+  apps f xs = CE.makeApps () (CE.XPrim () f) xs
+  bf = C.PrimMinimal . Min.PrimBuiltinFun

--- a/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/ToCore.hs
@@ -382,7 +382,7 @@ convertReduce xx
                   = (,) <$> convertCaseFreshenPat p <*> convertReduce alt
         patalts' <- mapM goPatAlt patalts
         let pats' = fmap                 fst  patalts'
-            alts' = fmap (pullPosts () . snd) patalts'
+            alts' = fmap (pullPosts ())       patalts'
 
         let bs' = fst scrut' <> mconcat (fmap fst alts')
 

--- a/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
+++ b/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
@@ -85,8 +85,8 @@ reifyPossibilityX' wrap x
              args' <- mapM (reifyPossibilityX' wrap) args
              makeApps a fun' args' False
 
-      -- Primitives do not need their annotation to be wrapped:
-      -- if they are Possiblies, their outer use will be wrapped in a Right.
+      -- Primitives are dealt with by makeApps, because we can only wrap their annotations after unwrapping the arguments.
+      -- There are no zero-argument primitives that return Possibly, but if there ever are, this would need to wrap them here.
       Prim a p
        -> return $ Prim a p
 
@@ -253,8 +253,6 @@ reifyPossibilityQ (Query (c:cs) final_x)
   ins ctx (Query ctxs x)
    = Query (ctx:ctxs) x
 
--- XXX this is ignoring the possibility of functions that return differing modes.
--- This is true of all current primitives, and at this stage we can only have primitives.
 makeApps
         :: Hashable n
         => Annot a n
@@ -263,6 +261,17 @@ makeApps
         -> Bool
         -> Fresh n (Exp (Annot a n) n)
 makeApps _ fun [] doWrap
+ -- After unwrapping the arguments, check if primitive introduces Possibly.
+ -- If so, we need to wrap all the return type annotations with (SumT ErrorT).
+ -- We also do not want to wrap it in a Right, since the prim will do that itself.
+ | Just (p, pa, args) <- takePrimApps fun
+ , primReturnsPossibly p (annResult pa)
+ = let pa'  = wrapAnnotReally pa
+       fun' = Prim pa' p
+       apps = foldl (App pa') fun' args
+   in  return apps
+
+ | otherwise
  = let funR = conRight fun
    in  if   doWrap
        then return funR
@@ -281,16 +290,7 @@ makeApps a fun (arg:rest) doWrap
             -- Bare value. Note that this is now definite, but with same (bare) type
             bare  = Var (extractValueAnnot arga) nValue
 
-        -- Check if we're calling a primitive which already returns its result wrapped.
-        -- If so, we do not need to perform rewrapping of the value.
-        let doWrap'
-              | Just (p, pa, _) <- takePrimApps fun
-              , primReturnsPossibly p (annResult pa)
-              = False
-              | otherwise
-              = True
-
-        fun' <- makeApps a (App annotWrapPrim fun bare) rest doWrap'
+        fun' <- makeApps a (App a fun bare) rest True
 
         let app'  = Case a' arg
                   [ ( PatCon ConLeft  [ PatVariable nError ]
@@ -302,15 +302,7 @@ makeApps a fun (arg:rest) doWrap
 
  -- If argument is a definitely, just apply it as usual
  | otherwise
- =  makeApps a (App annotWrapPrim fun arg) rest doWrap
-
- where
-  annotWrapPrim
-   | Just (p, pa, _) <- takePrimApps fun
-   , primReturnsPossibly p (annResult pa)
-   = wrapAnnotReally a
-   | otherwise
-   = a
+ =  makeApps a (App a fun arg) rest doWrap
 
 
 con0 :: Annot a n -> Constructor -> Exp (Annot a n) n

--- a/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
+++ b/icicle-source/src/Icicle/Source/Transform/ReifyPossibility.hs
@@ -284,8 +284,8 @@ makeApps a fun (arg:rest) doWrap
         -- Check if we're calling a primitive which already returns its result wrapped.
         -- If so, we do not need to perform rewrapping of the value.
         let doWrap'
-              | Just (p, _, _) <- takePrimApps fun
-              , primReturnsPossibly p
+              | Just (p, pa, _) <- takePrimApps fun
+              , primReturnsPossibly p (annResult pa)
               = False
               | otherwise
               = True
@@ -306,8 +306,8 @@ makeApps a fun (arg:rest) doWrap
 
  where
   annotWrapPrim
-   | Just (p, _, _) <- takePrimApps fun
-   , primReturnsPossibly p
+   | Just (p, pa, _) <- takePrimApps fun
+   , primReturnsPossibly p (annResult pa)
    = wrapAnnotReally a
    | otherwise
    = a

--- a/icicle-source/src/Icicle/Source/Type/Base.hs
+++ b/icicle-source/src/Icicle/Source/Type/Base.hs
@@ -113,6 +113,7 @@ valTypeOfType bt
 data Constraint n
  = CEquals (Type n) (Type n)
  | CIsNum (Type n)
+ | CPossibilityOfNum (Type n) (Type n)
  | CTemporalityJoin (Type n) (Type n) (Type n)
  | CReturnOfLetTemporalities (Type n) (Type n) (Type n)
  | CDataOfLatest (Type n) (Type n) (Type n) (Type n)
@@ -175,8 +176,10 @@ instance Pretty n => Pretty (Type n) where
 instance Pretty n => Pretty (Constraint n) where
  pretty (CEquals p q)
   = pretty p <+> "=:" <+> pretty q
- pretty (CIsNum p)
-  = "Num" <+> pretty p
+ pretty (CIsNum t)
+  = "IsNum" <+> pretty t
+ pretty (CPossibilityOfNum ret t)
+  = pretty ret <+> "=: PossibilityOfNum" <+> pretty t
  pretty (CTemporalityJoin ret a b)
   = pretty ret <+> "=: TemporalityJoin" <+> pretty a <+> pretty b
  pretty (CReturnOfLetTemporalities t def body)

--- a/icicle-source/src/Icicle/Source/Type/Base.hs
+++ b/icicle-source/src/Icicle/Source/Type/Base.hs
@@ -177,7 +177,7 @@ instance Pretty n => Pretty (Constraint n) where
  pretty (CEquals p q)
   = pretty p <+> "=:" <+> pretty q
  pretty (CIsNum t)
-  = "IsNum" <+> pretty t
+  = "Num" <+> pretty t
  pretty (CPossibilityOfNum ret t)
   = pretty ret <+> "=: PossibilityOfNum" <+> pretty t
  pretty (CTemporalityJoin ret a b)

--- a/icicle-source/src/Icicle/Source/Type/Compounds.hs
+++ b/icicle-source/src/Icicle/Source/Type/Compounds.hs
@@ -69,7 +69,8 @@ freeC :: (Hashable n, Eq n) => Constraint n -> Set.Set (Name n)
 freeC c
  = case c of
     CEquals p q             -> Set.union (freeT p) (freeT q)
-    CIsNum  p               -> freeT p
+    CIsNum              t   -> freeT t
+    CPossibilityOfNum p t   -> Set.union (freeT p) (freeT t)
     CReturnOfLetTemporalities
                     p q r   -> Set.unions
                              $ fmap freeT

--- a/icicle-source/src/Icicle/Source/Type/Constraints.hs
+++ b/icicle-source/src/Icicle/Source/Type/Constraints.hs
@@ -77,6 +77,15 @@ dischargeC c
     CIsNum t
      -> Left   $ NotANumber t
 
+    CPossibilityOfNum poss IntT
+     -> dischargeC (CEquals poss PossibilityDefinitely)
+    CPossibilityOfNum poss DoubleT
+     -> dischargeC (CEquals poss PossibilityPossibly)
+    CPossibilityOfNum poss (TypeVar _)
+     -> return $ DischargeLeftover c
+    CPossibilityOfNum _ t
+     -> Left   $ NotANumber t
+
     CEquals a b
      -> case unifyT a b of
          Nothing -> Left $ CannotUnify a b

--- a/icicle-source/src/Icicle/Source/Type/Constraints.hs
+++ b/icicle-source/src/Icicle/Source/Type/Constraints.hs
@@ -81,7 +81,7 @@ dischargeC c
      -> dischargeC (CEquals poss PossibilityDefinitely)
     CPossibilityOfNum poss DoubleT
      -> dischargeC (CEquals poss PossibilityPossibly)
-    CPossibilityOfNum poss (TypeVar _)
+    CPossibilityOfNum _ (TypeVar _)
      -> return $ DischargeLeftover c
     CPossibilityOfNum _ t
      -> Left   $ NotANumber t

--- a/icicle-source/src/Icicle/Source/Type/Subst.hs
+++ b/icicle-source/src/Icicle/Source/Type/Subst.hs
@@ -70,8 +70,10 @@ substC ss cc
  = case cc of
     CEquals p q
      -> CEquals (substT ss p) (substT ss q)
-    CIsNum p
-     -> CIsNum (substT ss p)
+    CIsNum t
+     -> CIsNum (substT ss t)
+    CPossibilityOfNum p t
+     -> CPossibilityOfNum (substT ss p) (substT ss t)
     CTemporalityJoin a b c
      -> CTemporalityJoin (substT ss a) (substT ss b) (substT ss c)
     CReturnOfLetTemporalities ret def body


### PR DESCRIPTION
Fix in two ways. One. make temporality of pattern bindings equal to result
temporality.
So this is outlawed, because the bindings 'b' and 'c' are Aggregates,
despite the scrutinee being pure.

> feature salary ~> case (0,0) | (b,c) -> (fold a = b : c ~> a) end

This makes the type checker more restrictive, but this shouldn't affect
any existing programs because they would currently fail to typecheck in
Core.

Two. Converting an Aggregate case to Core, some of the references will show up
in the precomputations. But the pattern isn't bound until post.
So take the set of names bound by the pattern, and run through the
precomputations, deferring anything that mentions the pattern names
until post. That way it will be nested beneath the pattern bindings.