### PR TITLE
Repl time information

### DIFF
--- a/icicle-compiler/src/Icicle/Repl/Data.hs
+++ b/icicle-compiler/src/Icicle/Repl/Data.hs
@@ -68,6 +68,7 @@ data Flag =
   | FlagSeaLLVM
   | FlagSeaRuntime
   | FlagSeaEval
+  | FlagStatTime
     deriving (Eq, Ord, Show)
 
 data FlagInfo =

--- a/icicle-compiler/src/Icicle/Repl/Flag.hs
+++ b/icicle-compiler/src/Icicle/Repl/Flag.hs
@@ -8,9 +8,12 @@ module Icicle.Repl.Flag (
   , namedFlags
   , whenSet
   , ifSet
+  , timeSection
+  , timeSectionWith
   ) where
 
 import           Control.Monad.State.Class (MonadState, gets)
+import           Control.Monad.IO.Class (MonadIO)
 
 import           Data.Map (Map)
 import qualified Data.Map as Map
@@ -18,6 +21,7 @@ import qualified Data.Set as Set
 import           Data.String (String)
 
 import           Icicle.Repl.Data
+import           Icicle.Command.Timer
 
 import           P
 
@@ -138,6 +142,11 @@ allFlags = [
       "Queries will be evaluated using the C evaluator."
       "Queries will no longer be evaluated using the C evaluator."
       "Show the result, using C evaluation."
+
+  , FlagInfo FlagStatTime "time"
+      "Time breakdown will be shown during evaluation."
+      "Time breakdown will be hidden during evaluation."
+      "Show the time breakdown during evaluation."
   ]
 
 namedFlags :: Map String Flag
@@ -157,3 +166,14 @@ ifSet :: MonadState State m => Flag -> m a -> m a -> m a
 ifSet flag t f = do
   flags <- gets stateFlags
   if Set.member flag flags then t else f
+
+timeSection :: (MonadState State m, MonadIO m) => Text -> m (m ())
+timeSection section = ifSet FlagStatTime (startTimer_ section) (return (return ()))
+
+timeSectionWith :: (MonadState State m, MonadIO m) => Text -> m a -> m a
+timeSectionWith section action = do
+  time <- timeSection section
+  ret  <- action
+  time
+  return ret
+

--- a/icicle-compiler/src/Icicle/Repl/Flag.hs
+++ b/icicle-compiler/src/Icicle/Repl/Flag.hs
@@ -37,7 +37,7 @@ allFlags = [
   , FlagInfo FlagTypeCheckLog "type-check-log"
       "The type checking log will be displayed during evaluation."
       "The type checking log will be hidden during evaluation."
-      "" -- FIXME
+      "Show the type checking log."
 
   , FlagInfo FlagBigData "big-data"
       "Queries are now subject to \"big data\" restrictions."
@@ -94,20 +94,20 @@ allFlags = [
       "Queries will no longer be evaluated using the avalanche evaluator."
       "Show the result, using avalanche evaluation."
 
-  , FlagInfo FlagFlattenSimp "flatten-simp"
-      "The flattened avalanche will be shown during evaluation."
-      "The flattened avalanche will be hidden during evaluation."
-      "Show the flattened avalanche conversion."
+  , FlagInfo FlagFlattenSimp "flatten"
+      "The flattened simplified avalanche will be shown during evaluation."
+      "The flattened simplified avalanche will be hidden during evaluation."
+      "Show the flattened avalanche conversion after simplifier."
 
-  , FlagInfo FlagFlattenNoSimp "flatten-no-simp"
-      "flatten-no-simp is now on."
-      "flatten-no-simp is now off."
-      "" -- FIXME more details
+  , FlagInfo FlagFlattenNoSimp "flatten-pre-simp"
+      "The flattened (unsimplified) avalanche will be shown during evaluation."
+      "The flattened (unsimplified) avalanche will be hidden during evaluation."
+      "Show the flattened avalanche before simplifier."
 
   , FlagInfo FlagFlattenSimpCheck "flatten-simp-check"
-      "flatten-simp-check is now on."
-      "flatten-simp-check is now off."
-      "" -- FIXME more details
+      "Typechecking will occur during flatten simplifier."
+      "No typechecking will occur during flatten simplifier."
+      "Perform typechecking between every stage of flatten simplifier."
 
   , FlagInfo FlagSeaPreamble "c-preamble"
       "The C preamble will be shown during evaluation."

--- a/icicle-compiler/test/cli/repl/t10.3-flatten/expected
+++ b/icicle-compiler/test/cli/repl/t10.3-flatten/expected
@@ -17,7 +17,7 @@ Selected psv file as input: test/cli/repl/data.psv
 
 λ -- Show everything
 λ The core will be simplified prior to evaluation.
-The flattened avalanche will be shown during evaluation.
+The flattened simplified avalanche will be shown during evaluation.
 λ λ -- A rather complicated feature to convert to Avalanche
 λ Flattened (simplified), not typechecked
 ---------------------------------------

--- a/icicle-compiler/test/cli/repl/t10.3-flatten/script
+++ b/icicle-compiler/test/cli/repl/t10.3-flatten/script
@@ -1,5 +1,5 @@
 -- Show everything
-:set +core-simp +flatten-simp
+:set +core-simp +flatten
 
 -- A rather complicated feature to convert to Avalanche
 feature salary ~> (filter value > 10 ~> count value), (latest 3 ~> value)

--- a/icicle-compiler/test/cli/repl/t30-sea/expected
+++ b/icicle-compiler/test/cli/repl/t30-sea/expected
@@ -16,7 +16,7 @@ Selected psv file as input: test/cli/repl/data.psv
                   ░     :help for help
 
 λ -- Show everything
-λ The flattened avalanche will be shown during evaluation.
+λ The flattened simplified avalanche will be shown during evaluation.
 The C will be shown during evaluation.
 λ λ -- Enable C evaluation
 λ Queries will be evaluated using the C evaluator.
@@ -3963,7 +3963,7 @@ marge|2009-12-12
 
 λ λ -- Math
 λ The C will be hidden during evaluation.
-The flattened avalanche will be hidden during evaluation.
+The flattened simplified avalanche will be hidden during evaluation.
 λ λ Core evaluation
 ---------------
 

--- a/icicle-compiler/test/cli/repl/t30-sea/script
+++ b/icicle-compiler/test/cli/repl/t30-sea/script
@@ -1,5 +1,5 @@
 -- Show everything
-:set +flatten-simp +c
+:set +flatten +c
 
 -- Enable C evaluation
 :set +c-eval
@@ -11,7 +11,7 @@ feature injury ~> mean (double severity) * (filter location == "torso" ~> sd sev
 feature salary ~> max (days between `1980-01-06` time days after `2000-01-01`)
 
 -- Math
-:set -c -flatten-simp
+:set -c -flatten
 
 feature injury ~> newest (sqrt (-1))
 


### PR DESCRIPTION
more time than you ever wanted. show the time breakdown when you evaluate a query. probably too much details but I'd rather that than not enough.

! @jystic @tranma 

```
λ :set +time
λ feature ints500 ~> latest 2 ~> fields

icicle: Compile Query
icicle: Compile Source
icicle: Compile Source (took 0.01s)
icicle: Compile Core
icicle: Compile Core (took 0.01s)
icicle: Compile Avalanche
icicle: Compile Avalanche (took 0.00s)
icicle: Compile Flattened Avalanche
icicle: Compile Flattened Avalanche (took 2.98s)
icicle: Compile Flattened Avalanche Check
icicle: Compile Flattened Avalanche Check (took 0.03s)
icicle: Compile Query (took 3.03s)
icicle: Compile Sea
icicle: Compile Sea Avalanche->Sea
icicle: Compile Sea Avalanche->Sea (took 0.00s)
icicle: Compile Sea Sea->object
icicle: Compile Sea Sea->object (took 39.45s)
icicle: Compile Sea (took 39.45s)
icicle: Evaluate Zebra
icicle: Evaluate Zebra Open
icicle: Evaluate Zebra Open (took 0.00s)
icicle: Evaluate Zebra Schema
icicle: Evaluate Zebra Schema (took 0.00s)
icicle: Evaluate Zebra Transmute
icicle: Evaluate Zebra Transmute (took 0.00s)
icicle: Evaluate Zebra Decode
icicle: Evaluate Zebra Decode (took 0.00s)
icicle: Evaluate Zebra Snapshot
icicle: Evaluate Zebra Snapshot (took 0.01s)
icicle: Evaluate Zebra Output
icicle: Evaluate Zebra Output (took 0.00s)
C evaluation
------------



icicle: Evaluate Zebra (took 0.01s)
```
/jury approved @tranma