### PR TITLE
Time test

### DIFF
--- a/data/sea/21-time.h
+++ b/data/sea/21-time.h
@@ -67,7 +67,7 @@ static iint_t INLINE itime_to_epoch_seconds (itime_t x)
   return s + 60*n + 3600*h + (365*y + y/4 - y/100 + y/400 + (m*306 + 5)/10 + (d - 1)) * 86400;
 }
 
-static itime_t INLINE itime_from_epoch_days (iint_t g)
+static itime_t INLINE itime_from_epoch_days (iint_t g, iint_t h, iint_t m, iint_t s)
 {
     int64_t y = ((10000*g + 14780)/3652425);
     int64_t ddd = g - (365*y + y/4 - y/100 + y/400);
@@ -84,7 +84,7 @@ static itime_t INLINE itime_from_epoch_days (iint_t g)
 
     int64_t dd = ddd - (mi*306 + 5)/10 + 1;
 
-    return itime_from_gregorian (y + 1600, mm, dd, 0, 0, 0);
+    return itime_from_gregorian (y + 1600, mm, dd, h, m, s);
 }
 
 static itime_t INLINE itime_from_epoch_seconds (iint_t s)
@@ -126,7 +126,10 @@ static iint_t INLINE itime_seconds_diff (itime_t x, itime_t y)
 
 static itime_t INLINE itime_minus_days (itime_t x, iint_t y)
 {
-    return itime_from_epoch_days (itime_to_epoch_days(x) - y);
+    int64_t _y, _M, _d, h, m, s;
+    itime_to_gregorian (x, &_y, &_M, &_d, &h, &m, &s);
+
+    return itime_from_epoch_days (itime_to_epoch_days(x) - y, h, m, s);
 }
 
 static itime_t INLINE itime_minus_seconds (itime_t x, iint_t y)

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
@@ -110,7 +110,8 @@ instance Arbitrary OutputId where
     OutputId <$> arbitrary <*> arbitrary
 
 instance Arbitrary Time where
-  arbitrary = timeOfIvorySeconds <$> choose (0,500 * 365 * 24 * 60 * 60)
+  arbitrary = timeOfIvorySeconds <$> choose (500 * year,1000 * year)
+   where year = 365 * 24 * 60 * 60
 
 instance Arbitrary Fact' where
   arbitrary =

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
@@ -9,6 +9,8 @@ module Icicle.Test.Arbitrary.Data (
   , fresh
   , valueOfEncoding
   , module Run
+
+  , TimeWithTime(..)
   ) where
 
 import qualified Icicle.Internal.Pretty as PP
@@ -109,8 +111,16 @@ instance Arbitrary OutputId where
   arbitrary =
     OutputId <$> arbitrary <*> arbitrary
 
+-- Time with out time:
+-- Many tests assume that this Time generator is just the date.
 instance Arbitrary Time where
-  arbitrary = timeOfIvorySeconds <$> choose (500 * year,1000 * year)
+  arbitrary = Maybe.fromJust <$> ((timeOfYMD <$> choose (2000, 2050) <*> choose (1, 12) <*> choose (1,31)) `suchThat` isJust)
+
+newtype TimeWithTime = TimeWithTime Time
+ deriving (Eq, Ord, Show)
+
+instance Arbitrary TimeWithTime where
+  arbitrary = TimeWithTime . timeOfIvorySeconds <$> choose (500 * year,1000 * year)
    where year = 365 * 24 * 60 * 60
 
 instance Arbitrary Fact' where

--- a/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
+++ b/icicle-compiler/test/Icicle/Test/Arbitrary/Data.hs
@@ -110,7 +110,7 @@ instance Arbitrary OutputId where
     OutputId <$> arbitrary <*> arbitrary
 
 instance Arbitrary Time where
-  arbitrary = Maybe.fromJust <$> ((timeOfYMD <$> choose (2000, 2050) <*> choose (1, 12) <*> choose (1,31)) `suchThat` isJust)
+  arbitrary = timeOfIvorySeconds <$> choose (0,500 * 365 * 24 * 60 * 60)
 
 instance Arbitrary Fact' where
   arbitrary =

--- a/icicle-compiler/test/Icicle/Test/Data/Time.hs
+++ b/icicle-compiler/test/Icicle/Test/Data/Time.hs
@@ -57,11 +57,17 @@ prop_time_sea_from_days d
   = testIO $ do
   let epochTime = unsafeTimeOfYMD 1600 03 01
   let epochDiff = daysDifference epochTime d
+  let timeH     = localHour   d
+  let timeM     = localMinute d
+  let timeS     = localSecond d
 
   runRight $ do
     library <- readLibrary seaTestables
     f <- function library "testable_itime_from_epoch_days" retInt64
-    r <- liftIO $ f [argWord64 $ fromIntegral epochDiff]
+    r <- liftIO $ f [ argWord64 $ fromIntegral epochDiff
+                    , argWord64 $ fromIntegral timeH
+                    , argWord64 $ fromIntegral timeM
+                    , argWord64 $ fromIntegral timeS ]
     pure $ d === timeOfPacked (fromIntegral r)
 
 prop_time_sea_from_seconds :: Time -> Property
@@ -149,7 +155,8 @@ seaTestables :: SourceCode
 seaTestables = codeOfDoc $ PP.vsep
   [ "iint_t testable_itime_to_epoch_days        (itime_t x)            { return itime_to_epoch_days      (x);    }"
   , "iint_t testable_itime_to_epoch_seconds     (itime_t x)            { return itime_to_epoch_seconds   (x);    }"
-  , "iint_t testable_itime_from_epoch_days      (iint_t g)             { return itime_from_epoch_days    (g);    }"
+  , "iint_t testable_itime_from_epoch_days      (iint_t g, iint_t h, iint_t m, iint_t s)"
+                                                                   <> "{ return itime_from_epoch_days (g,h,m,s); }"
   , "iint_t testable_itime_from_epoch_seconds   (iint_t g)             { return itime_from_epoch_seconds (g);    }"
   , "iint_t testable_itime_days_diff            (itime_t x, itime_t y) { return itime_days_diff          (x, y); }"
   , "iint_t testable_itime_seconds_diff         (itime_t x, itime_t y) { return itime_seconds_diff       (x, y); }"

--- a/icicle-compiler/test/Icicle/Test/Data/Time.hs
+++ b/icicle-compiler/test/Icicle/Test/Data/Time.hs
@@ -24,12 +24,12 @@ import           Test.QuickCheck.Property
 
 import           X.Control.Monad.Trans.Either
 
-prop_packed_symmetry :: Time -> Property
-prop_packed_symmetry d =
+prop_packed_symmetry :: TimeWithTime -> Property
+prop_packed_symmetry (TimeWithTime d) =
   d === timeOfPacked (packedOfTime d)
 
-prop_time_sea_to_days :: Time -> Property
-prop_time_sea_to_days d
+prop_time_sea_to_days :: TimeWithTime -> Property
+prop_time_sea_to_days (TimeWithTime d)
   = testIO $ do
   let epochTime = unsafeTimeOfYMD 1600 03 01
   let expected  = daysDifference epochTime d
@@ -40,8 +40,8 @@ prop_time_sea_to_days d
     r <- liftIO $ f [argWord64 $ packedOfTime d]
     pure $ expected === fromIntegral r
 
-prop_time_sea_to_seconds :: Time -> Property
-prop_time_sea_to_seconds d
+prop_time_sea_to_seconds :: TimeWithTime -> Property
+prop_time_sea_to_seconds (TimeWithTime d)
   = testIO $ do
   let epochTime = unsafeTimeOfYMD 1600 03 01
   let expected  = secondsDifference epochTime d
@@ -52,8 +52,8 @@ prop_time_sea_to_seconds d
     r <- liftIO $ f [argWord64 $ packedOfTime d]
     pure $ expected === fromIntegral r
 
-prop_time_sea_from_days :: Time -> Property
-prop_time_sea_from_days d
+prop_time_sea_from_days :: TimeWithTime -> Property
+prop_time_sea_from_days (TimeWithTime d)
   = testIO $ do
   let epochTime = unsafeTimeOfYMD 1600 03 01
   let epochDiff = daysDifference epochTime d
@@ -70,8 +70,8 @@ prop_time_sea_from_days d
                     , argWord64 $ fromIntegral timeS ]
     pure $ d === timeOfPacked (fromIntegral r)
 
-prop_time_sea_from_seconds :: Time -> Property
-prop_time_sea_from_seconds d
+prop_time_sea_from_seconds :: TimeWithTime -> Property
+prop_time_sea_from_seconds (TimeWithTime d)
   = testIO $ do
   let epochTime = unsafeTimeOfYMD 1600 03 01
   let epochDiff = secondsDifference epochTime d
@@ -82,8 +82,8 @@ prop_time_sea_from_seconds d
     r <- liftIO $ f [argWord64 $ fromIntegral epochDiff]
     pure $ d === timeOfPacked (fromIntegral r)
 
-prop_time_symmetry_sea_days :: Time -> Time -> Property
-prop_time_symmetry_sea_days d1 d2
+prop_time_symmetry_sea_days :: TimeWithTime -> TimeWithTime -> Property
+prop_time_symmetry_sea_days (TimeWithTime d1) (TimeWithTime d2)
   = testIO $ do
   let expected  = daysDifference d1 d2
 
@@ -93,8 +93,8 @@ prop_time_symmetry_sea_days d1 d2
     r <- liftIO $ f [argWord64 (packedOfTime d1), argWord64 (packedOfTime d2)]
     pure $ expected === fromIntegral r
 
-prop_time_symmetry_sea_seconds :: Time -> Time -> Property
-prop_time_symmetry_sea_seconds d1 d2
+prop_time_symmetry_sea_seconds :: TimeWithTime -> TimeWithTime -> Property
+prop_time_symmetry_sea_seconds (TimeWithTime d1) (TimeWithTime d2)
   = testIO $ do
   let expected  = secondsDifference d1 d2
 
@@ -104,8 +104,8 @@ prop_time_symmetry_sea_seconds d1 d2
     r <- liftIO $ f [argWord64 (packedOfTime d1), argWord64 (packedOfTime d2)]
     pure $ expected === fromIntegral r
 
-prop_time_minus_days :: Time -> Int -> Property
-prop_time_minus_days d num
+prop_time_minus_days :: TimeWithTime -> Int -> Property
+prop_time_minus_days (TimeWithTime d) num
   = testIO $ do
   -- Add or subtract only a few years.
   let num' = num `rem` 3650
@@ -117,8 +117,8 @@ prop_time_minus_days d num
     r <- liftIO $ f [argWord64 $ packedOfTime d, argWord64 (fromIntegral num')]
     pure $ expected === timeOfPacked (fromIntegral r)
 
-prop_time_minus_seconds :: Time -> Int -> Property
-prop_time_minus_seconds d num
+prop_time_minus_seconds :: TimeWithTime -> Int -> Property
+prop_time_minus_seconds (TimeWithTime d) num
   = testIO $ do
   -- Add or subtract only a few years.
   let num' = num `rem` 3650
@@ -130,8 +130,8 @@ prop_time_minus_seconds d num
     r <- liftIO $ f [argWord64 $ packedOfTime d, argWord64 (fromIntegral num')]
     pure $ expected === timeOfPacked (fromIntegral r)
 
-prop_time_minus_months :: Time -> Int -> Property
-prop_time_minus_months d num
+prop_time_minus_months :: TimeWithTime -> Int -> Property
+prop_time_minus_months (TimeWithTime d) num
   = testIO $ do
   -- Add or subtract only a few years.
   let num' = num `rem` 120

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -160,10 +160,9 @@ genPrimRelation = Gen.enumBounded
 genPrimLogical :: Gen PM.PrimLogical
 genPrimLogical = Gen.enumBounded
 
--- TODO: add PrimTimeMinusDays and PrimTimeMinusMonths after choosing a consistent time representation
+-- Note well: PrimTimeMinus* are treated kind of specially in Program.genPrimitive, and only ever called with small constant amounts.
 -- We have problems because the C and the Core use different representations, so they overflow or underflow at different points.
--- I think if we only allow minus seconds it will be less likely, because you need a lot of seconds to overflow.
--- You don't need many months to overflow.
+-- You don't need many months to overflow, so if we only generate small numbers it should be ok.
 genPrimTime :: Gen PM.PrimTime
 genPrimTime = Gen.element
  [ PM.PrimTimeDaysDifference
@@ -171,6 +170,8 @@ genPrimTime = Gen.element
  , PM.PrimTimeDaysJulianEpoch
  , PM.PrimTimeSecondsJulianEpoch
  , PM.PrimTimeMinusSeconds
+ , PM.PrimTimeMinusDays
+ , PM.PrimTimeMinusMonths
  , PM.PrimTimeProjectDay
  , PM.PrimTimeProjectMonth
  , PM.PrimTimeProjectYear ]

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Program.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Program.hs
@@ -319,24 +319,22 @@ tryGenPrimitiveForType r = do
     args <- mapM (genArg p) (functionArguments $ typeOfPrim p)
     return $ Just $ foldl xApp (xPrim p) args
  where
-  genArg p t
    -- Only ever minus by small constant amounts for times.
    -- Bit over a year.
-   | PM.PrimTime PM.PrimTimeMinusSeconds <- p
-   , IntT <- t
+  genArg (PrimMinimal (PM.PrimTime p)) (FunT [] IntT)
+   | PM.PrimTimeMinusSeconds <- p
    = genVInt (370 * 60 * 60 * 24)
-   | PM.PrimTime PM.PrimTimeMinusDays <- p
-   , IntT <- t
+   | PM.PrimTimeMinusDays <- p
    = genVInt 370
-   | PM.PrimTime PM.PrimTimeMinusMonths <- p
-   , IntT <- t
+   | PM.PrimTimeMinusMonths <- p
    = genVInt 13
-   -- Otherwise make an expression
-   | otherwise
+
+  -- Otherwise make an expression
+  genArg _ t
    = genExpForType t
 
   genVInt upper
-   = xValue IntT . VInt <$> Range.linear 0 upper
+   = xValue IntT . VInt <$> Gen.integral (Range.linear 0 upper)
 
 -- | Generate primitive application, falling back to context
 genPrimitiveForType :: C m => ValType -> m (Exp () Var Prim)


### PR DESCRIPTION
Can't properly test primitives for tempus? Fudge it. The problem with time primitives such as "minus months" is it doesn't take many months to overflow. So the number of months has to be small. If we use an arbitrary int expression it could be anything. The trick here is to only generate a *constant* number of months, between zero and thirteen.

The other problem is that "minus days" was throwing away the time of day, and the tests for that weren't catching it because they were only generating days without time. I have modified that test to generate real time of day, but not other tests, because some of them (eg roundtripping date) break on times.

! @jystic @tranma 