### PR TITLE
don't inline buffer reads

### DIFF
--- a/data/sea/31-buffer.h
+++ b/data/sea/31-buffer.h
@@ -98,7 +98,7 @@ Read(buf)
 
 #define MK_BUF_READ(n,t)                                                        \
                                                                                 \
-static ARRAY(t##_t) INLINE BUF_FUN(n,t,read) (anemone_mempool_t *pool, BUF_T(n,t) *buf)\
+static ARRAY(t##_t) NOINLINE BUF_FUN(n,t,read) (anemone_mempool_t *pool, BUF_T(n,t) *buf)\
 {                                                                               \
     iint_t size = buf->size;                                                    \
     iint_t head = buf->head;                                                    \


### PR DESCRIPTION
disable inlining buffer reads, which convert from buf to array. these allocate a new array and are probably only called once rather than inside the loop, so lack of inlining shouldn't affect runtime too much.

it reduces the compile time! for a `latest 1 ~> fields` query on a record with N fields:

```
100 fields
1.34s -> 0.59s

200 fields
3.41s -> 1.28s

300 fields
6.68s -> 2.25s

400 fields
11.5s -> 3.64s

500 fields
20s -> 5.39s
```
