### PR TITLE
Stencils for slicing out input facts that are valid for a chord/snapshot

### DIFF
--- a/icicle-compiler/src/Icicle/Command/Query.hs
+++ b/icicle-compiler/src/Icicle/Command/Query.hs
@@ -199,7 +199,7 @@ decodeZebra runtime = do
 
 fromSnapshotDate :: Date -> Runtime.SnapshotTime
 fromSnapshotDate =
-  Runtime.SnapshotTime . Runtime.Time64 . packedOfTime . exclusiveSnapshotTime
+  Runtime.SnapshotTime . Runtime.QueryTime . Runtime.Time64 . packedOfTime . exclusiveSnapshotTime
 
 encodeZebraSnapshot :: Runtime.Output SnapshotKey -> Either QueryError Zebra.Table
 encodeZebraSnapshot =

--- a/icicle-compiler/src/Icicle/Compiler/Sea.hs
+++ b/icicle-compiler/src/Icicle/Compiler/Sea.hs
@@ -94,8 +94,8 @@ fromInputs iid typ kvss = do
     lens =
       Storable.fromList $ fmap (fromIntegral . length) vss
 
-    times :: Storable.Vector Runtime.Time64 =
-      Storable.fromList $ fmap (Runtime.Time64 . packedOfTime . atTime) (concat vss)
+    times :: Storable.Vector Runtime.InputTime =
+      Storable.fromList $ fmap (Runtime.InputTime . Runtime.Time64 . packedOfTime . atTime) (concat vss)
 
   (tombstones, values) <-
     fmap List.unzip . first CompilerSeaLogicalError $
@@ -159,7 +159,7 @@ seaEval ctx facts0 (renameQT unVar -> query) program = do
       Runtime.MaximumMapSize . fromIntegral $ Common.evalMaxMapSize ctx
 
     stime =
-      Runtime.SnapshotTime . Runtime.Time64 . packedOfTime $ Common.evalSnapshotTime ctx
+      Runtime.SnapshotTime . Runtime.QueryTime . Runtime.Time64 . packedOfTime $ Common.evalSnapshotTime ctx
 
   context <- hoistEither . first CompilerSeaRuntimeError . Runtime.compileAvalanche $
     Runtime.AvalancheContext "Icicle.Compiler.Sea.seaEval" (Map.singleton iid (program :| []))

--- a/icicle-compiler/src/Icicle/Repl/Query.hs
+++ b/icicle-compiler/src/Icicle/Repl/Query.hs
@@ -519,7 +519,8 @@ evaluateZebra compiled path = do
 
       whenSet FlagSeaEval $ do
         mapSize <- Runtime.MaximumMapSize . fromIntegral <$> gets stateMaxMapSize
-        time <- Runtime.SnapshotTime . Runtime.Time64 . packedOfTime . exclusiveSnapshotTime <$> gets stateSnapshotDate
+        time <- Runtime.SnapshotTime . Runtime.QueryTime . Runtime.Time64 .
+          packedOfTime . exclusiveSnapshotTime <$> gets stateSnapshotDate
 
         limit <- gets stateLimit
         minput0 <- readZebraRows limit path

--- a/icicle-compiler/src/Icicle/Runtime/Data/IO.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/IO.hs
@@ -15,7 +15,10 @@ module Icicle.Runtime.Data.IO (
   , ChordDescriptor(..)
   , Label(..)
 
+  , QueryTime(..)
+
   , Input(..)
+  , InputTime(..)
   , InputColumn(..)
 
   , Output(..)
@@ -101,9 +104,27 @@ instance Show MaximumMapSize where
   showsPrec =
     gshowsPrec
 
+newtype QueryTime =
+  QueryTime {
+      unQueryTime :: Time64
+    } deriving (Eq, Ord, Generic, Storable)
+
+instance Show QueryTime where
+  showsPrec =
+    gshowsPrec
+
+newtype InputTime =
+  InputTime {
+      unInputTime :: Time64
+    } deriving (Eq, Ord, Generic, Storable)
+
+instance Show InputTime where
+  showsPrec =
+    gshowsPrec
+
 newtype SnapshotTime =
   SnapshotTime {
-      unSnapshotTime :: Time64
+      unSnapshotTime :: QueryTime
     } deriving (Eq, Ord, Generic, Storable)
 
 instance Show SnapshotTime where
@@ -117,7 +138,7 @@ newtype ChordDescriptor =
 
 data Label =
   Label {
-      labelTime :: !Time64
+      labelTime :: !QueryTime
     , labelTag :: !ByteString
     } deriving (Eq, Ord, Generic)
 
@@ -159,7 +180,7 @@ data InputColumn =
 
     -- | /invariant: length inputTime = sum inputLength/
     --
-    , inputTime :: !(Storable.Vector Time64)
+    , inputTime :: !(Storable.Vector InputTime)
 
     -- | /invariant: length inputTombstone = sum inputLength/
     --

--- a/icicle-compiler/src/Icicle/Runtime/Evaluator.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Evaluator.hs
@@ -403,12 +403,12 @@ runtimeOutputSchema =
 resolveAvailableCount ::
      SnapshotTime
   -> Storable.Vector Int64
-  -> Storable.Vector Time64
+  -> Storable.Vector InputTime
   -> Either RuntimeError (Storable.Vector Int64)
-resolveAvailableCount (SnapshotTime stime) ns ts = do
+resolveAvailableCount (SnapshotTime (QueryTime stime)) ns ts = do
   tss <- first RuntimeSegmentError $ Segment.reify ns ts
   pure . Storable.convert $
-    Boxed.map (fromIntegral . Storable.length . Storable.takeWhile (< stime)) tss
+    Boxed.map (fromIntegral . Storable.length . Storable.takeWhile (< InputTime stime)) tss
 
 snapshotCluster ::
      Cluster ClusterInfo KernelIO
@@ -427,7 +427,7 @@ snapshotCluster cluster maxMapSize stime input =
     inputData =
       Striped.Pair
         (Striped.Result (inputTombstone input) (inputColumn input))
-        (Striped.Time (inputTime input))
+        (Striped.Time (Storable.map unInputTime (inputTime input)))
 
     inputSchema =
       Striped.schema $ inputColumn input

--- a/icicle-compiler/src/Icicle/Runtime/Stencil.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Stencil.hs
@@ -1,0 +1,120 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+module Icicle.Runtime.Stencil (
+    Stencil(..)
+  , EntityStencil(..)
+  , zipStencil
+
+  , Segmented(..)
+  , toSegmented
+  , fromSegmented
+
+  , StencilError(..)
+  , renderStencilError
+
+  , chordStencil
+  , chordEntityStencil
+  , snapshotStencil
+  ) where
+
+import qualified Data.Text as Text
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
+
+import           Foreign.Storable (Storable)
+
+import           Icicle.Runtime.Data
+
+import           P
+
+import           Zebra.X.Vector.Segment (SegmentError)
+import qualified Zebra.X.Vector.Segment as Segment -- FIXME move to x-vector
+
+
+-- | The stencils to use for each entity in a block.
+--
+newtype Stencil =
+  Stencil {
+      unStencil :: Boxed.Vector EntityStencil
+    } deriving (Eq, Ord, Show)
+
+-- | The number of inputs to take for each query we want to run against a single entity.
+--
+newtype EntityStencil =
+  EntityStencil {
+      unEntityStencil :: Storable.Vector Int64
+    } deriving (Eq, Ord, Show, Monoid)
+
+data Segmented a =
+  Segmented {
+      segmentedLength :: !(Storable.Vector Int64)
+    , segmentedData :: !(Storable.Vector a)
+    } deriving (Eq, Ord, Show)
+
+data StencilError =
+    StencilEntityCountMismatch !Int !Int
+  | StencilSegmentError !SegmentError
+    deriving (Eq, Show)
+
+renderStencilError :: StencilError -> Text
+renderStencilError = \case
+  StencilEntityCountMismatch qc ic ->
+    "Entity count mismatch, query time count = " <> Text.pack (show qc) <> ", input time count = " <> Text.pack (show ic)
+  StencilSegmentError x ->
+    Segment.renderSegmentError x
+
+toSegmented :: Storable a => Boxed.Vector (Storable.Vector a) -> Segmented a
+toSegmented xss =
+  Segmented
+    (Storable.convert $ Boxed.map (fromIntegral . Storable.length) xss)
+    (Storable.concat $ Boxed.toList xss)
+
+fromSegmented :: Storable a => Segmented a -> Either StencilError (Boxed.Vector (Storable.Vector a))
+fromSegmented x =
+  first StencilSegmentError $
+    Segment.reify (segmentedLength x) (segmentedData x)
+
+zipStencil :: Stencil -> Stencil -> Stencil
+zipStencil (Stencil xs) (Stencil ys) =
+  Stencil $ Boxed.zipWith (<>) xs ys
+
+checkEntityCounts :: Segmented a -> Segmented b -> Either StencilError ()
+checkEntityCounts x y =
+  let
+    n =
+      Storable.length $ segmentedLength x
+
+    m =
+      Storable.length $ segmentedLength y
+  in
+    if n == m then
+      Right ()
+    else
+      Left $ StencilEntityCountMismatch n m
+
+queryStencil :: QueryTime -> Storable.Vector InputTime -> Int64
+queryStencil (QueryTime time) ts =
+  fromIntegral . Storable.length $ Storable.takeWhile (< InputTime time) ts
+
+snapshotStencil :: SnapshotTime -> Segmented InputTime -> Either StencilError Stencil
+snapshotStencil time tss0 = do
+  tss <- fromSegmented tss0
+  pure . Stencil $
+    Boxed.map (EntityStencil . Storable.singleton . queryStencil (unSnapshotTime time)) tss
+
+chordEntityStencil :: Storable.Vector QueryTime -> Storable.Vector InputTime -> EntityStencil
+chordEntityStencil qtimes ftimes =
+  EntityStencil $
+    Storable.map (flip queryStencil ftimes) qtimes
+
+chordStencil :: Segmented QueryTime -> Segmented InputTime -> Either StencilError Stencil
+chordStencil qtimes0 ftimes0 = do
+  checkEntityCounts qtimes0 ftimes0
+
+  qtimes <- fromSegmented qtimes0
+  ftimes <- fromSegmented ftimes0
+
+  pure . Stencil $
+    Boxed.zipWith chordEntityStencil qtimes ftimes

--- a/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
@@ -44,9 +44,17 @@ genTime64 =
       <*> Gen.integral (Range.constant 1 28)
       <*> Gen.integral (Range.constant 0 86399)
 
+genQueryTime :: Gen QueryTime
+genQueryTime =
+  QueryTime <$> genTime64
+
+genInputTime :: Gen InputTime
+genInputTime =
+  InputTime <$> genTime64
+
 genSnapshotTime :: Gen SnapshotTime
 genSnapshotTime =
-  SnapshotTime <$> genTime64
+  SnapshotTime <$> genQueryTime
 
 genError64 :: Gen Error64
 genError64 =
@@ -172,7 +180,7 @@ genEntityInputColumn schema = do
     n =
       Striped.length column
 
-  times <- Storable.fromList . List.sort <$> Gen.list (Range.singleton n) genTime64
+  times <- Storable.fromList . List.sort <$> Gen.list (Range.singleton n) genInputTime
   tombstones <- Storable.fromList <$> Gen.list (Range.singleton n) genTombstoneOrSuccess
 
   pure $ InputColumn (Storable.singleton $ fromIntegral n) times tombstones column

--- a/icicle-compiler/test/Icicle/Test/Runtime/Corpus.hs
+++ b/icicle-compiler/test/Icicle/Test/Runtime/Corpus.hs
@@ -97,7 +97,7 @@ evalWellTypedRuntime stime0 maxMapSize cid wt = do
 
   let
     stime =
-      SnapshotTime . Time64 $ packedOfTime stime0
+      SnapshotTime . QueryTime . Time64 $ packedOfTime stime0
 
   input <- evalEither $ fromInputs [inputid|test:input|] (wtInputType wt) (wtInputs wt)
   output0 <- evalExceptT . hoist liftIO $ snapshotBlock runtime maxMapSize stime input

--- a/icicle-compiler/test/Icicle/Test/Runtime/Evaluator.hs
+++ b/icicle-compiler/test/Icicle/Test/Runtime/Evaluator.hs
@@ -28,7 +28,7 @@ import qualified Icicle.Runtime.Data.Striped as Striped
 import qualified Icicle.Runtime.Evaluator as Runtime
 import           Icicle.Test.Gen.Data.Fact
 import           Icicle.Test.Gen.Data.Name
-import           Icicle.Test.Gen.Runtime.Data (genEntityInputColumn, genEntityKey, genTime64)
+import           Icicle.Test.Gen.Runtime.Data (genEntityInputColumn, genEntityKey, genSnapshotTime)
 
 import           P
 
@@ -148,13 +148,13 @@ takeInput et =
   Input (testEntities et) (fmap concatEntities $ testInputs et)
 
 takeWhileBefore :: SnapshotTime -> InputColumn -> InputColumn
-takeWhileBefore (SnapshotTime stime) icolumn =
+takeWhileBefore (SnapshotTime (QueryTime stime)) icolumn =
   if Storable.length (inputLength icolumn) /= 1 then
     Savage.error "takeWhileBefore: this function only works for a single entities"
   else
     let
       time =
-        Storable.takeWhile (< stime) $ inputTime icolumn
+        Storable.takeWhile (< InputTime stime) $ inputTime icolumn
 
       n =
         Storable.length time
@@ -175,7 +175,7 @@ prop_evaluator_roundtrip :: Property
 prop_evaluator_roundtrip =
   withTests 100 . property $ do
     et@(EvaluatorTest dictionary _entities _inputs) <- forAll genEvaluatorTest
-    stime <- forAll $ SnapshotTime <$> genTime64
+    stime <- forAll genSnapshotTime
 
     ccoptions0 <- Runtime.getCompilerOptions
 

--- a/icicle-compiler/test/Icicle/Test/Runtime/Stencil.hs
+++ b/icicle-compiler/test/Icicle/Test/Runtime/Stencil.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE NoImplicitPrelude #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
+module Icicle.Test.Runtime.Stencil where
+
+import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Morph (hoist)
+
+import           Data.Map (Map)
+import qualified Data.Map.Strict as Map
+import qualified Data.Set as Set
+import qualified Data.Text as Text
+import qualified Data.Vector as Boxed
+import qualified Data.Vector.Storable as Storable
+
+import           Foreign.Storable (Storable)
+
+import           Hedgehog
+import qualified Hedgehog.Gen as Gen
+import qualified Hedgehog.Range as Range
+
+import           Icicle.Runtime.Data
+import           Icicle.Runtime.Stencil
+import           Icicle.Test.Gen.Runtime.Data
+
+import           P
+
+import           System.IO (IO)
+
+
+genSegment :: Storable a => Gen a -> Gen (Segmented a)
+genSegment gen = do
+  xss <- Gen.list (Range.linear 0 10) $ Gen.list (Range.linear 0 10) gen
+  pure . toSegmented . Boxed.fromList $ fmap Storable.fromList xss
+
+prop_snapshot_chord_compare :: Property
+prop_snapshot_chord_compare =
+  property $ do
+    time0 <- forAll genSnapshotTime
+    time1 <- forAll genSnapshotTime
+    itimes <- forAll $ genSegment genInputTime
+
+    let
+      qtimes =
+        toSegmented .
+        Boxed.map (const $ Storable.fromList [unSnapshotTime time0, unSnapshotTime time1]) .
+        Boxed.convert $
+        segmentedLength itimes
+
+    snapshot0 <- evalEither $ snapshotStencil time0 itimes
+    snapshot1 <- evalEither $ snapshotStencil time1 itimes
+    chord <- evalEither $ chordStencil qtimes itimes
+
+    zipStencil snapshot0 snapshot1 === chord
+
+return []
+tests :: IO Bool
+tests =
+  checkParallel $$(discover)


### PR DESCRIPTION
This isn't hooked up yet, but the idea is that a stencil can slice out the relevant facts for a given query time. For a chord there are multiple fact counts per entity, for a snapshot there is just one per entity.

! @tranma @amosr 