### PR TITLE
Typechecking error: was throwing away information

### DIFF
--- a/icicle-compiler/test/cli/repl/t13-cases-either/expected
+++ b/icicle-compiler/test/cli/repl/t13-cases-either/expected
@@ -77,4 +77,17 @@ Core evaluation
 homer|0
 marge|0
 
-λ 
+λ λ -- Nested case with a polymorphic scrutinee (Num a => (Bool,a))
+λ Type
+----
+
+repl:output :
+  Aggregate (Definitely Bool)
+
+Core evaluation
+---------------
+
+homer|False
+marge|False
+
+λ λ 

--- a/icicle-compiler/test/cli/repl/t13-cases-either/script
+++ b/icicle-compiler/test/cli/repl/t13-cases-either/script
@@ -8,3 +8,7 @@ feature salary ~> fold perhaps = Left 0 : case perhaps | Right i -> Left i | Lef
 
 -- Cases can be strange
 feature salary ~> windowed 1 days ~> case None | Some a -> Some a | None -> Some 0 end
+
+-- Nested case with a polymorphic scrutinee (Num a => (Bool,a))
+feature salary ~> let v = (True,1) ~> fold s2 = False : case (case v | (a,b) -> a end) | True -> False | False -> True end ~> s2
+

--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -617,12 +617,13 @@ generateX x env
            let t'    = canonT
                      $ Temporality returnTemp'
                      $ Possibility returnPoss' returnType
+           let subs' = compose sub subs
            let cons' = concat [consS, consTj, consPs, consA]
 
            let x' = annotate cons' t'
                   $ \a' -> Case a' scrut' pats'
 
-           return (x', subs, cons')
+           return (x', subs', cons')
   where
   annotate cs t' f
    = let a' = Annot (annotOfExp x) t' cs


### PR DESCRIPTION
I broke case expressions when I rewrote the `generateP` constraint generation function.
The `case` typechecking was typechecking the scrutinee and getting its type, as well as keeping the substitution (the things you learned while typechecking). And it was sending the substitution downwards, but when it returned the new substitution upwards, I forgot to include the scrutinee part.

```
Num t0; v : (Bool, t0) |- case (fst v) | True -> False | False -> True end 
```

when you typecheck the scrutinee, you introduce new type variables `t1` and `t2` for the arguments to `fst`, before unifying them with the type of `v`. So you learn that `t1 = Bool` and `t2 = t0`. But if you don't return the substitution upwards, you forget the fact that `t2 = t0`, and end up with the annotated program saying that the `(fst : (Bool,t2) -> Bool)`, which gets defaulted to unit at the top-level.

Anyway this fixes it.

! @jystic @tranma 
/jury approved @jystic