### PR TITLE
Safe array indexing

### DIFF
--- a/data/sea/00-includes.h
+++ b/data/sea/00-includes.h
@@ -35,6 +35,8 @@ static const ierror_t ierror_not_an_error           = 0;
 static const ierror_t ierror_tombstone              = 1;
 static const ierror_t ierror_fold1_no_value         = 2;
 static const ierror_t ierror_cannot_compute         = 3;
+static const ierror_t ierror_not_a_number           = 4;
+static const ierror_t ierror_index_out_of_bounds    = 5;
 
 static const iunit_t iunit  = 0x13013;
 static const ibool_t ifalse = 0;

--- a/doc/internals/icicle-v0.bnf
+++ b/doc/internals/icicle-v0.bnf
@@ -295,6 +295,8 @@
                |  ExceptTombstone
                |  ExceptFold1NoValue
                |  ExceptCannotCompute
+               |  ExceptNotANumber
+               |  ExceptIndexOutOfBounds
 
 <window>      ::= <integer> <window-unit>
                |  between <integer> <window-unit> and <integer> <window-unit>

--- a/doc/internals/sorbet.bnf
+++ b/doc/internals/sorbet.bnf
@@ -366,3 +366,5 @@
                   |  ExceptTombstone
                   |  ExceptFold1NoValue
                   |  ExceptCannotCompute
+                  |  ExceptNotANumber
+                  |  ExceptIndexOutOfBounds

--- a/icicle-compiler/src/Icicle/Repl/Query.hs
+++ b/icicle-compiler/src/Icicle/Repl/Query.hs
@@ -335,13 +335,15 @@ compileQuery query = do
   -- Flatten Avalanche, not simplified.
   --
 
-  case Compiler.flattenAvalanche avalancheSimped of
+  case Compiler.flattenAvalancheUntyped avalancheSimped of
     Left err ->
       putSection "Flatten Avalanche (not simplified) error" err
 
     Right avalancheFlatUnsimped ->
       case Compiler.checkAvalanche $ Avalanche.eraseAnnotP avalancheFlatUnsimped of
-        Left err ->
+        Left err -> do
+          whenSet FlagFlattenNoSimp $
+            putSection "Flattened Avalanche (not simplified)" avalancheFlatUnsimped
           putSection "Flattened Avalanche (not simplified) type error" err
         Right flatUnsimpedChecked ->
           whenSet FlagFlattenNoSimp $

--- a/icicle-compiler/src/Icicle/Runtime/Data/Logical.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/Logical.hs
@@ -272,6 +272,18 @@ prettyValue p schema = \case
       pure $
         annotate AnnError "CannotCompute"
 
+  Error NotANumber64
+    | Schema.Result _ <- schema
+    ->
+      pure $
+        annotate AnnError "NotANumber"
+
+  Error IndexOutOfBounds64
+    | Schema.Result _ <- schema
+    ->
+      pure $
+        annotate AnnError "IndexOutOfBounds"
+
   Error (Error64 x)
     | Schema.Result _ <- schema
     ->

--- a/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
@@ -29,6 +29,8 @@ module Icicle.Runtime.Data.Primitive (
   , pattern Tombstone64
   , pattern Fold1NoValue64
   , pattern CannotCompute64
+  , pattern NotANumber64
+  , pattern IndexOutOfBounds64
   , fromExceptionInfo
   , fromError64
   , isError
@@ -226,6 +228,18 @@ pattern CannotCompute64 :: Error64
 pattern CannotCompute64 =
   Error64 3
 
+#if __GLASGOW_HASKELL__ >= 800
+pattern NotANumber64 :: Error64
+#endif
+pattern NotANumber64 =
+  Error64 4
+
+#if __GLASGOW_HASKELL__ >= 800
+pattern IndexOutOfBounds64 :: Error64
+#endif
+pattern IndexOutOfBounds64 =
+  Error64 5
+
 fromExceptionInfo :: ExceptionInfo -> Error64
 fromExceptionInfo = \case
   ExceptNotAnError ->
@@ -236,6 +250,10 @@ fromExceptionInfo = \case
     Fold1NoValue64
   ExceptCannotCompute ->
     CannotCompute64
+  ExceptNotANumber ->
+    NotANumber64
+  ExceptIndexOutOfBounds ->
+    Tombstone64
 {-# INLINE fromExceptionInfo #-}
 
 isError :: Error64 -> Bool
@@ -256,6 +274,10 @@ fromError64 = \case
     Just ExceptFold1NoValue
   CannotCompute64 ->
     Just ExceptCannotCompute
+  NotANumber64 ->
+    Just ExceptNotANumber
+  IndexOutOfBounds64 ->
+    Just ExceptIndexOutOfBounds
   _ ->
     Nothing
 {-# INLINE fromError64 #-}

--- a/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Data/Primitive.hs
@@ -153,11 +153,15 @@ instance Storable UnpackedTime64 where
 newtype Error64 =
   Error64 {
       unError64 :: Word64
-    } deriving (Eq, Ord, Generic, Storable)
+    } deriving (Eq, Ord, Generic, Storable, Enum)
 
 instance Show Error64 where
   showsPrec =
     gshowsPrec
+
+instance Bounded Error64 where
+  minBound = NotAnError64
+  maxBound = IndexOutOfBounds64
 
 -- | A named struct field.
 --
@@ -253,7 +257,7 @@ fromExceptionInfo = \case
   ExceptNotANumber ->
     NotANumber64
   ExceptIndexOutOfBounds ->
-    Tombstone64
+    IndexOutOfBounds64
 {-# INLINE fromExceptionInfo #-}
 
 isError :: Error64 -> Bool

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Schema.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Schema.hs
@@ -220,6 +220,8 @@ encodeColumnSchema = \case
         , (Zebra.Variant "tombstone" Zebra.Unit)
         , (Zebra.Variant "fold1_no_value" Zebra.Unit)
         , (Zebra.Variant "cannot_compute" Zebra.Unit)
+        , (Zebra.Variant "not_a_number" Zebra.Unit)
+        , (Zebra.Variant "index_out_of_bounds" Zebra.Unit)
         ]
 
   Icicle.Pair x y ->

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Schema.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Schema.hs
@@ -120,7 +120,9 @@ decodeColumnSchema = \case
       [Zebra.Variant "success" x,
        Zebra.Variant "tombstone" Zebra.Unit,
        Zebra.Variant "fold1_no_value" Zebra.Unit,
-       Zebra.Variant "cannot_compute" Zebra.Unit] ->
+       Zebra.Variant "cannot_compute" Zebra.Unit,
+       Zebra.Variant "not_a_number" Zebra.Unit,
+       Zebra.Variant "index_out_of_bounds" Zebra.Unit] ->
         Icicle.Result <$> decodeColumnSchema x
 
       _ ->

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Striped.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Striped.hs
@@ -319,6 +319,10 @@ decodeResultTags =
       pure Fold1NoValue64
     3 ->
       pure CannotCompute64
+    4 ->
+      pure NotANumber64
+    5 ->
+      pure IndexOutOfBounds64
     n ->
       Left $ ZebraStripedUnknownResultTag n
 
@@ -598,6 +602,10 @@ encodeErrorTags =
       pure 2
     CannotCompute64 ->
       pure 3
+    NotANumber64 ->
+      pure 4
+    IndexOutOfBounds64 ->
+      pure 5
     n ->
       Left $ ZebraStripedUnknownError64 n
 

--- a/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Striped.hs
+++ b/icicle-compiler/src/Icicle/Runtime/Serial/Zebra/Striped.hs
@@ -122,9 +122,9 @@ snoc xs0 x =
     Cons.from hd (tl <> Boxed.singleton x)
 
 -- FIXME x-vector
-from4 :: a -> a -> a -> a -> Cons Boxed.Vector a
-from4 x y z w =
-  Cons.unsafeFromList [x, y, z, w]
+from6 :: a -> a -> a -> a -> a -> a -> Cons Boxed.Vector a
+from6 u v w x y z=
+  Cons.unsafeFromList [u, v, w, x, y, z]
 
 -- FIXME zebra-core
 takeOption :: Zebra.Column -> Either Schema.SchemaError (Zebra.Default, Storable.Vector Zebra.Tag, Zebra.Column)
@@ -376,7 +376,9 @@ decodeColumn = \case
       [Zebra.Variant "success" x,
        Zebra.Variant "tombstone" (Zebra.Unit _),
        Zebra.Variant "fold1_no_value" (Zebra.Unit _),
-       Zebra.Variant "cannot_compute" (Zebra.Unit _)] ->
+       Zebra.Variant "cannot_compute" (Zebra.Unit _),
+       Zebra.Variant "not_a_number" (Zebra.Unit _),
+       Zebra.Variant "index_out_of_bounds" (Zebra.Unit _)] ->
         Icicle.Result <$> decodeResultTags tags <*> decodeColumn x
 
       _ ->
@@ -653,11 +655,13 @@ encodeColumn = \case
   Icicle.Result tags x ->
     Zebra.Enum Zebra.DenyDefault
       <$> encodeErrorTags tags
-      <*> (from4
+      <*> (from6
         <$> (Zebra.Variant "success" <$> encodeColumn x)
         <*> pure (Zebra.Variant "tombstone" . Zebra.Unit $ Storable.length tags)
         <*> pure (Zebra.Variant "fold1_no_value" . Zebra.Unit $ Storable.length tags)
-        <*> pure (Zebra.Variant "cannot_compute" . Zebra.Unit $ Storable.length tags))
+        <*> pure (Zebra.Variant "cannot_compute" . Zebra.Unit $ Storable.length tags)
+        <*> pure (Zebra.Variant "not_a_number" . Zebra.Unit $ Storable.length tags)
+        <*> pure (Zebra.Variant "index_out_of_bounds" . Zebra.Unit $ Storable.length tags))
 
   Icicle.Pair x y ->
     fmap (Zebra.Struct Zebra.DenyDefault) $

--- a/icicle-compiler/src/Icicle/Sea/FromAvalanche/Program.hs
+++ b/icicle-compiler/src/Icicle/Sea/FromAvalanche/Program.hs
@@ -339,3 +339,9 @@ seaOfError e
      ExceptCannotCompute
       -> "ierror_cannot_compute"
 
+     ExceptNotANumber
+      -> "ierror_not_a_number"
+
+     ExceptIndexOutOfBounds
+      -> "ierror_index_out_of_bounds"
+

--- a/icicle-compiler/test/Icicle/Test/Core/Exp/Simp.hs
+++ b/icicle-compiler/test/Icicle/Test/Core/Exp/Simp.hs
@@ -87,10 +87,12 @@ prop_core_simp_type = property $ do
 -- Core simplification preserves result
 prop_core_simp_eval = property $ do
   x <- forAll (fst <$> genExpTop)
-  eval0 evalPrim x `hedgehogNanEq` eval0 evalPrim
-   ( snd
-   $ Fresh.runFresh (CoreSimp.simp () x)
-                    (Fresh.counterNameState (NameBase . Var "anf") 0))
+  annotate (show . pretty $ x)
+  let x' = snd
+         $ Fresh.runFresh (CoreSimp.simp () x)
+                          (Fresh.counterNameState (NameBase . Var "anf") 0)
+  annotate (show . pretty $ x')
+  eval0 evalPrim x `hedgehogNanEq` eval0 evalPrim x'
 
 
 return []

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -183,12 +183,11 @@ genPrimBuiltinMap genT = Gen.choice
     [ PM.PrimBuiltinKeys <$> genOrdValTypeOf' genT <*> genT
     , PM.PrimBuiltinVals <$> genOrdValTypeOf' genT <*> genT ]
 
--- TODO: missing PrimBuiltinIndex; modify index to be safe.
--- Returning an Option would probably be fine for Core, if we had an explicitly unsafe primitive in Flat.
 genPrimBuiltinArray :: Gen ValType -> Gen PM.PrimBuiltinArray
 genPrimBuiltinArray genT = Gen.choice
   [ PM.PrimBuiltinSort <$> genT
-  , PM.PrimBuiltinLength <$> genT ]
+  , PM.PrimBuiltinLength <$> genT
+  , PM.PrimBuiltinIndex <$> genT ]
 
 genPrimBuiltinFun :: Gen ValType -> Gen PM.PrimBuiltinFun
 genPrimBuiltinFun genT = Gen.choice

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
@@ -62,16 +62,16 @@ baseValueForType t
      -> Gen.small
       (VStruct <$> traverse baseValueForType fs)
 
-genExceptionInfo :: Gen ExceptionInfo
-genExceptionInfo
+genExceptionInfo :: MonadGen m => m ExceptionInfo
+genExceptionInfo = do
  -- Because of the melted representation of (Sum Error a), we cannot distinguish between these two:
  -- > Left  ExceptNotAnError
  -- > Right default
  -- So we cannot generate NotAnError.
  e <- Gen.enumBounded
  case e of
-  NotAnError
-    -> return Tombstone
+  ExceptNotAnError
+    -> return ExceptTombstone
   _ -> return e
 
 r10 :: Integral a => Range a

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
@@ -33,7 +33,7 @@ baseValueForType t
     UnitT
      -> return VUnit
     ErrorT
-     -> return $ VError ExceptTombstone
+     -> VError <$> Gen.enumBounded
     BoolT
      -> VBool <$> Gen.bool
     TimeT

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Value.hs
@@ -33,7 +33,7 @@ baseValueForType t
     UnitT
      -> return VUnit
     ErrorT
-     -> VError <$> Gen.enumBounded
+     -> VError <$> genExceptionInfo
     BoolT
      -> VBool <$> Gen.bool
     TimeT
@@ -61,6 +61,18 @@ baseValueForType t
     StructT (StructType fs)
      -> Gen.small
       (VStruct <$> traverse baseValueForType fs)
+
+genExceptionInfo :: Gen ExceptionInfo
+genExceptionInfo
+ -- Because of the melted representation of (Sum Error a), we cannot distinguish between these two:
+ -- > Left  ExceptNotAnError
+ -- > Right default
+ -- So we cannot generate NotAnError.
+ e <- Gen.enumBounded
+ case e of
+  NotAnError
+    -> return Tombstone
+  _ -> return e
 
 r10 :: Integral a => Range a
 r10 = Range.linear 0 10

--- a/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
@@ -59,11 +59,16 @@ genSnapshotTime =
 
 genError64 :: Gen Error64
 genError64 =
-  Gen.element [NotAnError64, Tombstone64, Fold1NoValue64, CannotCompute64, NotANumber64, IndexOutOfBounds64]
+  Gen.enumBounded
 
 genResultError :: Gen Error64
-genResultError =
-  Gen.element [Tombstone64, Fold1NoValue64, CannotCompute64, NotANumber64, IndexOutOfBounds64]
+genResultError = do
+ -- Generate any tag, but if it's NotAnError just return Tombstone.
+ e <- genError64
+ case e of
+  NotAnError64
+    -> return Tombstone64
+  _ -> return e
 
 genTombstoneOrSuccess :: Gen Error64
 genTombstoneOrSuccess =

--- a/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Runtime/Data.hs
@@ -59,11 +59,11 @@ genSnapshotTime =
 
 genError64 :: Gen Error64
 genError64 =
-  Gen.element [NotAnError64, Tombstone64, Fold1NoValue64, CannotCompute64]
+  Gen.element [NotAnError64, Tombstone64, Fold1NoValue64, CannotCompute64, NotANumber64, IndexOutOfBounds64]
 
 genResultError :: Gen Error64
 genResultError =
-  Gen.element [Tombstone64, Fold1NoValue64, CannotCompute64]
+  Gen.element [Tombstone64, Fold1NoValue64, CannotCompute64, NotANumber64, IndexOutOfBounds64]
 
 genTombstoneOrSuccess :: Gen Error64
 genTombstoneOrSuccess =

--- a/icicle-compiler/test/cli/repl/t30-sea/expected
+++ b/icicle-compiler/test/cli/repl/t30-sea/expected
@@ -157,7 +157,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-35-simpflat-70 =w ExceptCannotCompute
+                    flat-35-simpflat-70 =w ExceptNotANumber
                     flat-35-simpflat-71 =w 0.0
                 }
                 
@@ -196,7 +196,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-28-simpflat-78 =w ExceptCannotCompute
+                    flat-28-simpflat-78 =w ExceptNotANumber
                     flat-28-simpflat-79 =w 0.0
                 }
                 
@@ -224,7 +224,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-32-simpflat-84 =w ExceptCannotCompute
+                        flat-32-simpflat-84 =w ExceptNotANumber
                         flat-32-simpflat-85 =w 0.0
                     }
                     
@@ -274,7 +274,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-25-simpflat-94 =w ExceptCannotCompute
+                    flat-25-simpflat-94 =w ExceptNotANumber
                     flat-25-simpflat-95 =w 0.0
                 }
                 
@@ -314,7 +314,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-19-simpflat-103 =w ExceptCannotCompute
+                    flat-19-simpflat-103 =w ExceptNotANumber
                     flat-19-simpflat-104 =w 0.0
                 }
                 
@@ -555,7 +555,7 @@ for_facts conv-1 : Time
             }
             else
             {
-                flat-44-simpflat-164 =w ExceptCannotCompute
+                flat-44-simpflat-164 =w ExceptNotANumber
                 flat-44-simpflat-165 =w 0.0
             }
             
@@ -583,7 +583,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-89-simpflat-170 =w ExceptCannotCompute
+                    flat-89-simpflat-170 =w ExceptNotANumber
                     flat-89-simpflat-171 =w 0.0
                 }
                 
@@ -629,7 +629,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-86-simpflat-180 =w ExceptCannotCompute
+                        flat-86-simpflat-180 =w ExceptNotANumber
                         flat-86-simpflat-181 =w 0.0
                     }
                     
@@ -679,7 +679,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-80-simpflat-190 =w ExceptCannotCompute
+                    flat-80-simpflat-190 =w ExceptNotANumber
                     flat-80-simpflat-191 =w 0.0
                 }
                 
@@ -732,7 +732,7 @@ for_facts conv-1 : Time
                         }
                         else
                         {
-                            flat-77-simpflat-202 =w ExceptCannotCompute
+                            flat-77-simpflat-202 =w ExceptNotANumber
                             flat-77-simpflat-203 =w 0.0
                         }
                         
@@ -782,7 +782,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-71-simpflat-212 =w ExceptCannotCompute
+                        flat-71-simpflat-212 =w ExceptNotANumber
                         flat-71-simpflat-213 =w 0.0
                     }
                     
@@ -832,7 +832,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-64-simpflat-222 =w ExceptCannotCompute
+                    flat-64-simpflat-222 =w ExceptNotANumber
                     flat-64-simpflat-223 =w 0.0
                 }
                 
@@ -1033,7 +1033,7 @@ if (eq#
         }
         else
         {
-            flat-121-simpflat-275 =w ExceptCannotCompute
+            flat-121-simpflat-275 =w ExceptNotANumber
             flat-121-simpflat-276 =w 0.0
         }
         
@@ -1061,7 +1061,7 @@ if (eq#
             }
             else
             {
-                flat-125-simpflat-281 =w ExceptCannotCompute
+                flat-125-simpflat-281 =w ExceptNotANumber
                 flat-125-simpflat-282 =w 0.0
             }
             
@@ -1109,7 +1109,7 @@ if (eq#
         }
         else
         {
-            flat-118-simpflat-291 =w ExceptCannotCompute
+            flat-118-simpflat-291 =w ExceptNotANumber
             flat-118-simpflat-292 =w 0.0
         }
         
@@ -1148,7 +1148,7 @@ if (eq#
         }
         else
         {
-            flat-115-simpflat-299 =w ExceptCannotCompute
+            flat-115-simpflat-299 =w ExceptNotANumber
             flat-115-simpflat-300 =w 0.0
         }
         
@@ -1317,7 +1317,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-35-simpflat-70 =w ExceptCannotCompute
+                    flat-35-simpflat-70 =w ExceptNotANumber
                     flat-35-simpflat-71 =w 0.0
                 }
                 
@@ -1356,7 +1356,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-28-simpflat-78 =w ExceptCannotCompute
+                    flat-28-simpflat-78 =w ExceptNotANumber
                     flat-28-simpflat-79 =w 0.0
                 }
                 
@@ -1384,7 +1384,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-32-simpflat-84 =w ExceptCannotCompute
+                        flat-32-simpflat-84 =w ExceptNotANumber
                         flat-32-simpflat-85 =w 0.0
                     }
                     
@@ -1434,7 +1434,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-25-simpflat-94 =w ExceptCannotCompute
+                    flat-25-simpflat-94 =w ExceptNotANumber
                     flat-25-simpflat-95 =w 0.0
                 }
                 
@@ -1474,7 +1474,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-19-simpflat-103 =w ExceptCannotCompute
+                    flat-19-simpflat-103 =w ExceptNotANumber
                     flat-19-simpflat-104 =w 0.0
                 }
                 
@@ -1715,7 +1715,7 @@ for_facts conv-1 : Time
             }
             else
             {
-                flat-44-simpflat-164 =w ExceptCannotCompute
+                flat-44-simpflat-164 =w ExceptNotANumber
                 flat-44-simpflat-165 =w 0.0
             }
             
@@ -1743,7 +1743,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-89-simpflat-170 =w ExceptCannotCompute
+                    flat-89-simpflat-170 =w ExceptNotANumber
                     flat-89-simpflat-171 =w 0.0
                 }
                 
@@ -1789,7 +1789,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-86-simpflat-180 =w ExceptCannotCompute
+                        flat-86-simpflat-180 =w ExceptNotANumber
                         flat-86-simpflat-181 =w 0.0
                     }
                     
@@ -1839,7 +1839,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-80-simpflat-190 =w ExceptCannotCompute
+                    flat-80-simpflat-190 =w ExceptNotANumber
                     flat-80-simpflat-191 =w 0.0
                 }
                 
@@ -1892,7 +1892,7 @@ for_facts conv-1 : Time
                         }
                         else
                         {
-                            flat-77-simpflat-202 =w ExceptCannotCompute
+                            flat-77-simpflat-202 =w ExceptNotANumber
                             flat-77-simpflat-203 =w 0.0
                         }
                         
@@ -1942,7 +1942,7 @@ for_facts conv-1 : Time
                     }
                     else
                     {
-                        flat-71-simpflat-212 =w ExceptCannotCompute
+                        flat-71-simpflat-212 =w ExceptNotANumber
                         flat-71-simpflat-213 =w 0.0
                     }
                     
@@ -1992,7 +1992,7 @@ for_facts conv-1 : Time
                 }
                 else
                 {
-                    flat-64-simpflat-222 =w ExceptCannotCompute
+                    flat-64-simpflat-222 =w ExceptNotANumber
                     flat-64-simpflat-223 =w 0.0
                 }
                 
@@ -2193,7 +2193,7 @@ if (eq#
         }
         else
         {
-            flat-121-simpflat-275 =w ExceptCannotCompute
+            flat-121-simpflat-275 =w ExceptNotANumber
             flat-121-simpflat-276 =w 0.0
         }
         
@@ -2221,7 +2221,7 @@ if (eq#
             }
             else
             {
-                flat-125-simpflat-281 =w ExceptCannotCompute
+                flat-125-simpflat-281 =w ExceptNotANumber
                 flat-125-simpflat-282 =w 0.0
             }
             
@@ -2269,7 +2269,7 @@ if (eq#
         }
         else
         {
-            flat-118-simpflat-291 =w ExceptCannotCompute
+            flat-118-simpflat-291 =w ExceptNotANumber
             flat-118-simpflat-292 =w 0.0
         }
         
@@ -2308,7 +2308,7 @@ if (eq#
         }
         else
         {
-            flat-115-simpflat-299 =w ExceptCannotCompute
+            flat-115-simpflat-299 =w ExceptNotANumber
             flat-115-simpflat-300 =w 0.0
         }
         
@@ -2813,7 +2813,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm35zmsimpflatzm70 = ierror_not_an_error;                 /* write */
                         flatzm35zmsimpflatzm71 = idouble_sub (convzm10zmavalzm1zmsimpflatzm54, szmreifyzm6zmconvzm11zmavalzm0zmsimpflatzm60); /* write */
                     } else {
-                        flatzm35zmsimpflatzm70 = ierror_cannot_compute;               /* write */
+                        flatzm35zmsimpflatzm70 = ierror_not_a_number;                 /* write */
                         flatzm35zmsimpflatzm71 = 0.0;                                 /* write */
                     }
                     
@@ -2840,7 +2840,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm28zmsimpflatzm78 = ierror_not_an_error;                 /* write */
                         flatzm28zmsimpflatzm79 = idouble_add (szmreifyzm6zmconvzm11zmavalzm0zmsimpflatzm61, 1.0); /* write */
                     } else {
-                        flatzm28zmsimpflatzm78 = ierror_cannot_compute;               /* write */
+                        flatzm28zmsimpflatzm78 = ierror_not_a_number;                 /* write */
                         flatzm28zmsimpflatzm79 = 0.0;                                 /* write */
                     }
                     
@@ -2858,7 +2858,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                             flatzm32zmsimpflatzm84 = ierror_not_an_error;             /* write */
                             flatzm32zmsimpflatzm85 = idouble_div (flatzm13zmsimpflatzm75, flatzm28zmsimpflatzm81); /* write */
                         } else {
-                            flatzm32zmsimpflatzm84 = ierror_cannot_compute;           /* write */
+                            flatzm32zmsimpflatzm84 = ierror_not_a_number;             /* write */
                             flatzm32zmsimpflatzm85 = 0.0;                             /* write */
                         }
                         
@@ -2894,7 +2894,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm25zmsimpflatzm94 = ierror_not_an_error;                 /* write */
                         flatzm25zmsimpflatzm95 = idouble_add (szmreifyzm6zmconvzm11zmavalzm0zmsimpflatzm60, flatzm14zmsimpflatzm91); /* write */
                     } else {
-                        flatzm25zmsimpflatzm94 = ierror_cannot_compute;               /* write */
+                        flatzm25zmsimpflatzm94 = ierror_not_a_number;                 /* write */
                         flatzm25zmsimpflatzm95 = 0.0;                                 /* write */
                     }
                     
@@ -2922,7 +2922,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm19zmsimpflatzm103 = ierror_not_an_error;                /* write */
                         flatzm19zmsimpflatzm104 = idouble_add (szmreifyzm6zmconvzm11zmavalzm0zmsimpflatzm61, 1.0); /* write */
                     } else {
-                        flatzm19zmsimpflatzm103 = ierror_cannot_compute;              /* write */
+                        flatzm19zmsimpflatzm103 = ierror_not_a_number;                /* write */
                         flatzm19zmsimpflatzm104 = 0.0;                                /* write */
                     }
                     
@@ -3103,7 +3103,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                     flatzm44zmsimpflatzm164   = ierror_not_an_error;                  /* write */
                     flatzm44zmsimpflatzm165   = idouble_add (azmconvzm76zmavalzm2zmsimpflatzm157, 1.0); /* write */
                 } else {
-                    flatzm44zmsimpflatzm164   = ierror_cannot_compute;                /* write */
+                    flatzm44zmsimpflatzm164   = ierror_not_a_number;                  /* write */
                     flatzm44zmsimpflatzm165   = 0.0;                                  /* write */
                 }
                 
@@ -3121,7 +3121,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm89zmsimpflatzm170 = ierror_not_an_error;                /* write */
                         flatzm89zmsimpflatzm171 = idouble_sub (convzm75zmavalzm3zmsimpflatzm151, azmconvzm76zmavalzm2zmsimpflatzm158); /* write */
                     } else {
-                        flatzm89zmsimpflatzm170 = ierror_cannot_compute;              /* write */
+                        flatzm89zmsimpflatzm170 = ierror_not_a_number;                /* write */
                         flatzm89zmsimpflatzm171 = 0.0;                                /* write */
                     }
                     
@@ -3152,7 +3152,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                             flatzm86zmsimpflatzm180 = ierror_not_an_error;            /* write */
                             flatzm86zmsimpflatzm181 = idouble_div (flatzm45zmsimpflatzm175, flatzm44zmsimpflatzm167); /* write */
                         } else {
-                            flatzm86zmsimpflatzm180 = ierror_cannot_compute;          /* write */
+                            flatzm86zmsimpflatzm180 = ierror_not_a_number;            /* write */
                             flatzm86zmsimpflatzm181 = 0.0;                            /* write */
                         }
                         
@@ -3188,7 +3188,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm80zmsimpflatzm190 = ierror_not_an_error;                /* write */
                         flatzm80zmsimpflatzm191 = idouble_add (azmconvzm76zmavalzm2zmsimpflatzm158, flatzm46zmsimpflatzm187); /* write */
                     } else {
-                        flatzm80zmsimpflatzm190 = ierror_cannot_compute;              /* write */
+                        flatzm80zmsimpflatzm190 = ierror_not_a_number;                /* write */
                         flatzm80zmsimpflatzm191 = 0.0;                                /* write */
                     }
                     
@@ -3223,7 +3223,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                                 flatzm77zmsimpflatzm202 = ierror_not_an_error;        /* write */
                                 flatzm77zmsimpflatzm203 = idouble_sub (convzm75zmavalzm3zmsimpflatzm151, flatzm47zmsimpflatzm195); /* write */
                             } else {
-                                flatzm77zmsimpflatzm202 = ierror_cannot_compute;      /* write */
+                                flatzm77zmsimpflatzm202 = ierror_not_a_number;        /* write */
                                 flatzm77zmsimpflatzm203 = 0.0;                        /* write */
                             }
                             
@@ -3259,7 +3259,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                             flatzm71zmsimpflatzm212 = ierror_not_an_error;            /* write */
                             flatzm71zmsimpflatzm213 = idouble_mul (flatzm45zmsimpflatzm175, flatzm67zmsimpflatzm209); /* write */
                         } else {
-                            flatzm71zmsimpflatzm212 = ierror_cannot_compute;          /* write */
+                            flatzm71zmsimpflatzm212 = ierror_not_a_number;            /* write */
                             flatzm71zmsimpflatzm213 = 0.0;                            /* write */
                         }
                         
@@ -3295,7 +3295,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                         flatzm64zmsimpflatzm222 = ierror_not_an_error;                /* write */
                         flatzm64zmsimpflatzm223 = idouble_add (azmconvzm76zmavalzm2zmsimpflatzm159, flatzm48zmsimpflatzm219); /* write */
                     } else {
-                        flatzm64zmsimpflatzm222 = ierror_cannot_compute;              /* write */
+                        flatzm64zmsimpflatzm222 = ierror_not_a_number;                /* write */
                         flatzm64zmsimpflatzm223 = 0.0;                                /* write */
                     }
                     
@@ -3476,7 +3476,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                 flatzm121zmsimpflatzm275      = ierror_not_an_error;                  /* write */
                 flatzm121zmsimpflatzm276      = idouble_sub (azmconvzm76zmsimpflatzm261, 1.0); /* write */
             } else {
-                flatzm121zmsimpflatzm275      = ierror_cannot_compute;                /* write */
+                flatzm121zmsimpflatzm275      = ierror_not_a_number;                  /* write */
                 flatzm121zmsimpflatzm276      = 0.0;                                  /* write */
             }
             
@@ -3494,7 +3494,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                     flatzm125zmsimpflatzm281  = ierror_not_an_error;                  /* write */
                     flatzm125zmsimpflatzm282  = idouble_div (azmconvzm76zmsimpflatzm263, flatzm121zmsimpflatzm278); /* write */
                 } else {
-                    flatzm125zmsimpflatzm281  = ierror_cannot_compute;                /* write */
+                    flatzm125zmsimpflatzm281  = ierror_not_a_number;                  /* write */
                     flatzm125zmsimpflatzm282  = 0.0;                                  /* write */
                 }
                 
@@ -3530,7 +3530,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                 flatzm118zmsimpflatzm291      = ierror_not_an_error;                  /* write */
                 flatzm118zmsimpflatzm292      = idouble_sqrt (flatzm110zmsimpflatzm288); /* write */
             } else {
-                flatzm118zmsimpflatzm291      = ierror_cannot_compute;                /* write */
+                flatzm118zmsimpflatzm291      = ierror_not_a_number;                  /* write */
                 flatzm118zmsimpflatzm292      = 0.0;                                  /* write */
             }
             
@@ -3557,7 +3557,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                 flatzm115zmsimpflatzm299      = ierror_not_an_error;                  /* write */
                 flatzm115zmsimpflatzm300      = idouble_mul (flatzm106zmsimpflatzm270, flatzm111zmsimpflatzm296); /* write */
             } else {
-                flatzm115zmsimpflatzm299      = ierror_cannot_compute;                /* write */
+                flatzm115zmsimpflatzm299      = ierror_not_a_number;                  /* write */
                 flatzm115zmsimpflatzm300      = 0.0;                                  /* write */
             }
             

--- a/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
+++ b/icicle-compiler/test/cli/repl/t30.3-sum-not-error/expected
@@ -175,7 +175,7 @@ void icluster_0_kernel_0(icluster_0_t *s)
                     flatzm6zmsimpflatzm21     = ierror_not_an_error;                  /* write */
                     flatzm6zmsimpflatzm22     = idouble_add (simpflatzm66, 1.0);      /* write */
                 } else {
-                    flatzm6zmsimpflatzm21     = ierror_cannot_compute;                /* write */
+                    flatzm6zmsimpflatzm21     = ierror_not_a_number;                  /* write */
                     flatzm6zmsimpflatzm22     = 0.0;                                  /* write */
                 }
                 

--- a/icicle-compiler/test/cli/repl/t80-array-index/expected
+++ b/icicle-compiler/test/cli/repl/t80-array-index/expected
@@ -1,6 +1,6 @@
 Queries will no longer be evaluated using the C evaluator.
 Snapshot mode activated with a snapshot date of 2017-01-01.
-Loaded dictionary with 5 inputs, 0 outputs, 38 functions.
+Loaded dictionary with 5 inputs, 0 outputs, 39 functions.
 Selected psv file as input: test/cli/repl/data.psv
 
   ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
@@ -15,7 +15,7 @@ Selected psv file as input: test/cli/repl/data.psv
      ░            ░
                   ░     :help for help
 
-λ Loaded dictionary with 5 inputs, 0 outputs, 38 functions.
+λ Loaded dictionary with 5 inputs, 0 outputs, 39 functions.
 λ Selected psv file as input: test/cli/repl/data.psv
 λ λ -- Valid indices
 λ Core evaluation

--- a/icicle-compiler/test/cli/repl/t80-array-index/expected
+++ b/icicle-compiler/test/cli/repl/t80-array-index/expected
@@ -56,4 +56,25 @@ marge|tombstone
 homer|tombstone
 marge|tombstone
 
-λ 
+λ λ -- Varied possibilities: Array is Definitely of Definitely
+λ Core evaluation
+---------------
+
+homer|149690
+marge|142370
+
+λ λ -- Array is Possibly of Definitely
+λ Core evaluation
+---------------
+
+homer|149690
+marge|142370
+
+λ λ -- Array is Possibly of Possibly
+λ Core evaluation
+---------------
+
+homer|500
+marge|20
+
+λ λ 

--- a/icicle-compiler/test/cli/repl/t80-array-index/expected
+++ b/icicle-compiler/test/cli/repl/t80-array-index/expected
@@ -1,0 +1,59 @@
+Queries will no longer be evaluated using the C evaluator.
+Snapshot mode activated with a snapshot date of 2017-01-01.
+Loaded dictionary with 5 inputs, 0 outputs, 38 functions.
+Selected psv file as input: test/cli/repl/data.psv
+
+  ██▓ ▄████▄   ██▓ ▄████▄   ██▓    ▓█████
+ ▓██▒▒██▀ ▀█  ▓██▒▒██▀ ▀█  ▓██▒    ▓█   ▀
+ ▒██▒▒▓█    ▄ ▒██▒▒▓█    ▄ ▒██░    ▒███
+ ░██░▒▓▓▄ ▄██▒░██░▒▓▓▄ ▄██▒▒██░    ▒▓█  ▄
+ ░██░▒ ▓███▀ ░░██░▒ ▓███▀ ░░██████▒░▒████▒
+ ░▓  ░ ░▒ ▒  ░░▓  ░ ░▒ ▒  ░░ ▒░▓  ░░░ ▒░ ░
+  ▒ ░  ░  ▒    ▒ ░  ░  ▒   ░ ░ ▒  ░ ░ ░  ░
+  ▒ ░░         ▒ ░░          ░ ░ REPL ░
+  ░  ░ ░       ░  ░ ░          ░  ░   ░  ░
+     ░            ░
+                  ░     :help for help
+
+λ Loaded dictionary with 5 inputs, 0 outputs, 38 functions.
+λ Selected psv file as input: test/cli/repl/data.psv
+λ λ -- Valid indices
+λ Core evaluation
+---------------
+
+homer|300
+marge|0
+
+λ Core evaluation
+---------------
+
+homer|500
+marge|20
+
+λ λ -- Would be valid, except there's not enough data
+λ Core evaluation
+---------------
+
+homer|tombstone
+marge|tombstone
+
+λ λ -- Totally invalid indices
+λ Core evaluation
+---------------
+
+homer|tombstone
+marge|tombstone
+
+λ Core evaluation
+---------------
+
+homer|tombstone
+marge|tombstone
+
+λ Core evaluation
+---------------
+
+homer|tombstone
+marge|tombstone
+
+λ 

--- a/icicle-compiler/test/cli/repl/t80-array-index/script
+++ b/icicle-compiler/test/cli/repl/t80-array-index/script
@@ -1,0 +1,14 @@
+:load test/cli/repl/dictionary.toml
+:load test/cli/repl/data.psv
+
+-- Valid indices
+feature salary ~> let arr = (latest 3 ~> value) ~> index arr 0
+feature salary ~> let arr = (latest 3 ~> value) ~> index arr 2
+
+-- Would be valid, except there's not enough data
+feature salary ~> let arr = (latest 50 ~> value) ~> index arr 49
+
+-- Totally invalid indices
+feature salary ~> let arr = (latest 3 ~> value) ~> index arr 100
+feature salary ~> let arr = (latest 3 ~> value) ~> index arr 3
+feature salary ~> let arr = (latest 3 ~> value) ~> index arr (-1)

--- a/icicle-compiler/test/cli/repl/t80-array-index/script
+++ b/icicle-compiler/test/cli/repl/t80-array-index/script
@@ -12,3 +12,13 @@ feature salary ~> let arr = (latest 50 ~> value) ~> index arr 49
 feature salary ~> let arr = (latest 3 ~> value) ~> index arr 100
 feature salary ~> let arr = (latest 3 ~> value) ~> index arr 3
 feature salary ~> let arr = (latest 3 ~> value) ~> index arr (-1)
+
+-- Varied possibilities: Array is Definitely of Definitely
+feature salary ~> let arr = (latest 3 ~> time) ~> let a = index arr 2 ~> days a
+
+-- Array is Possibly of Definitely
+feature salary ~> let arr = box (Some (latest 3 ~> time)) ~> let a = index arr 2 ~> days a
+
+-- Array is Possibly of Possibly
+feature salary ~> let arr = box (Some (latest 3 ~> value)) ~> let a = index arr 2 ~> a
+

--- a/icicle-core/src/Icicle/Core/Exp/Simp.hs
+++ b/icicle-core/src/Icicle/Core/Exp/Simp.hs
@@ -69,6 +69,7 @@ simpX a_fresh = go . B.beta
 --
 simpP :: (Hashable n, Eq n) => a -> Prim -> [Value a n Prim] -> Maybe (C.Exp a n)
 simpP a_fresh p vs
+ | length (functionArguments $ C.typeOfPrim p) == length vs
  = case CE.evalPrim p vs of
     Right (VBase b)
      -> Just
@@ -79,6 +80,8 @@ simpP a_fresh p vs
      -> Nothing
     Left _
      -> Nothing
+ | otherwise
+ = Nothing
 
 
 -- | Dead binding removal

--- a/icicle-data/src/Icicle/Common/Base.hs
+++ b/icicle-data/src/Icicle/Common/Base.hs
@@ -116,6 +116,8 @@ data ExceptionInfo
  | ExceptTombstone
  | ExceptFold1NoValue
  | ExceptCannotCompute
+ | ExceptNotANumber
+ | ExceptIndexOutOfBounds
  deriving (Show, Ord, Eq, Generic)
 
 instance NFData ExceptionInfo

--- a/icicle-data/src/Icicle/Common/Base.hs
+++ b/icicle-data/src/Icicle/Common/Base.hs
@@ -118,7 +118,7 @@ data ExceptionInfo
  | ExceptCannotCompute
  | ExceptNotANumber
  | ExceptIndexOutOfBounds
- deriving (Show, Ord, Eq, Generic)
+ deriving (Show, Ord, Eq, Generic, Enum, Bounded)
 
 instance NFData ExceptionInfo
 instance NanEq ExceptionInfo

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
@@ -229,10 +229,11 @@ evalPrim p originalP vs
 
      PrimBuiltinFun (PrimBuiltinArray (PrimBuiltinIndex _))
       | [VBase (VArray a), VBase (VInt i)] <- vs
-      , i >= 0 && i < length a
-      -> return $ VBase $ VRight $ a List.!! i
+      -> if i >= 0 && i < length a
+         then return $ VBase $ VRight $ a List.!! i
+         else return $ VBase $ VLeft  $ VError ExceptIndexOutOfBounds
       | otherwise
-      -> return $ VBase $ VLeft  $ VError ExceptIndexOutOfBounds
+      -> primError
 
      -- Relation
      PrimRelation rel _

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Eval.hs
@@ -230,9 +230,9 @@ evalPrim p originalP vs
      PrimBuiltinFun (PrimBuiltinArray (PrimBuiltinIndex _))
       | [VBase (VArray a), VBase (VInt i)] <- vs
       , i >= 0 && i < length a
-      -> return $ VBase $ a List.!! i
+      -> return $ VBase $ VRight $ a List.!! i
       | otherwise
-      -> return $ VBase $ VError ExceptTombstone
+      -> return $ VBase $ VLeft  $ VError ExceptIndexOutOfBounds
 
      -- Relation
      PrimRelation rel _

--- a/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
+++ b/icicle-data/src/Icicle/Common/Exp/Prim/Minimal.hs
@@ -186,7 +186,7 @@ typeOfPrim p
     PrimBuiltinFun    (PrimBuiltinArray (PrimBuiltinLength t))
      -> FunT [funOfVal (ArrayT t)] IntT
     PrimBuiltinFun    (PrimBuiltinArray (PrimBuiltinIndex t))
-     -> FunT [funOfVal (ArrayT t), funOfVal IntT] t
+     -> FunT [funOfVal (ArrayT t), funOfVal IntT] (SumT ErrorT t)
 
     -- All relations are binary to bool
     PrimRelation _ val

--- a/icicle-source/src/Icicle/Source/Parser/Constructor.hs
+++ b/icicle-source/src/Icicle/Source/Parser/Constructor.hs
@@ -38,6 +38,8 @@ constructors
    ,("ExceptTombstone",         Q.ConError ExceptTombstone)
    ,("ExceptFold1NoValue",      Q.ConError ExceptFold1NoValue)
    ,("ExceptCannotCompute",     Q.ConError ExceptCannotCompute)
+   ,("ExceptNotANumber",        Q.ConError ExceptNotANumber)
+   ,("ExceptIndexOutOfBounds",  Q.ConError ExceptIndexOutOfBounds)
    ]
 
 

--- a/icicle-source/src/Icicle/Source/Query/Prim.hs
+++ b/icicle-source/src/Icicle/Source/Query/Prim.hs
@@ -136,7 +136,7 @@ primLookup' prim
     Fun (BuiltinArray ArrayLength)
      -> f1 $ \a at -> FunctionType [a] [] [ArrayT at] IntT
     Fun (BuiltinArray ArrayIndex)
-     -> f1 $ \a at -> FunctionType [a] [] [ArrayT at, IntT] at
+     -> f1 $ \a at -> FunctionType [a] [] [ArrayT at, IntT] (Possibility PossibilityPossibly at)
 
     Fun (BuiltinMap MapKeys)
      -> f2 $ \a at b bt -> FunctionType [a,b] [] [GroupT at bt] (ArrayT at)
@@ -212,8 +212,9 @@ primLookup' prim
 -- As it is, we're looking at the expression and the result of type inference to decide - trying to work backwards to
 -- figure out what inference did.
 primReturnsPossibly :: Prim -> Type n -> Bool
-primReturnsPossibly (Fun (BuiltinData Box))      _ = True
-primReturnsPossibly (Fun (BuiltinMap MapInsert)) _ = True
+primReturnsPossibly (Fun (BuiltinData  Box))        _ = True
+primReturnsPossibly (Fun (BuiltinMap   MapInsert))  _ = True
+primReturnsPossibly (Fun (BuiltinArray ArrayIndex)) _ = True
 primReturnsPossibly p ty
  | (_, pos, dat)       <- decomposeT ty
  , DoubleT             <- dat

--- a/icicle-source/src/Icicle/Source/ToCore/Prim.hs
+++ b/icicle-source/src/Icicle/Source/ToCore/Prim.hs
@@ -456,9 +456,8 @@ primCheckDouble fx = do
 
   let xvalid = apps (bf $ Min.PrimBuiltinMath $ Min.PrimBuiltinDoubleIsValid) [ v'x ]
 
-  -- TODO: add ExceptNotANumber
   let verr   = CE.XValue () (T.SumT T.ErrorT T.DoubleT)
-             $ V.VLeft $ V.VError V.ExceptCannotCompute
+             $ V.VLeft $ V.VError V.ExceptNotANumber
   let vright = apps (C.PrimMinimal $ Min.PrimConst $ Min.PrimConstRight T.ErrorT T.DoubleT)
              [ v'x ]
 


### PR DESCRIPTION
#586 
New exception tags: `NotANumber` and `IndexOutOfBounds`.

Make `index` return Possibly in Source. This is converted to a straightforward safe indexing in Core, which returns `Sum Error t`. Having safe indexing in Core means we can generate random programs using that. Then when we flatten, it introduces explicit bounds checks before converting to unsafe indexing.

The array and map primitives in Flatten are using unsafe indexing, so this won't affect them.

! @jystic @tranma 
/jury approved @jystic