### PR TITLE
Calculate correct offset in to input column using all facts

### DIFF
--- a/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
@@ -41,7 +41,6 @@ module Icicle.Runtime.Data.Primitive (
   ) where
 
 import           Data.Bits ((.|.), (.&.), unsafeShiftL, unsafeShiftR)
-import qualified Data.List as List
 import qualified Data.Text as Text
 import qualified Data.Vector.Storable as Storable
 import           Data.Word (Word64, Word32, Word8)
@@ -52,8 +51,6 @@ import           Foreign.Storable (Storable(..))
 import           GHC.Generics (Generic)
 
 import           Icicle.Common.Base (ExceptionInfo(..))
-
-import           Numeric (showHex)
 
 import           P
 
@@ -97,14 +94,8 @@ newtype Time64 =
     } deriving (Eq, Ord, Generic, Storable)
 
 instance Show Time64 where
-  showsPrec p (Time64 x) =
-    let
-      showPadding hx rest =
-        '0' : 'x' : List.replicate (16 - length hx) '0' <> hx <> rest
-    in
-      showParen (p > 10) $
-        showString "Time64 " .
-        showPadding (showHex x "")
+  showsPrec p =
+    showsPrec p . unpackTime
 
 -- | The @itime_t@ runtime type in unpacked form.
 --
@@ -114,7 +105,11 @@ data UnpackedTime64 =
     , timeMonth :: !Word8
     , timeDay :: !Word8
     , timeSeconds :: !Word32
-    } deriving (Eq, Ord, Show, Generic)
+    } deriving (Eq, Ord, Generic)
+
+instance Show UnpackedTime64 where
+  showsPrec =
+    gshowsPrec
 
 instance Storable UnpackedTime64 where
   sizeOf _ =

--- a/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
@@ -5,6 +5,7 @@
 module Icicle.Test.Gen.Runtime.Data where
 
 import           Data.ByteString (ByteString)
+import qualified Data.List as List
 import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Vector as Boxed
@@ -171,7 +172,7 @@ genEntityInputColumn schema = do
     n =
       Striped.length column
 
-  times <- Storable.fromList <$> Gen.list (Range.singleton n) genTime64
+  times <- Storable.fromList . List.sort <$> Gen.list (Range.singleton n) genTime64
   tombstones <- Storable.fromList <$> Gen.list (Range.singleton n) genTombstoneOrSuccess
 
   pure $ InputColumn (Storable.singleton $ fromIntegral n) times tombstones column

--- a/icicle-compiler/test/Icicle/Test/Runtime/Evaluator.hs
+++ b/icicle-compiler/test/Icicle/Test/Runtime/Evaluator.hs
@@ -6,10 +6,12 @@ module Icicle.Test.Runtime.Evaluator where
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Morph (hoist)
 
+import           Data.Map (Map)
 import qualified Data.Map.Strict as Map
 import qualified Data.Set as Set
 import qualified Data.Text as Text
 import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
@@ -26,13 +28,15 @@ import qualified Icicle.Runtime.Data.Striped as Striped
 import qualified Icicle.Runtime.Evaluator as Runtime
 import           Icicle.Test.Gen.Data.Fact
 import           Icicle.Test.Gen.Data.Name
-import           Icicle.Test.Gen.Runtime.Data (genInputColumn, genEntityKey)
+import           Icicle.Test.Gen.Runtime.Data (genEntityInputColumn, genEntityKey, genTime64)
 
 import           P
 
 import qualified Prelude as Savage
 
 import           System.IO (IO)
+
+import qualified X.Data.Vector.Cons as Cons
 
 
 genDictionaryInput :: Gen DictionaryInput
@@ -95,18 +99,25 @@ genDictionary = do
   pure $
     Dictionary inputs outputs []
 
-genDictionaryInputColumn :: Int -> DictionaryInput -> Gen InputColumn
-genDictionaryInputColumn n_entities input =
+genDictionaryInputColumn :: DictionaryInput -> Gen InputColumn
+genDictionaryInputColumn input =
   case Schema.fromEncoding $ inputEncoding input of
     Left x ->
       Savage.error $ "genDictionaryInputColumn: " <> show x
     Right schema ->
-      genInputColumn n_entities schema
+      genEntityInputColumn schema
 
-genInput :: Dictionary -> Gen Input
-genInput dictionary = do
-  entities <- Boxed.fromList <$> Gen.list (Range.linear 1 5) genEntityKey
-  Input entities <$> traverse (genDictionaryInputColumn (Boxed.length entities)) (dictionaryInputs dictionary)
+genInputColumns :: Int -> Dictionary -> Gen (Map InputId [InputColumn])
+genInputColumns n_entities dictionary = do
+  let
+    range_entities =
+      Range.singleton n_entities
+
+  traverse (Gen.list range_entities . genDictionaryInputColumn) (dictionaryInputs dictionary)
+
+concatEntities :: [InputColumn] -> InputColumn
+concatEntities =
+  either (Savage.error . ("genInput: " <>) . show) id . concatInputColumn . Cons.unsafeFromList
 
 maximumMapSize :: MaximumMapSize
 maximumMapSize =
@@ -119,25 +130,58 @@ fromInputColumn input =
     (Striped.Result (inputTombstone input) (inputColumn input))
 
 data EvaluatorTest =
-  EvaluatorTest !Dictionary !Input
-  deriving (Show)
+  EvaluatorTest {
+      testDictionary :: !Dictionary
+    , testEntities :: !(Boxed.Vector EntityKey)
+    , testInputs :: !(Map InputId [InputColumn])
+    } deriving (Show)
 
 genEvaluatorTest :: Gen EvaluatorTest
 genEvaluatorTest = do
   dictionary <- genDictionary
-  EvaluatorTest dictionary <$> genInput dictionary
+  entities <- Boxed.fromList <$> Gen.list (Range.linear 1 5) genEntityKey
+  inputs <- genInputColumns (Boxed.length entities) dictionary
+  pure $ EvaluatorTest dictionary entities inputs
+
+takeInput :: EvaluatorTest -> Input
+takeInput et =
+  Input (testEntities et) (fmap concatEntities $ testInputs et)
+
+takeWhileBefore :: SnapshotTime -> InputColumn -> InputColumn
+takeWhileBefore (SnapshotTime stime) icolumn =
+  if Storable.length (inputLength icolumn) /= 1 then
+    Savage.error "takeWhileBefore: this function only works for a single entities"
+  else
+    let
+      time =
+        Storable.takeWhile (< stime) $ inputTime icolumn
+
+      n =
+        Storable.length time
+
+      tombstone =
+        Storable.take n $ inputTombstone icolumn
+
+      (column, _) =
+        Striped.splitAt n $ inputColumn icolumn
+    in
+      InputColumn (Storable.singleton $ fromIntegral n) time tombstone column
+
+takeInputBefore :: SnapshotTime -> EvaluatorTest -> Input
+takeInputBefore stime et =
+  Input (testEntities et) (fmap (concatEntities . fmap (takeWhileBefore stime)) $ testInputs et)
 
 prop_evaluator_roundtrip :: Property
 prop_evaluator_roundtrip =
   withTests 100 . property $ do
-    EvaluatorTest dictionary input <- forAll genEvaluatorTest
+    et@(EvaluatorTest dictionary _entities _inputs) <- forAll genEvaluatorTest
+    stime <- forAll $ SnapshotTime <$> genTime64
 
     ccoptions0 <- Runtime.getCompilerOptions
 
     let
-      stime =
-        SnapshotTime . packTime $
-          UnpackedTime64 3000 1 1 0
+      input =
+        takeInput et
 
       options =
         Compiler.defaultCompileOptions {
@@ -168,7 +212,11 @@ prop_evaluator_roundtrip =
         ]
 
       inputAsOutput =
-        Map.fromList . concatMap two . Map.toList $ inputColumns input
+        Map.fromList .
+        concatMap two .
+        Map.toList .
+        inputColumns $
+        takeInputBefore stime et
 
     inputAsOutput === outputColumns output
 


### PR DESCRIPTION
I was calculating the wrong offset in to the input data, using `ncounts_valid` instead of `ncounts_all`.

`ncounts_all` = the count of facts in the zebra file
`ncounts_valid` = the count of facts which occurred before snapshot time

! @tranma 