### PR TITLE
Pretty with annotations

### DIFF
--- a/icicle-source/src/Icicle/Source/PrettyAnnot.hs
+++ b/icicle-source/src/Icicle/Source/PrettyAnnot.hs
@@ -78,6 +78,7 @@ instance (Pretty a, Pretty n) => Pretty (PrettyAnnot (Exp a n)) where
     primRequiresAnnot = \case
      Op o -> case o of
       ArithUnary{}    -> True
+      ArithBinary{}   -> True
       ArithDouble{}   -> False
       Relation{}      -> True
       LogicalUnary{}  -> False


### PR DESCRIPTION
When prettying with annotations, we were annotating the return type of the let, instead of the binding type, which is kind of confusing. It was also printing the expressions in lets and folds without annotations, so I changed that. Also, there's not much point annotating monomorphic primitives. `True:{Bool}` is boring, but `None:{Option Double}` is interesting.

Example below. It's not as pretty because of the annotations inside the case, now, but I think it's more useful.

```
feature "injury"
~> let v:{ (Bool, Int) } =
     ((,):{ (Bool, Int) } True 1)
~> fold s2:{ Bool } =
     False : case:{ Element (Definitely Bool) } case:{ Element (Definitely Bool) } v:{ (Bool, Unit) }
     | (desugar_q-0, desugar_q-1) ->
         desugar_q-0:{ Element Bool }
     end
     | True ->
         False
     | False ->
         True
     end
~> s2:{ Aggregate (Definitely Bool) }
```

! @jystic @tranma 
/jury approved @jystic