### PR TITLE
Allow empty output blocks

### DIFF
--- a/icicle-compiler/src/Icicle/Command/Query.hs
+++ b/icicle-compiler/src/Icicle/Command/Query.hs
@@ -169,8 +169,10 @@ writeZebra :: (MonadResource m, MonadCatch m) => OutputZebra -> Stream (Of Zebra
 writeZebra (OutputZebra path) xs =
   let
     bss =
-      hoist (firstT QueryZebraBinaryStripedEncodeError) $
-        Zebra.encodeStriped xs
+      hoist (firstJoin QueryZebraBinaryStripedEncodeError) .
+        Zebra.encodeStriped .
+      hoist (firstT QueryZebraStripedError) $
+        Zebra.rechunk 1024 xs
   in
     firstJoin QueryIOError $
       ByteStream.writeFile path bss

--- a/icicle-compiler/src/Icicle/Runtime/Evaluator.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Evaluator.hs
@@ -514,7 +514,7 @@ runQuery cluster maxMapSize stencil input =
 
         case Cons.fromVector columns of
           Nothing ->
-            left $ RuntimeClusterHadNoOutputs (clusterId cluster)
+            hoistEither $ mkOutputColumns (Striped.empty outputSchema)
           Just xss0 -> do
             xss <- hoistEither . first RuntimeStripedError $ Striped.unsafeConcat xss0
             hoistEither $ mkOutputColumns xss


### PR DESCRIPTION
When running a chord it's common for an input block to produce no outputs