### PR TITLE
Generate a bit more

### DIFF
--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/ThreshOrd.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Simp/ThreshOrd.hs
@@ -59,7 +59,6 @@ instance (Ord a, Hashable n, Eq n) => Ord (ThreshMapOrd a n) where
     = case (x, y) of
        (Min.PrimArithUnary p _, Min.PrimArithUnary p' _) -> compare p p'
        (Min.PrimArithBinary p _, Min.PrimArithBinary p' _) -> compare p p'
-       (Min.PrimToString _, Min.PrimToString _) -> EQ
        (Min.PrimRelation p _, Min.PrimRelation p' _) -> compare p p'
        (Min.PrimLogical p, Min.PrimLogical p') -> compare p p'
        -- Constructors actually do matter what their type is.

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Prim.hs
@@ -99,7 +99,6 @@ seaOfPrimArithBinary p
      M.PrimArithPlus  -> "add"
      M.PrimArithMinus -> "sub"
      M.PrimArithMul   -> "mul"
-     M.PrimArithPow   -> "pow"
 
 seaOfPrimTime :: M.PrimTime -> Doc
 seaOfPrimTime p
@@ -118,6 +117,7 @@ seaOfPrimTime p
 seaOfPrimBuiltinMath :: M.PrimBuiltinMath -> Doc
 seaOfPrimBuiltinMath p = case p of
   M.PrimBuiltinDiv             -> idouble <> "div"
+  M.PrimBuiltinPow             -> idouble <> "pow"
   M.PrimBuiltinLog             -> idouble <> "log"
   M.PrimBuiltinExp             -> idouble <> "exp"
   M.PrimBuiltinSqrt            -> idouble <> "sqrt"

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Source.hs
@@ -500,7 +500,7 @@ instance Arbitrary Prim where
         , ArithBinary Mul
         , ArithBinary Add
         , ArithBinary Sub
-        , ArithBinary Pow
+        , ArithDouble Pow
         , ArithDouble Div
         , Relation Lt
         , Relation Le

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -149,7 +149,6 @@ genPrimMinimal
 genPrimArithUnary :: Gen PM.PrimArithUnary
 genPrimArithUnary = Gen.enumBounded
 
--- TODO: missing PrimArithPow; this should be modified to work on Doubles only
 genPrimArithBinary :: Gen PM.PrimArithBinary
 genPrimArithBinary = Gen.element
   [ PM.PrimArithPlus
@@ -185,7 +184,7 @@ genPrimBuiltinMath = Gen.element
   , PM.PrimBuiltinRound
   , PM.PrimBuiltinToDoubleFromInt
   -- TODO: missing NaN-introducing primitives; modify tests to use NanEq instead of Eq.
-  , PM.PrimBuiltinPow
+  -- , PM.PrimBuiltinPow
   -- , PM.PrimBuiltinDiv
   -- , PM.PrimBuiltinLog
   -- , PM.PrimBuiltinExp

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Test.Gen.Core.Prim where
 
+import           Icicle.Common.Base
 import           Icicle.Common.Type
 
 import           Icicle.Core.Exp.Prim
@@ -12,6 +13,7 @@ import Icicle.Test.Gen.Core.Type
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
 
 import P
 import qualified Data.Map   as Map
@@ -50,7 +52,10 @@ genPrimMany genT = do
     , PrimFold  <$> (PrimFoldMap    <$> genT  <*> genT) <*> genT
     , PrimMap   <$> (PrimMapInsertOrUpdate    <$> genT  <*> genT)
     , PrimMap   <$> (PrimMapMapValues         <$> genT  <*> genT <*> genT)
+    , PrimMap   <$> (PrimMapDelete            <$> genT  <*> genT)
+    , PrimMap   <$> (PrimMapLookup            <$> genT  <*> genT)
     , PrimArray <$> (PrimArrayMap   <$> genT  <*> genT)
+    , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
     ]
 
   -- Generate buffer prims in pairs so for a given size and type we can always push and read
@@ -59,6 +64,15 @@ genPrimMany genT = do
    a <- genT
    return [ PrimLatest $ PrimLatestPush n a
           , PrimLatest $ PrimLatestRead n a ]
+
+
+genWindowUnit :: Gen WindowUnit
+genWindowUnit = Gen.choice
+  [ Days <$> pos
+  , Months <$> pos
+  , Weeks <$> pos ]
+ where
+  pos = Gen.integral $ Range.linear 0 10
 
 genPrimMinimalMany :: Gen ValType -> Gen [PM.Prim]
 genPrimMinimalMany genT

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -77,7 +77,7 @@ genWindowUnit = Gen.choice
 
 genPrimMinimalMany :: Gen ValType -> Gen [PM.Prim]
 genPrimMinimalMany genT
- = concatGens [pure arith, pure tostring, pure logical, relation <$> genT, struct <$> genT, pure consts, pure builtins]
+ = concatGens [pure arith, pure logical, relation <$> genT, struct <$> genT, pure consts, pure builtins]
  where
   concatGens :: [Gen [Gen PM.Prim]] -> Gen [PM.Prim]
   concatGens gs = join (sequence <$> (concat <$> (sequence gs)))
@@ -85,12 +85,6 @@ genPrimMinimalMany genT
   arith
    = [ PM.PrimArithUnary  <$> genPrimArithUnary <*> genArithType
      , PM.PrimArithBinary <$> genPrimArithBinary <*> genArithType ]
-
-  -- TODO: ToString are not supported by C *or* exposed by front-end?
-  tostring
-   = []
-     -- [ return $ PM.PrimToString PM.PrimToStringFromInt
-     -- , return $ PM.PrimToString PM.PrimToStringFromDouble ]
 
   logical
    = [ PM.PrimLogical     <$> genPrimLogical
@@ -132,8 +126,6 @@ genPrimMinimal
  = Gen.choice
  [ PM.PrimArithUnary  <$> genPrimArithUnary <*> genArithType
  , PM.PrimArithBinary <$> genPrimArithBinary <*> genArithType
- , return $ PM.PrimToString PM.PrimToStringFromInt
- , return $ PM.PrimToString PM.PrimToStringFromDouble
  , PM.PrimLogical     <$> genPrimLogical
  , PM.PrimTime        <$> genPrimTime
  , PM.PrimConst <$> (PM.PrimConstPair  <$> genValType <*> genValType)

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -185,6 +185,7 @@ genPrimBuiltinMath = Gen.element
   , PM.PrimBuiltinRound
   , PM.PrimBuiltinToDoubleFromInt
   -- TODO: missing NaN-introducing primitives; modify tests to use NanEq instead of Eq.
+  , PM.PrimBuiltinPow
   -- , PM.PrimBuiltinDiv
   -- , PM.PrimBuiltinLog
   -- , PM.PrimBuiltinExp

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
@@ -26,7 +26,7 @@ genDerivedTypeTop t
  , SumT <$> genDerivedTypeTop t <*> genDerivedTypeTop t
  , ArrayT <$> genDerivedTypeTop t
  , MapT <$> genDerivedTypeTop t <*> genDerivedTypeTop t
- -- , BufT <$> Gen.integral (Range.linear 1 10) <*> genDerivedTypeTop t
+ , BufT <$> genBufLength <*> genDerivedTypeTop t
  ] ]
 
 genDerivedType :: ValType -> Gen ValType
@@ -50,6 +50,9 @@ genDerivedType t = case t of
  where
   usually = Gen.choice [genPrimType, return t]
 
+genBufLength :: Gen Int
+genBufLength = Gen.integral (Range.linear 1 5)
+
 --------------------------------------------------------------------------------
 
 genArithType :: Gen ArithType
@@ -64,7 +67,7 @@ genValType = Gen.recursive Gen.choice
   , OptionT <$> genValType
   , SumT    <$> genValType <*> genValType
   , ArrayT  <$> genValType
-  -- , BufT    <$> (Gen.integral $ Range.linear 1 20) <*> genValType
+  , BufT    <$> genBufLength <*> genValType
   , MapT    <$> genValType <*> genValType
   , StructT <$> genStructType
   ]

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Builtin.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Builtin.hs
@@ -27,6 +27,7 @@ data PrimBuiltinMath
  | PrimBuiltinRound
  | PrimBuiltinToDoubleFromInt
  | PrimBuiltinDiv
+ | PrimBuiltinPow
  | PrimBuiltinLog
  | PrimBuiltinExp
  | PrimBuiltinSqrt
@@ -60,6 +61,7 @@ instance Pretty PrimBuiltinFun where
 instance Pretty PrimBuiltinMath where
  pretty p = case p of
    PrimBuiltinDiv             -> "div#"
+   PrimBuiltinPow             -> "pow#"
    PrimBuiltinLog             -> "log#"
    PrimBuiltinExp             -> "exp#"
    PrimBuiltinSqrt            -> "sqrt#"

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
@@ -74,21 +74,19 @@ evalPrim p originalP vs
       | otherwise
       -> primError
 
-     PrimArithBinary PrimArithPow _
-      | [VBase (VDouble i), VBase (VDouble j)] <- vs
-      -> return $ VBase $ VDouble $ i ** j
-      | [VBase (VInt i), VBase (VInt j)] <- vs
-      -> return $ VBase $ VInt $ i ^ j
-      | otherwise
-      -> primError
-
-
      -- Builtin
      PrimBuiltinFun (PrimBuiltinMath PrimBuiltinDiv)
       | [VBase (VDouble i), VBase (VDouble j)] <- vs
       -> return $ VBase $ VDouble $ i / j
       | otherwise
       -> primError
+
+     PrimBuiltinFun (PrimBuiltinMath PrimBuiltinPow)
+      | [VBase (VDouble i), VBase (VDouble j)] <- vs
+      -> return $ VBase $ VDouble $ i ** j
+      | otherwise
+      -> primError
+
 
      PrimBuiltinFun (PrimBuiltinMath PrimBuiltinLog)
       | [VBase (VDouble i)] <- vs

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
@@ -15,7 +15,6 @@ import              P
 
 import qualified    Data.Map                        as Map
 import qualified    Data.List                       as List
-import qualified    Data.Text                       as T
 
 
 -- | Evaluate a primitive, given list of argument values
@@ -175,19 +174,6 @@ evalPrim p originalP vs
       -> return $ VBase $ a List.!! i
       | otherwise
       -> return $ VBase $ VError ExceptTombstone
-
-     -- To string
-     PrimToString PrimToStringFromInt
-      | [VBase (VInt i)] <- vs
-      -> return $ VBase $ VString $ T.pack $ show i
-      | otherwise
-      -> primError
-     PrimToString PrimToStringFromDouble
-      | [VBase (VDouble i)] <- vs
-      -> return $ VBase $ VString $ T.pack $ show i
-      | otherwise
-      -> primError
-
 
      -- Relation
      PrimRelation rel _

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
@@ -57,7 +57,6 @@ data PrimArithBinary
  = PrimArithPlus
  | PrimArithMinus
  | PrimArithMul
- | PrimArithPow
  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 -- | Predicates like >=
@@ -125,7 +124,6 @@ instance NFData Prim
 typeOfPrim :: Prim -> Type
 typeOfPrim p
  = case p of
-    -- All arithmetics are working on ints for now
     PrimArithUnary _ t
      -> FunT [funOfVal (valTypeOfArithType t)] (valTypeOfArithType t)
     PrimArithBinary _ t
@@ -143,6 +141,8 @@ typeOfPrim p
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinRound)
      -> FunT [funOfVal DoubleT] IntT
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinDiv)
+     -> FunT [funOfVal DoubleT, funOfVal DoubleT] DoubleT
+    PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinPow)
      -> FunT [funOfVal DoubleT, funOfVal DoubleT] DoubleT
     PrimBuiltinFun    (PrimBuiltinMath PrimBuiltinLog)
      -> FunT [funOfVal DoubleT] DoubleT
@@ -226,7 +226,6 @@ instance Pretty PrimArithBinary where
  pretty PrimArithPlus  = "add#"
  pretty PrimArithMinus = "sub#"
  pretty PrimArithMul   = "mul#"
- pretty PrimArithPow   = "pow#"
 
 instance Pretty PrimRelation where
  pretty PrimRelationGt = "gt#"

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
@@ -5,7 +5,6 @@ module Icicle.Common.Exp.Prim.Minimal (
       Prim            (..)
     , PrimArithUnary  (..)
     , PrimArithBinary (..)
-    , PrimToString    (..)
     , PrimRelation    (..)
     , PrimLogical     (..)
     , PrimConst       (..)
@@ -36,7 +35,6 @@ import           P
 data Prim
  = PrimArithUnary  !PrimArithUnary  !ArithType  -- ^ "Polymorphic" (double or int) unary operators
  | PrimArithBinary !PrimArithBinary !ArithType  -- ^ "Polymorphic" (double or int) binary operators
- | PrimToString    !PrimToString                -- ^ Conversion to string
  | PrimRelation    !PrimRelation    !ValType    -- ^ "Polymorphic" relation operators
  | PrimLogical     !PrimLogical                 -- ^ Logical operators
  | PrimConst       !PrimConst                   -- ^ Literal value constructors
@@ -60,11 +58,6 @@ data PrimArithBinary
  | PrimArithMinus
  | PrimArithMul
  | PrimArithPow
- deriving (Eq, Ord, Show, Enum, Bounded, Generic)
-
-data PrimToString
- = PrimToStringFromInt
- | PrimToStringFromDouble
  deriving (Eq, Ord, Show, Enum, Bounded, Generic)
 
 -- | Predicates like >=
@@ -119,7 +112,6 @@ data PrimStruct
 instance NFData PrimPair
 instance NFData PrimArithUnary
 instance NFData PrimArithBinary
-instance NFData PrimToString
 instance NFData PrimRelation
 instance NFData PrimLogical
 instance NFData PrimConst
@@ -172,11 +164,6 @@ typeOfPrim p
      -> FunT [funOfVal (ArrayT t)] IntT
     PrimBuiltinFun    (PrimBuiltinArray (PrimBuiltinIndex t))
      -> FunT [funOfVal (ArrayT t), funOfVal IntT] t
-
-    PrimToString PrimToStringFromInt
-     -> FunT [funOfVal IntT] StringT
-    PrimToString PrimToStringFromDouble
-     -> FunT [funOfVal DoubleT] StringT
 
     -- All relations are binary to bool
     PrimRelation _ val
@@ -249,10 +236,6 @@ instance Pretty PrimRelation where
  pretty PrimRelationEq = "eq#"
  pretty PrimRelationNe = "ne#"
 
-instance Pretty PrimToString where
- pretty PrimToStringFromInt    = "stringOfInt#"
- pretty PrimToStringFromDouble = "stringOfDouble#"
-
 instance Pretty PrimLogical where
  pretty PrimLogicalNot   = "not#"
  pretty PrimLogicalAnd   = "and#"
@@ -287,7 +270,6 @@ instance Pretty Prim where
  pretty (PrimArithUnary  p _t) = pretty p
  pretty (PrimArithBinary p _t) = pretty p
  pretty (PrimRelation    p _t) = pretty p
- pretty (PrimToString    p)   = pretty p
  pretty (PrimLogical     p)   = pretty p
  pretty (PrimConst       p)   = pretty p
  pretty (PrimTime        p)   = pretty p

--- a/icicle-source/src/Icicle/Source/Eval.hs
+++ b/icicle-source/src/Icicle/Source/Eval.hs
@@ -426,7 +426,7 @@ evalP ann p xs vs env
              | otherwise
              -> err
 
-            ArithBinary Pow
+            ArithDouble Pow
              | [VDouble i, VDouble j] <- args
              -> return $ VDouble (i ** j)
              | otherwise

--- a/icicle-source/src/Icicle/Source/Query/Operators.hs
+++ b/icicle-source/src/Icicle/Source/Query/Operators.hs
@@ -53,13 +53,13 @@ data ArithBinary
  = Mul
  | Add
  | Sub
- | Pow
  deriving (Show, Eq, Ord, Generic)
 
 instance NFData ArithBinary
 
 data ArithDouble
  = Div
+ | Pow
  deriving (Show, Eq, Ord, Generic)
 
 instance NFData ArithDouble
@@ -130,11 +130,11 @@ fixity o
      -> FInfix $ Infix AssocLeft 6
     ArithBinary Sub
      -> FInfix $ Infix AssocLeft 6
-    ArithBinary Pow
-     -> FInfix $ Infix AssocRight 8
 
     ArithDouble Div
      -> FInfix $ Infix AssocLeft 7
+    ArithDouble Pow
+     -> FInfix $ Infix AssocRight 8
 
     Relation _
      -> FInfix $ Infix AssocLeft 4
@@ -166,7 +166,7 @@ symbol s
     "/" -> inf (ArithDouble Div)
     "*" -> inf (ArithBinary Mul)
     "+" -> inf (ArithBinary Add)
-    "^" -> inf (ArithBinary Pow)
+    "^" -> inf (ArithDouble Pow)
     "-" -> OpsOfSymbol (Just $ ArithBinary Sub) (Just $ ArithUnary Negate)
 
     ">" -> inf $ Relation Gt
@@ -216,7 +216,7 @@ instance Pretty Op where
  pretty (ArithBinary Mul)       = "*"
  pretty (ArithBinary Add)       = "+"
  pretty (ArithBinary Sub)       = "-"
- pretty (ArithBinary Pow)       = "^"
+ pretty (ArithDouble Pow)       = "^"
  pretty (ArithDouble Div)       = "/"
 
  pretty (Relation Lt)           = "<"

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -37,6 +37,11 @@ primLookup' prim
     Op (ArithDouble Div)
      -> f0 [DoubleT, DoubleT] possiblyDouble
 
+    -- Pow can return Inf for large powers
+    Op (ArithDouble Pow)
+     -> f0 [DoubleT, DoubleT] possiblyDouble
+
+
     Op (Relation _)
      -> f1 $ \a at -> FunctionType [a] [] [at, at] BoolT
 
@@ -195,6 +200,7 @@ primReturnsPossibly p ty
  = case p of
     Op (ArithBinary _)     -> True
     Op (ArithDouble Div)   -> True
+    Op (ArithDouble Pow)   -> True
     Fun (BuiltinMath Log)  -> True
     Fun (BuiltinMath Exp)  -> True
     Fun (BuiltinMath Sqrt) -> True

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -132,7 +132,6 @@ convertPrim p ann resT xts = go p
              Add -> Min.PrimArithPlus
              Sub -> Min.PrimArithMinus
              Mul -> Min.PrimArithMul
-             Pow -> Min.PrimArithPow
    let fx = primmin (Min.PrimArithBinary p' tt)
    case tt of
     T.ArithDoubleT ->
@@ -142,6 +141,8 @@ convertPrim p ann resT xts = go p
 
   goop (ArithDouble Div)
    = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinDiv
+  goop (ArithDouble Pow)
+   = primCheckDouble $ primbuiltin $ Min.PrimBuiltinMath Min.PrimBuiltinPow
 
   -- Logic
   goop (LogicalUnary Not)


### PR DESCRIPTION
Introduce some new primitives to the Core generator, as well as small changes necessary to make pass.

Remove the ToString primitives: these weren't exposed in Source, and weren't generating C code either.

Change the type of Pow from `Num a => a -> a -> a` to only work on Doubles. This won't affect real programs because Pow wasn't generating valid code for Ints before, anyway.

! @jystic @tranma 
/jury approved @jystic