### PR TITLE
Add separated parsers for QueryTop

### DIFF
--- a/icicle-source/src/Icicle/Source/Parser.hs
+++ b/icicle-source/src/Icicle/Source/Parser.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE NoImplicitPrelude #-}
 module Icicle.Source.Parser (
     parseQueryTop
+  , parseQuery
+  , parseTop
   , parseFunctions
   , prettyParse
   , ParseError
@@ -10,7 +12,7 @@ module Icicle.Source.Parser (
 
 import Icicle.Source.Lexer.Lexer
 import Icicle.Source.Lexer.Token
-import Icicle.Source.Parser.Parser
+import Icicle.Source.Parser.Parser as Parser
 import Icicle.Source.Parser.Token
 
 import Icicle.Source.Query
@@ -36,6 +38,17 @@ parseQueryTop :: OutputId -> Text -> Either ParseError (QueryTop SourcePos Varia
 parseQueryTop name inp
  = let toks = lexer "" inp
    in  runParser (consumeAll $ top name) () "" toks
+
+parseTop :: Text -> Either ParseError UnresolvedInputId
+parseTop inp
+ = let toks = lexer "" inp
+   in  runParser (consumeAll pUnresolvedInputId) () "" toks
+
+parseQuery :: UnresolvedInputId -> OutputId -> Text -> Either ParseError (QueryTop SourcePos Variable)
+parseQuery v name inp = do
+  let toks = lexer "" inp
+  q <- runParser (consumeAll Parser.query) () "" toks
+  return $ QueryTop v name q
 
 consumeAll :: Parser a -> Parser a
 consumeAll f = do

--- a/icicle-source/src/Icicle/Source/Parser.hs
+++ b/icicle-source/src/Icicle/Source/Parser.hs
@@ -2,7 +2,7 @@
 module Icicle.Source.Parser (
     parseQueryTop
   , parseQuery
-  , parseTop
+  , parseFactName
   , parseFunctions
   , prettyParse
   , ParseError
@@ -39,8 +39,8 @@ parseQueryTop name inp
  = let toks = lexer "" inp
    in  runParser (consumeAll $ top name) () "" toks
 
-parseTop :: Text -> Either ParseError UnresolvedInputId
-parseTop inp
+parseFactName :: Text -> Either ParseError UnresolvedInputId
+parseFactName inp
  = let toks = lexer "" inp
    in  runParser (consumeAll pUnresolvedInputId) () "" toks
 


### PR DESCRIPTION
! @jystic @tranma 

Had a chat with @don41382 this morning regarding parsing
icicle expressions outside of icicle dictionaries (such as in a
web UI). There was a struggle with source locations due to
`feature blah ~>` being artificially prepended before the parse
and type check.

I pointed him to the fact that the parser can actually parse
these separately. But adding these two functions will make it
much easier in that it can be done without any knowledge of,
or imports from Parsec.

@tranma  @charleso  as discussed.
/jury approved @amosr