### PR TITLE
Use pattern guards for `filter` in sorbet.

### DIFF
--- a/doc/internals/sorbet.bnf
+++ b/doc/internals/sorbet.bnf
@@ -272,7 +272,7 @@
 <context>        ::= let      <decls>
                   |  group    <exp>
                   |  distinct <exp>
-                  |  filter   <exp>
+                  |  filter   <guards>
                   |  latest   <integer>
                   |  windowed <window>
 

--- a/icicle-compiler/test/Icicle/Test/Sorbet/Concrete/Jack.hs
+++ b/icicle-compiler/test/Icicle/Test/Sorbet/Concrete/Jack.hs
@@ -125,7 +125,7 @@ jContext =
       Let X <$> listOfMax1 10 jDecl
     , Group X <$> jExp
     , Distinct X <$> jExp
-    , Filter X <$> jExp
+    , Filter X <$> jGuards
     ]
 
 jLatestSize :: Jack (LatestSize X)

--- a/icicle-source/src/Icicle/Sorbet/Concrete/Parser.hs
+++ b/icicle-source/src/Icicle/Sorbet/Concrete/Parser.hs
@@ -277,7 +277,7 @@ pContextFilter :: Parser s m => m (Context Position)
 pContextFilter =
   Filter
     <$> pToken Tok_Filter
-    <*> pExp
+    <*> pGuards
 
 pContextLatest :: Parser s m => m (Context Position)
 pContextLatest =

--- a/icicle-source/src/Icicle/Sorbet/Concrete/Pretty.hs
+++ b/icicle-source/src/Icicle/Sorbet/Concrete/Pretty.hs
@@ -266,9 +266,9 @@ ppContext layout = \case
   Distinct a exp ->
     annotate a $
       ppKeyword "distinct" <+> ppExp layout exp
-  Filter a exp ->
+  Filter a gs ->
     annotate a $
-      ppKeyword "filter" <+> ppExp layout exp
+      ppKeyword "filter" <+> ppGuards gs
   Latest a size ->
     annotate a $
       ppKeyword "latest" <+> ppLatestSize size

--- a/icicle-source/src/Icicle/Sorbet/Concrete/Syntax.hs
+++ b/icicle-source/src/Icicle/Sorbet/Concrete/Syntax.hs
@@ -97,7 +97,7 @@ data Context a =
     Let !a !(NonEmpty (Decl a))
   | Group !a !(Exp a)
   | Distinct !a !(Exp a)
-  | Filter !a !(Exp a)
+  | Filter !a !(NonEmpty (Guard a))
   | Latest !a !(LatestSize a)
   | Windowed !a !(Window a)
     deriving (Eq, Ord, Show, Generic, Data, Typeable, Functor, Foldable, Traversable)


### PR DESCRIPTION
A common use case has been
```
filter
  is_some x
in
  let
    x' = box x
  in
    mean x'
```
which isn't very pleasant. I see no reason why we shouldn't write
```
filter
  Some x' <- x
in
  mean x'
```