### PR TITLE
Generate Ord type based on original type. Generate map primitives with Ord

### DIFF
--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -56,7 +56,7 @@ genPrimMany genT = do
     , PrimMap   <$> (PrimMapLookup            <$> genOrdValTypeOf' genT <*> genT)
     , PrimArray <$> (PrimArrayMap   <$> genT  <*> genT)
     -- TODO: missing PrimWindow; investigate conversion of windows to Avalanche and reinstate
-    -- , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
+    , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
     ]
 
   -- Generate buffer prims in pairs so for a given size and type we can always push and read

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -50,10 +50,10 @@ genPrimMany genT = do
     , PrimFold  <$> (PrimFoldOption <$> genT) <*> genT
     , PrimFold  <$> (PrimFoldSum    <$> genT  <*> genT) <*> genT
     , PrimFold  <$> (PrimFoldMap    <$> genT  <*> genT) <*> genT
-    , PrimMap   <$> (PrimMapInsertOrUpdate    <$> genT  <*> genT)
-    , PrimMap   <$> (PrimMapMapValues         <$> genT  <*> genT <*> genT)
-    , PrimMap   <$> (PrimMapDelete            <$> genT  <*> genT)
-    , PrimMap   <$> (PrimMapLookup            <$> genT  <*> genT)
+    , PrimMap   <$> (PrimMapInsertOrUpdate    <$> genOrdValTypeOf' genT <*> genT)
+    , PrimMap   <$> (PrimMapMapValues         <$> genOrdValTypeOf' genT <*> genT <*> genT)
+    , PrimMap   <$> (PrimMapDelete            <$> genOrdValTypeOf' genT <*> genT)
+    , PrimMap   <$> (PrimMapLookup            <$> genOrdValTypeOf' genT <*> genT)
     , PrimArray <$> (PrimArrayMap   <$> genT  <*> genT)
     -- TODO: missing PrimWindow; investigate conversion of windows to Avalanche and reinstate
     -- , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
@@ -192,8 +192,8 @@ genPrimBuiltinMath = Gen.element
 
 genPrimBuiltinMap :: Gen ValType -> Gen PM.PrimBuiltinMap
 genPrimBuiltinMap genT = Gen.choice
-    [ PM.PrimBuiltinKeys <$> genT <*> genT
-    , PM.PrimBuiltinVals <$> genT <*> genT ]
+    [ PM.PrimBuiltinKeys <$> genOrdValTypeOf' genT <*> genT
+    , PM.PrimBuiltinVals <$> genOrdValTypeOf' genT <*> genT ]
 
 -- TODO: missing PrimBuiltinIndex; modify index to be safe.
 -- Returning an Option would probably be fine for Core, if we had an explicitly unsafe primitive in Flat.

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -55,7 +55,6 @@ genPrimMany genT = do
     , PrimMap   <$> (PrimMapDelete            <$> genOrdValTypeOf' genT <*> genT)
     , PrimMap   <$> (PrimMapLookup            <$> genOrdValTypeOf' genT <*> genT)
     , PrimArray <$> (PrimArrayMap   <$> genT  <*> genT)
-    -- TODO: missing PrimWindow; investigate conversion of windows to Avalanche and reinstate
     , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
     ]
 

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
@@ -144,7 +144,8 @@ genOrdValTypeOf t = case t of
    -> Gen.choice [genOrdValTypeOf k, genOrdValTypeOf v]
   BufT _ a
    -> genOrdValTypeOf a
-  -- Generate a primitive if we can't
+  -- Generate a primitive if we can't salvage any of it.
+  -- Eg. if the input type is Double
   _
    -> genOrdValType
 

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
@@ -209,7 +209,7 @@ genOutputType = Gen.recursive Gen.choice
   , SumT ErrorT <$> genOutputType
   , PairT   <$> genOutputType <*> genOutputType
   , ArrayT  <$> genOutputType
-  , MapT    <$> genPrimType   <*> genOutputType
+  , MapT    <$> genOrdValType <*> genOutputType
   , StructT <$> genStructType' genOutputType
   ]
 

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Type.hs
@@ -108,7 +108,11 @@ genStructField = StructField <$> Gen.element colours
 --
 genOrdValType :: Gen ValType
 genOrdValType = Gen.recursive Gen.choice
-    genPrimTypes
+  [ return UnitT
+  , return BoolT
+  , return IntT
+  , return TimeT
+  , return StringT ]
   [ PairT   <$> genOrdValType <*> genOrdValType
   , OptionT <$> genOrdValType
   , SumT    <$> genOrdValType <*> genOrdValType
@@ -152,10 +156,11 @@ isOrdValType t = case t of
  IntT       -> True
  UnitT      -> True
  BoolT      -> True
- DoubleT    -> True
  TimeT      -> True
  StringT    -> True
  ErrorT     -> True
+ -- Double is not "Ord" because NaN cannot be used as the key of a Map.
+ DoubleT    -> False
  PairT a b  -> isOrdValType a && isOrdValType b
  SumT a b   -> isOrdValType a && isOrdValType b
  OptionT a  -> isOrdValType a


### PR DESCRIPTION
Don't generate Map primitives with arrays as the keys.
#625 

! @jystic @tranma 
/jury approved @jystic