### PR TITLE
Improve errors for partial bindings

### DIFF
--- a/icicle-source/src/Icicle/Source/Checker/Error.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Error.hs
@@ -126,7 +126,7 @@ instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (CheckErro
             fmap pretty sugs
         ]
 
-instance (Pretty a, Pretty n) => Pretty (ErrorInfo a n) where
+instance (IsString n, Pretty a, Pretty n, Hashable n, Eq n) => Pretty (ErrorInfo a n) where
   pretty = \case
     ErrorNoSuchVariable a n ->
       "Unknown variable" <+> annotate AnnError (pretty n) <+> "at" <+> pretty a
@@ -146,7 +146,7 @@ instance (Pretty a, Pretty n) => Pretty (ErrorInfo a n) where
           "Function applied to wrong number of arguments at" <+> pretty a
         , mempty
         , "Expression:     " <> inp x
-        , "Function type:  " <> inp f
+        , "Function type:  " <> inp (prettyFunFromStrings f)
         , "Argument types: " <> inp tys
         ]
 


### PR DESCRIPTION
Print a nicer function type when displaying partial application
errors.

Example:
```
feature injury ~> let x = is_some ~> x action
```

Gives a nasty type, with the function rendered as
```
Option <interactive>-110 -> Bool
```

With this change it becomes
```
Option a -> Bool
```