### PR TITLE
Topic/remove window prim

### DIFF
--- a/icicle-compiler/src/Icicle/Avalanche/Statement/Flatten/Exp.hs
+++ b/icicle-compiler/src/Icicle/Avalanche/Statement/Flatten/Exp.hs
@@ -281,25 +281,6 @@ flatX a_fresh xx stm
        | otherwise
        -> lift $ Left $ FlattenErrorPrimBadArgs p xs
 
-      Core.PrimWindow newerThan olderThan
-       | [now, fact] <- xs
-       -> flatX' now
-       $  \now'
-       -> flatX' fact
-       $  \fact'
-       -> let  ge    = xPrim $ Flat.PrimMinimal $ Min.PrimRelation Min.PrimRelationGe TimeT
-               andb  = xPrim $ Flat.PrimMinimal $ Min.PrimLogical  Min.PrimLogicalAnd
-               newer = ge `makeApps'` [fact', windowEdge now' newerThan]
-               both  | Just olderThan' <- olderThan
-                     = andb `makeApps'` [ newer, ge `makeApps'` [windowEdge now' olderThan', fact']]
-                     | otherwise
-                     = newer
-          in stm both
-
-       | otherwise
-       -> lift $ Left $ FlattenErrorPrimBadArgs p xs
-
-
   -- Convert arguments to a simple primitive.
   -- conv is what we've already converted
   primApps p [] conv
@@ -426,11 +407,6 @@ flatX a_fresh xx stm
             = Min.PrimPairSnd ta tb
      in (xPrim $ pmin $ Min.PrimPair $ pm) `xApp` e
   projCore = proj Core.PrimMinimal
-
-
-  windowEdge x (Days   d) = xPrim (Flat.PrimMinimal $ Min.PrimTime Min.PrimTimeMinusDays)   `makeApps'` [x, xValue IntT $ VInt d]
-  windowEdge x (Weeks  w) = xPrim (Flat.PrimMinimal $ Min.PrimTime Min.PrimTimeMinusDays)   `makeApps'` [x, xValue IntT $ VInt (7*w)]
-  windowEdge x (Months m) = xPrim (Flat.PrimMinimal $ Min.PrimTime Min.PrimTimeMinusMonths) `makeApps'` [x, xValue IntT $ VInt m]
 
   slet'      = slet a_fresh
   forI'      = forI a_fresh

--- a/icicle-compiler/src/Icicle/Repl/Completion.hs
+++ b/icicle-compiler/src/Icicle/Repl/Completion.hs
@@ -72,9 +72,7 @@ completion (prefix0, suffix) =
     -- the action it points to.
     action =
       if null rest
-        then wrapCompleter " " $ \w ->
-          let candidates = fmap fst ccs
-          in  return $ filter (w `isPrefixOf`) candidates
+        then wrapPure " " $ fst <$> ccs
         else fromMaybe Haskeline.noCompletion $ List.lookup prefix ccs
 
     in

--- a/icicle-compiler/src/Icicle/Repl/Query.hs
+++ b/icicle-compiler/src/Icicle/Repl/Query.hs
@@ -588,7 +588,7 @@ evaluateZebra compiled path = do
               firstT QueryRuntimeError . hoist liftIO $
                 Runtime.snapshotBlock runtime mapSize time input
 
-            output1 <- 
+            output1 <-
               timeSectionWith "Evaluate Zebra Output" $
               hoistEither $ fromOutput (compiledOutputId compiled) output0
 

--- a/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
+++ b/icicle-compiler/test/Icicle/Test/Gen/Core/Prim.hs
@@ -3,7 +3,6 @@
 {-# LANGUAGE PatternGuards #-}
 module Icicle.Test.Gen.Core.Prim where
 
-import           Icicle.Common.Base
 import           Icicle.Common.Type
 
 import           Icicle.Core.Exp.Prim
@@ -13,7 +12,6 @@ import Icicle.Test.Gen.Core.Type
 
 import           Hedgehog
 import qualified Hedgehog.Gen as Gen
-import qualified Hedgehog.Range as Range
 
 import P
 import qualified Data.Map   as Map
@@ -55,7 +53,6 @@ genPrimMany genT = do
     , PrimMap   <$> (PrimMapDelete            <$> genOrdValTypeOf' genT <*> genT)
     , PrimMap   <$> (PrimMapLookup            <$> genOrdValTypeOf' genT <*> genT)
     , PrimArray <$> (PrimArrayMap   <$> genT  <*> genT)
-    , PrimWindow <$> genWindowUnit <*> Gen.maybe genWindowUnit
     ]
 
   -- Generate buffer prims in pairs so for a given size and type we can always push and read
@@ -64,15 +61,6 @@ genPrimMany genT = do
    a <- genT
    return [ PrimLatest $ PrimLatestPush n a
           , PrimLatest $ PrimLatestRead n a ]
-
-
-genWindowUnit :: Gen WindowUnit
-genWindowUnit = Gen.choice
-  [ Days <$> pos
-  , Months <$> pos
-  , Weeks <$> pos ]
- where
-  pos = Gen.integral $ Range.linear 0 10
 
 genPrimMinimalMany :: Gen ValType -> Gen [PM.Prim]
 genPrimMinimalMany genT

--- a/icicle-core/src/Icicle/Core/Eval/Exp.hs
+++ b/icicle-core/src/Icicle/Core/Eval/Exp.hs
@@ -9,7 +9,6 @@ import Icicle.Common.Base
 import Icicle.Common.Value
 import Icicle.Common.Exp.Eval
 import Icicle.Core.Exp.Prim
-import Icicle.Data.Time
 import qualified    Icicle.Common.Exp.Prim.Eval as Min
 
 import              P
@@ -118,14 +117,6 @@ evalPrim p vs
       | otherwise
       -> primError
 
-     PrimWindow newerThan olderThan
-      | [VBase (VTime now), VBase (VTime fact)] <- vs
-      -> let newer = windowEdge now     newerThan 
-             older = windowEdge now <$> olderThan
-             range = fact >= newer && maybe True (fact <=) older
-         in  return . VBase . VBool $ range
-      | otherwise
-      -> primError
 
  where
   applies' = applies evalPrim
@@ -144,8 +135,4 @@ evalPrim p vs
    = xs <> [x]
    | otherwise
    = List.drop 1 (xs <> [x])
-
-  windowEdge now (Days   d) = minusDays   now d
-  windowEdge now (Weeks  w) = minusDays   now $ 7 * w
-  windowEdge now (Months m) = minusMonths now m
 

--- a/icicle-core/src/Icicle/Core/Exp/Prim.hs
+++ b/icicle-core/src/Icicle/Core/Exp/Prim.hs
@@ -15,7 +15,6 @@ module Icicle.Core.Exp.Prim (
 import           GHC.Generics (Generic)
 
 import           Icicle.Internal.Pretty
-import           Icicle.Common.Base
 import           Icicle.Common.NanEq
 import           Icicle.Common.Type
 import qualified Icicle.Common.Exp.Prim.Minimal as Min
@@ -36,7 +35,6 @@ data Prim
  | PrimMap      !PrimMap
  -- | Circular buffer for latest
  | PrimLatest   !PrimLatest
- | PrimWindow   !WindowUnit !(Maybe WindowUnit)
  deriving (Eq, Ord, Show, Generic, NanEq)
 
 
@@ -118,10 +116,6 @@ typeOfPrim p
     PrimLatest (PrimLatestRead i t)
      -> FunT [funOfVal (BufT i t)] (ArrayT t)
 
-    PrimWindow _ _
-     -> FunT [funOfVal TimeT, funOfVal TimeT] BoolT
-
-
 -- Pretty -------------
 
 instance Pretty Prim where
@@ -161,6 +155,3 @@ instance Pretty Prim where
 
  pretty (PrimLatest (PrimLatestRead _ _t))
   = "Latest_read#"
-
- pretty (PrimWindow newer older)
-  = "window# " <> pretty newer <> pretty older


### PR DESCRIPTION
Without bubble-gum on the horizon, having a window primitive in Core doesn't make very much sense, and causes a small inefficiency, as the edges of the windows should be precomputations, and not calculated for each fact.