### PR TITLE
Discharge join constraints in the function typechecker

### DIFF
--- a/icicle-source/src/Icicle/Source/Checker/Constraint.hs
+++ b/icicle-source/src/Icicle/Source/Checker/Constraint.hs
@@ -164,7 +164,7 @@ constraintsQ env q
     Left errs
      -> genHoistEither
       $ errorNoSuggestions (ErrorConstraintsNotSatisfied (annotOfQuery q) errs)
-    Right (sub', cons') 
+    Right (sub', cons')
      -> let q'' = substTQ sub' q'
         in  return (q'', cons')
 


### PR DESCRIPTION
We should be able to run these discharges in the function definitions,
as they are self contained.

With this change, the type of `any` becomes

```haskell
any : Element Bool -> Aggregate Bool
```
instead of
```haskell
any :
     d =: PossibilityJoin c d
  => c =: PossibilityJoin a d
  => Element =: TemporalityJoin b Element
  => b (a Bool)
  -> Aggregate (c Bool)
```