### PR TITLE
Melting relation primops: (SumT ErrorT t) special case

### DIFF
--- a/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
@@ -201,6 +201,7 @@ typeOfPrim p
 
 -- We need to distinguish between an error and an error which is the tag in (Sum Error t)
 data MeltLogical = MeltRep ValType | MeltTagSumError -- | MeltTagSum | MeltTagOption
+ deriving Eq
 
 repOfMelt :: MeltLogical -> ValType
 repOfMelt (MeltRep v)     = v

--- a/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Prim/Flat.hs
@@ -13,6 +13,9 @@ module Icicle.Avalanche.Prim.Flat (
     , PrimMap     (..)
     , typeOfPrim
     , flatFragment
+    , MeltLogical (..)
+    , meltLogical
+    , repOfMelt
     , meltType
     , tryMeltType
     , typeOfUnpack
@@ -196,42 +199,52 @@ typeOfPrim p
     PrimBuf     (PrimBufRead i t)
      -> FunT [funOfVal (BufT i t)] (ArrayT t)
 
+-- We need to distinguish between an error and an error which is the tag in (Sum Error t)
+data MeltLogical = MeltRep ValType | MeltTagSumError -- | MeltTagSum | MeltTagOption
 
+repOfMelt :: MeltLogical -> ValType
+repOfMelt (MeltRep v)     = v
+repOfMelt MeltTagSumError = ErrorT
 
-meltType :: ValType -> [ValType]
-meltType t
+meltLogical :: ValType -> [MeltLogical]
+meltLogical t
  = case t of
-    UnitT   -> [t]
-    IntT    -> [t]
-    DoubleT -> [t]
-    BoolT   -> [t]
-    TimeT   -> [t]
-    StringT -> [t]
-    ErrorT  -> [t]
+    UnitT   -> rep t
+    IntT    -> rep t
+    DoubleT -> rep t
+    BoolT   -> rep t
+    TimeT   -> rep t
+    StringT -> rep t
+    ErrorT  -> rep t
     FactIdentifierT
-            -> [t]
+            -> rep t
 
-    PairT   a b -> meltType a <> meltType b
+    PairT   a b -> meltLogical a <> meltLogical b
 
     SumT    a b
      | ErrorT <- a
-     -> [ErrorT]               <> meltType b
+     -> [MeltTagSumError]           <> meltLogical b
      | otherwise
-     -> [BoolT]  <> meltType a <> meltType b
+     -> rep BoolT  <> meltLogical a <> meltLogical b
 
-    OptionT a   -> [BoolT] <> meltType a
+    OptionT a   -> rep BoolT <> meltLogical a
 
-    ArrayT a -> fmap ArrayT   (meltType a)
-    BufT i a -> fmap (BufT i) (meltType a)
-    MapT k v -> meltType (ArrayT k) <> meltType (ArrayT v)
+    ArrayT a -> nested ArrayT   (meltLogical a)
+    BufT i a -> nested (BufT i) (meltLogical a)
+    MapT k v -> meltLogical (ArrayT k) <> meltLogical (ArrayT v)
 
     StructT (StructType fs)
      | Map.null fs
-     -> [UnitT]
+     -> rep UnitT
 
      | otherwise
-     -> concat $ fmap meltType (Map.elems fs)
+     -> concat $ fmap meltLogical (Map.elems fs)
+ where
+  rep t' = [MeltRep t']
+  nested f = fmap (MeltRep . f . repOfMelt)
 
+meltType :: ValType -> [ValType]
+meltType = fmap repOfMelt . meltLogical
 
 tryMeltType :: ValType -> Maybe [ValType]
 tryMeltType t

--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/Constructor.hs
@@ -322,7 +322,7 @@ constructor a_fresh statements
 
    | (PrimMinimal (Min.PrimRelation op t), [nx, ny]) <- prima
    , melts <- meltLogical t
-   , length melts /= 1
+   , melts /= [MeltRep t]
    = let tis = List.zip melts [0..]
          with0 p tvi = withPrim p t nx ny tvi
          mk = makeComparisons with0 tis


### PR DESCRIPTION
Less-than etc weren't working for the too-smart `(Error,t)` representation. In a melted normal sum the tag is True for Right, which makes `left < right`. In the `(Error,t)` case, the "tag" is ExceptNotAnError==0 for Right, so `left > right`!

So I modified the melt type to distinguish between bare errors and tag errors. When we see a tag error, we can convert it to an "isRight" by using `error == ErrorNotAnError`. Then we can compare on that as before, pretending it's a real sum with that as the tag.

This *doesn't* change (Sum Error t) nested inside arrays, bufs, etc. But, the relation semantics for these are already different. Comparison of pair-of-arrays vs array-of-pairs are different. So the tests are already ignoring these.


! @jystic @tranma 